### PR TITLE
docs: final batched guides for research, dashboard, and templates

### DIFF
--- a/docs/API_DOCS_QUALITY_CHECKLIST.md
+++ b/docs/API_DOCS_QUALITY_CHECKLIST.md
@@ -1,0 +1,25 @@
+# API Docs Quality Checklist
+
+Use this checklist before merging docs updates tied to endpoint changes.
+
+## Required checks
+- [ ] New/changed endpoint is listed with method + path
+- [ ] Required request fields are explicit
+- [ ] Error cases and status expectations are noted
+- [ ] At least one curl example exists
+- [ ] Contract gates (doing/validating/done) are updated when relevant
+- [ ] Quickstarts/index links updated if new guide added
+
+## Quality bar
+- Prefer concrete examples over abstract prose
+- Keep snippets copy/paste ready
+- Include source of truth path in PR body
+- Map done criteria to specific doc sections in handoff comment
+
+## Regression check
+Run and compare:
+```bash
+curl -s http://127.0.0.1:4445/docs
+```
+
+Confirm latest guide links and endpoint rows are visible in rendered docs output.

--- a/docs/CONTRIBUTOR_ONBOARDING_SCRIPT.md
+++ b/docs/CONTRIBUTOR_ONBOARDING_SCRIPT.md
@@ -1,0 +1,38 @@
+# Contributor Onboarding Script (First Day)
+
+## 1) Clone and install
+```bash
+git clone https://github.com/reflectt/reflectt-node.git
+cd reflectt-node
+npm install
+npm run build
+```
+
+## 2) Start local server
+```bash
+npm run start
+curl -s http://127.0.0.1:4445/health
+```
+
+## 3) Read critical docs
+- `README.md`
+- `public/docs.md`
+- `docs/REVIEWER_HANDOFF_BUNDLE_TEMPLATE.md`
+- `docs/TASK_CREATION_TEMPLATE.md`
+
+## 4) Pull a task and claim it
+```bash
+curl -s "http://127.0.0.1:4445/tasks/next?agent=<name>"
+```
+
+## 5) Work loop
+1. Move to `doing` with `metadata.eta`
+2. Implement + test
+3. Add proof artifact
+4. Post reviewer handoff bundle
+5. Move to `validating` with PR link
+
+## 6) Close loop
+Only close to `done` with:
+- `metadata.artifacts`
+- `metadata.reviewer_approved=true`

--- a/docs/DASHBOARD_PANEL_REFERENCE.md
+++ b/docs/DASHBOARD_PANEL_REFERENCE.md
@@ -1,0 +1,25 @@
+# Dashboard Panel Reference
+
+Snapshot reference for key dashboard panels and their data sources.
+
+## Panels
+
+| Panel | Purpose | Primary endpoint |
+|---|---|---|
+| Task Board | Task status visibility by column | `GET /tasks` |
+| Available Work | Unassigned todo queue | `GET /tasks/backlog` |
+| Team Health | Agent status + blockers | `GET /health/team`, `GET /health/agents` |
+| Compliance | SLA/cadence view | `GET /health/compliance` |
+| Promotion SSOT | ops links + freshness signal | static links + remote metadata |
+| Chat | operational coordination stream | `GET /chat/messages` |
+| Activity | recent events feed | `GET /activity` |
+
+## Refresh behavior
+- foreground: adaptive 20–30s polling
+- background: ~60s polling
+- periodic full sync to reconcile deltas
+
+## Debug tips
+- if panel is empty, verify endpoint returns data directly
+- if counts stale, force full refresh and compare `updatedAt`/timestamps
+- if link refs fail, check task IDs exist in current `/tasks` payload

--- a/docs/INCIDENT_WRITEUP_TEMPLATE.md
+++ b/docs/INCIDENT_WRITEUP_TEMPLATE.md
@@ -1,0 +1,33 @@
+# Incident Writeup Template
+
+## Incident
+- ID:
+- Date/time:
+- Severity:
+- Owner:
+
+## Summary
+What happened in 2–3 lines.
+
+## Impact
+- Who/what was affected
+- Duration
+- User-visible symptoms
+
+## Timeline
+- T0 detected
+- T1 mitigation
+- T2 recovery
+- T3 validation complete
+
+## Root cause
+Primary cause and contributing factors.
+
+## Fix
+What changed (PR/commit/ops action).
+
+## Verification
+How we confirmed recovery.
+
+## Prevention
+Follow-up tasks to reduce recurrence.

