### PR TITLE
feat: add /tasks/search keyword endpoint

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -33,6 +33,7 @@ Base URL: `http://localhost:4445`
 | PATCH | `/tasks/:id` | Update task (partial). Any task field, plus optional `actor` for history attribution. Status contract: `doing` requires reviewer + `metadata.eta`; `validating` requires `metadata.artifact_path`. |
 | DELETE | `/tasks/:id` | Delete task |
 | GET | `/tasks/next` | Pull-based assignment. Query: `agent` |
+| GET | `/tasks/search` | Keyword search across task `title` + `description` (case-insensitive). Query: `q`, optional `limit` |
 | GET | `/tasks/analytics` | Task completion analytics and velocity |
 | GET | `/tasks/instrumentation/lifecycle` | Reviewer/done-criteria gates + status-contract violations (`doing` missing ETA, `validating` missing artifact path) |
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -786,6 +786,16 @@ export async function createServer(): Promise<FastifyInstance> {
     return payload
   })
 
+  // Search tasks by keyword in title + description
+  app.get('/tasks/search', async (request) => {
+    const query = request.query as Record<string, string>
+    const q = query.q || ''
+    const limit = boundedLimit(query.limit, DEFAULT_LIMITS.tasks, MAX_LIMITS.tasks)
+
+    const tasks = taskManager.searchTasks(q).slice(0, limit)
+    return { tasks: tasks.map(enrichTaskWithComments), count: tasks.length }
+  })
+
   // List recurring task definitions
   app.get('/tasks/recurring', async (request) => {
     const query = request.query as Record<string, string>

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -620,6 +620,19 @@ class TaskManager {
     return tasks.sort((a, b) => b.updatedAt - a.updatedAt)
   }
 
+  searchTasks(query: string): Task[] {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return []
+
+    return Array.from(this.tasks.values())
+      .filter(task => {
+        const title = task.title.toLowerCase()
+        const description = (task.description || '').toLowerCase()
+        return title.includes(normalized) || description.includes(normalized)
+      })
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  }
+
   private resolveHistoryActor(task: Task, updates: Partial<Omit<Task, 'id' | 'createdAt' | 'createdBy'>>): string {
     const metadataActor = (updates.metadata as any)?.actor
     if (typeof metadataActor === 'string' && metadataActor.trim().length > 0) {


### PR DESCRIPTION
## Summary
- add `taskManager.searchTasks(query)` for case-insensitive title + description matching
- add `GET /tasks/search?q=keyword` endpoint with optional `limit`
- document endpoint in `/docs`

## Validation
- `npm run build`
- `curl 'http://127.0.0.1:4450/tasks/search?q=KEYWORD'` returns matches
- `curl 'http://127.0.0.1:4450/tasks/search?q=zzzznotfound'` returns empty array

## Task
- task-1771104738843-v6eqpep2e
