### PR TITLE
feat: self-serve backlog — agents can find and claim unassigned work

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -563,6 +563,11 @@ export function getDashboardHTML(): string {
   </div>
 
   <div class="panel">
+    <div class="panel-header">📦 Available Work <span class="count" id="backlog-count"></span></div>
+    <div class="panel-body" id="backlog-body" style="max-height:300px;overflow-y:auto"></div>
+  </div>
+
+  <div class="panel">
     <div class="panel-header">🏥 Team Health <span class="count" id="health-count"></span></div>
     <div class="panel-body" id="health-body"></div>
   </div>


### PR DESCRIPTION
## What
- **GET /tasks/backlog** — ranked list of unassigned todo tasks (priority → age)
- **POST /tasks/:id/claim** — self-assign endpoint (409 if taken, 404 if missing)
- **Dashboard panel** — 'Available Work' section showing claimable tasks

## Why
Agents idle between lanes because they wait for Kai to assign work. This lets any agent self-serve: check the backlog, claim a task, start working.

## Done criteria (from task-1771095292708-prdlz0wbg)
- [x] Backlog of 10+ ranked tasks exists in task system (12 created)
- [x] Any agent can self-assign from backlog via API (/tasks/:id/claim)
- [x] Dashboard shows available backlog items
- [ ] Link confirms he can pull work without waiting for direction

## Files changed
- `src/server.ts` — backlog + claim endpoints
- `src/dashboard.ts` — backlog panel HTML
- `public/dashboard.js` — backlog render function

CI: tsc ✅ | smoke ✅