### PR TITLE
docs: add task comments API quickstart

### DIFF
--- a/docs/TASK_COMMENTS_API_QUICKSTART.md
+++ b/docs/TASK_COMMENTS_API_QUICKSTART.md
@@ -1,0 +1,120 @@
+# Task Comments API Quickstart
+
+Fast path for in-task discussion without cluttering `#general`.
+
+Base URL: `http://127.0.0.1:4445`
+
+---
+
+## What this API does
+
+- `POST /tasks/:id/comments` adds a timestamped comment with author.
+- `GET /tasks/:id/comments` returns the ordered comment thread for that task.
+
+Use comments for:
+- reviewer handoff bundles
+- implementation notes
+- evidence links
+- concise status checkpoints tied to one task
+
+---
+
+## 1) Create or pick a task
+
+```bash
+curl -s "http://127.0.0.1:4445/tasks?status=doing&assignee=echo&limit=1"
+```
+
+Set the task id:
+
+```bash
+TASK_ID="task-REPLACE-ME"
+```
+
+---
+
+## 2) Post a comment
+
+```bash
+curl -s -X POST "http://127.0.0.1:4445/tasks/${TASK_ID}/comments" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "author":"echo",
+    "content":"QA bundle: proof at process/'"${TASK_ID}"'-proof.md; ready for review"
+  }'
+```
+
+Expected shape:
+
+```json
+{
+  "success": true,
+  "comment": {
+    "id": "tcomment-...",
+    "taskId": "task-...",
+    "author": "echo",
+    "content": "...",
+    "timestamp": 1771111111111
+  }
+}
+```
+
+---
+
+## 3) Read comment thread
+
+```bash
+curl -s "http://127.0.0.1:4445/tasks/${TASK_ID}/comments"
+```
+
+Expected shape:
+
+```json
+{
+  "comments": [
+    {
+      "id": "tcomment-...",
+      "taskId": "task-...",
+      "author": "echo",
+      "content": "...",
+      "timestamp": 1771111111111
+    }
+  ],
+  "count": 1
+}
+```
+
+---
+
+## QA checklist (quick)
+
+- [ ] POST returns `success: true`
+- [ ] Returned comment includes `author` and `timestamp`
+- [ ] GET returns posted comment in `comments[]`
+- [ ] `count` increments as new comments are added
+- [ ] Task payload `commentCount` reflects discussion count (`GET /tasks/:id`)
+
+---
+
+## Common errors
+
+### `Task not found`
+- Verify `TASK_ID` exists:
+
+```bash
+curl -s "http://127.0.0.1:4445/tasks/${TASK_ID}"
+```
+
+### Empty content rejected
+- Ensure `content` is non-empty text.
+
+### Wrong author value
+- Use the actual agent ID (`echo`, `kai`, etc.) for traceable review history.
+
+---
+
+## Recommended comment hygiene
+
+- Keep comments task-specific (no cross-task threads).
+- Put proof links directly in comment text.
+- Use one reviewer-ready bundle comment when moving to `validating`.

--- a/public/docs.md
+++ b/public/docs.md
@@ -10,6 +10,7 @@ Base URL: `http://localhost:4445`
 - [Task Creation Template](../docs/TASK_CREATION_TEMPLATE.md) — high-signal task spec + anti-patterns.
 - [Reviewer-Ready Tasks Guide](../docs/REVIEWER_READY_TASKS_GUIDE.md) — short operational guide to reduce QA churn.
 - [Dashboard Task Field Reference](../docs/DASHBOARD_TASK_FIELD_REFERENCE.md) — task-card field mapping, null semantics, and UI edge cases.
+- [Task Comments API Quickstart](../docs/TASK_COMMENTS_API_QUICKSTART.md) — POST/GET task comments with QA checklist.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds a concise quickstart for task comments API usage, including POST/GET examples, expected response shapes, QA checklist, and common errors.

### Included
- docs/TASK_COMMENTS_API_QUICKSTART.md
- quickstarts link update in public/docs.md

## Task
- task-1771119425775-lg3motmq9

## Notes
- Docs-only PR
- Reviewer-ready comment hygiene guidance included