--- a/docs/RESEARCH_INTAKE_HANDBOOK.md
+++ b/docs/RESEARCH_INTAKE_HANDBOOK.md
@@ -1,0 +1,41 @@
+# Research Intake Handbook
+
+How to use research intake endpoints and convert findings into actionable tasks.
+
+Base URL: `http://127.0.0.1:4445`
+
+## Endpoints
+- `GET /research/requests`
+- `POST /research/requests`
+- `GET /research/findings`
+- `POST /research/findings`
+
+## Typical flow
+1. Create research request with owner + SLA context.
+2. Add findings linked to request id.
+3. Mark request answered when evidence is sufficient.
+4. Convert finding into implementation task with source links.
+
+## Create request
+```bash
+curl -s -X POST http://127.0.0.1:4445/research/requests \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Need X market signal","owner":"scout","priority":"P1"}'
+```
+
+## Create finding
+```bash
+curl -s -X POST http://127.0.0.1:4445/research/findings \
+  -H 'Content-Type: application/json' \
+  -d '{"requestId":"rreq-...","summary":"Top pain point is Y","source":"https://..."}'
+```
+
+## Handoff protocol
+- include request id, finding id, evidence links
+- state confidence and unresolved questions
+- propose concrete task with done criteria
+
+## Verification
+- request appears in `GET /research/requests`
+- finding appears in `GET /research/findings`
+- linkage (`requestId`) is present and valid

--- a/docs/WEEKLY_SHIP_LOG_TEMPLATE.md
+++ b/docs/WEEKLY_SHIP_LOG_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Weekly Ship Log Template
+
+## Week of <YYYY-MM-DD>
+
+### Shipped
+- <item> — <proof link>
+- <item> — <proof link>
+
+### Blocked
+- <blocker> — owner: <name> — unblock: <condition>
+
+### Learnings
+- <what changed in process/product>
+
+### Next week priorities
+1. <priority + owner + ETA>
+2. <priority + owner + ETA>
+
+### Metrics snapshot
+- PRs merged:
+- Tasks closed:
+- Review SLA breaches:
+
+### Notes
+- Keep concise; link artifacts instead of pasting long logs.

--- a/public/docs.md
+++ b/public/docs.md
@@ -15,6 +15,12 @@ Base URL: `http://localhost:4445`
 - [Review Queue SOP](../docs/REVIEW_QUEUE_SOP.md) — validating queue workflow, SLA, and PASS/FAIL discipline.
 - [Task-Close Gate Playbook](../docs/TASK_CLOSE_GATE_PLAYBOOK.md) — required close metadata with pass/fail examples.
 - [Backlog Claim Troubleshooting](../docs/BACKLOG_CLAIM_TROUBLESHOOTING.md) — claim flow, metadata requirements, and common errors.
+- [Research Intake Handbook](../docs/RESEARCH_INTAKE_HANDBOOK.md) — requests/findings flow and handoff protocol.
+- [Dashboard Panel Reference](../docs/DASHBOARD_PANEL_REFERENCE.md) — panel-to-endpoint mapping and refresh behavior.
+- [API Docs Quality Checklist](../docs/API_DOCS_QUALITY_CHECKLIST.md) — pre-merge checks for endpoint-doc consistency.
+- [Weekly Ship Log Template](../docs/WEEKLY_SHIP_LOG_TEMPLATE.md) — compact weekly status template.
+- [Incident Writeup Template](../docs/INCIDENT_WRITEUP_TEMPLATE.md) — timeline/root-cause/fix/prevention structure.
+- [Contributor Onboarding Script](../docs/CONTRIBUTOR_ONBOARDING_SCRIPT.md) — first-day workflow from clone to validated task.
 
 ---
 


### PR DESCRIPTION
## Summary
Batched remaining docs into one PR to reduce repeated public/docs.md conflicts and review churn.

### Included guides
- docs/RESEARCH_INTAKE_HANDBOOK.md
- docs/DASHBOARD_PANEL_REFERENCE.md
- docs/API_DOCS_QUALITY_CHECKLIST.md
- docs/WEEKLY_SHIP_LOG_TEMPLATE.md
- docs/INCIDENT_WRITEUP_TEMPLATE.md
- docs/CONTRIBUTOR_ONBOARDING_SCRIPT.md

### Index updates
- quickstarts links added in public/docs.md

## Task linkage
- task-1771119425787-20hmgk4ix
- task-1771119425788-4j5bl1beg
- task-1771119425790-goiifs7b8
- task-1771119425791-wa5z09xxb
- task-1771119425792-tsal3r6mj
- task-1771119425794-za39jeehg

## Notes
- Docs-only PR
- Opened as a single batch per reviewer request
