### PR TITLE
feat(api): consistent error envelope across endpoints

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -24,6 +24,22 @@ Base URL: `http://localhost:4445`
 
 ---
 
+## Error Envelope (all endpoints)
+
+All API errors normalize to:
+
+```json
+{
+  "success": false,
+  "error": "human-readable message",
+  "code": "BAD_REQUEST|NOT_FOUND|CONFLICT|...",
+  "status": 400,
+  "hint": "optional fix guidance"
+}
+```
+
+For 4xx errors, `hint` is included by default to speed up client-side troubleshooting.
+
 ## Health
 
 | Method | Path | Description |


### PR DESCRIPTION
## Summary
Standardizes API error responses with a consistent envelope using a centralized Fastify `preSerialization` hook.

## What changed
- Added a global error normalization hook in `src/server.ts` that converts error payloads to:
  - `success: false`
  - `error`
  - `code`
  - `status`
  - optional `hint` / `details`
- Added status/code inference helpers for legacy `{ error: "..." }` handlers
- Added default 4xx hint text for faster troubleshooting
- Added targeted Zod validation on selected chat/inbox endpoints so malformed requests return normalized 400s with details
- Documented envelope in `public/docs.md`

## Done criteria
- [x] Error envelope schema defined
- [x] Error responses use envelope
- [x] 4xx include hints
- [x] Documented in `/docs`

## Verification
- `npm run build` ✅

## Notes
Scope is intentionally limited to error envelope + endpoint validation plumbing.
