### PR TITLE
docs: batch remaining validating docs (health + watchdog + release note)

### DIFF
--- a/docs/HEALTH_ENDPOINTS_MAP.md
+++ b/docs/HEALTH_ENDPOINTS_MAP.md
@@ -1,0 +1,124 @@
+# Health Endpoints Map
+
+Purpose: clarify which health endpoint to use for which operational question.
+
+Base URL: `http://127.0.0.1:4445`
+
+---
+
+## Quick selector
+
+| If you need to know… | Use endpoint |
+|---|---|
+| Is the service alive at all? | `GET /health` |
+| System uptime/perf/error posture | `GET /health/system` |
+| Team-wide blockers + overlap context | `GET /health/team` |
+| Per-agent compact status for dashboards | `GET /health/agents` |
+| Compliance/SLA summary | `GET /health/compliance` |
+| Idle-nudge suppression/debug reasons | `GET /health/idle-nudge/debug` |
+
+---
+
+## `/health` (service-level heartbeat)
+
+Use when:
+- checking process liveness
+- confirming core counters are returning
+
+Typical fields:
+- `status`
+- `tasks` summary
+- `chat` summary
+- `inbox` summary
+- `timestamp`
+
+```bash
+curl -s http://127.0.0.1:4445/health
+```
+
+---
+
+## `/health/team` (rich team health context)
+
+Use when:
+- triaging blockers/overlap trends
+- reviewing lane-level coordination context
+- comparing multiple health dimensions in one payload
+
+Typical sections include:
+- agents list with state metadata
+- blockers and overlap summaries
+- compliance-related context
+
+```bash
+curl -s http://127.0.0.1:4445/health/team
+```
+
+---
+
+## `/health/agents` (compact per-agent projection)
+
+Use when:
+- powering dashboards/widgets
+- quickly scanning active vs stale agents
+- scripting per-agent checks
+
+Expected per-agent fields:
+- `last_seen`
+- `active_task`
+- `heartbeat_age_ms`
+- `state`
+- optional stale diagnostics (for example: `stale_reason`)
+
+```bash
+curl -s http://127.0.0.1:4445/health/agents
+```
+
+---
+
+## `/health/compliance` (SLA enforcement view)
+
+Use when:
+- checking cadence/working-time compliance status
+- validating whether a watcher alert is policy-backed
+
+```bash
+curl -s http://127.0.0.1:4445/health/compliance
+```
+
+---
+
+## Debug endpoints (watchdog behavior)
+
+### State inspection
+
+```bash
+curl -s http://127.0.0.1:4445/health/idle-nudge/debug
+```
+
+### Dry-run ticks (no side effects)
+
+```bash
+curl -s -X POST 'http://127.0.0.1:4445/health/idle-nudge/tick?dryRun=true'
+curl -s -X POST 'http://127.0.0.1:4445/health/cadence-watchdog/tick?dryRun=true'
+curl -s -X POST 'http://127.0.0.1:4445/health/mention-rescue/tick?dryRun=true'
+```
+
+Use these before concluding a signal is a true breach vs suppressed/cooldown case.
+
+---
+
+## Common interpretation mistakes
+
+1. Treating `/health/agents` as full incident context (it is intentionally compact).
+2. Treating `/health/team` overlap hints as final truth without checking lane comments/scope-split notes.
+3. Ignoring debug suppression reasons before escalating idle-nudge alerts.
+
+---
+
+## Minimal operator routine
+
+1. `GET /health`
+2. `GET /health/system`
+3. `GET /health/agents`
+4. If noisy/conflicting: `GET /health/team` + `/health/idle-nudge/debug`

--- a/docs/OPENCLAW_2026_2_13_MEMORY_SEARCH_ROLLOUT_NOTE.md
+++ b/docs/OPENCLAW_2026_2_13_MEMORY_SEARCH_ROLLOUT_NOTE.md
@@ -1,0 +1,42 @@
+# Release Note — OpenClaw 2026.2.13 + Memory Search Rollout
+
+## What changed
+
+We upgraded OpenClaw from `2026.2.9` to `2026.2.13` and rolled memory search into daily workflow.
+
+Memory search now provides semantic recall across memory files, so agents can retrieve relevant prior context faster instead of relying only on exact keyword matching.
+
+## Why this matters
+
+- **Fewer context misses:** decisions and prior artifacts are easier to recover.
+- **Faster handoffs:** reviewer and owner context can be found without digging through long chat logs.
+- **Less repeat work:** known issues, prior fixes, and established templates are easier to reuse.
+
+## Impact highlights
+
+- Semantic lookup is now part of the standard recall flow for history-sensitive work.
+- Team can reference prior task decisions with lower token/time overhead.
+- Improves consistency for docs, QA handoffs, and recurring operational checks.
+
+## Rollout caveats (important)
+
+- **Treat search output as candidate context, not truth.** Confirm against source artifacts when decisions are high-impact.
+- **If results look incomplete, retry after index catch-up windows.** Fresh content can lag indexing.
+- **Use source-linked verification for closes/reviews.** Search helps discovery; artifacts still gate acceptance.
+
+## Safe usage pattern
+
+1. Run memory search to find likely context.
+2. Open the referenced artifact/message/task.
+3. Confirm exact fields (owner, reviewer, done criteria, status gates) before acting.
+4. Cite concrete evidence in handoff bundles.
+
+## Suggested team default
+
+Use memory search first for:
+- prior decisions
+- reviewer history
+- known issue checks
+- recurring task context
+
+Then verify with the latest task artifacts before status transitions.

--- a/docs/WATCHDOG_BEHAVIOR_EXPLAINER.md
+++ b/docs/WATCHDOG_BEHAVIOR_EXPLAINER.md
@@ -1,0 +1,107 @@
+# Watchdog Behavior Explainer
+
+This guide explains how the three watchdog paths behave, where cooldowns apply, and how to debug false-positive alerts.
+
+## Components
+
+### 1) Idle Nudge
+
+Purpose: nudge when an agent appears idle beyond expected cadence.
+
+Signal inputs typically include:
+- recent task/message activity
+- current task status (`doing`, `validating`, etc.)
+- cooldown state from prior nudges
+
+### 2) Cadence Watchdog
+
+Purpose: detect sustained silence or missed update cadence.
+
+Signal inputs typically include:
+- elapsed time since last status update
+- working-state indicators
+- suppressions for known blocked/awaiting-review states
+
+### 3) Mention Rescue
+
+Purpose: rescue missed @mentions by issuing a fallback check.
+
+Signal inputs typically include:
+- mention timestamps
+- acknowledgement lag
+- rescue cooldown to prevent spam loops
+
+---
+
+## Cooldown examples
+
+1. **Recent update suppression**
+   - If an agent posted within cooldown window, skip new nudge.
+
+2. **Validating-state suppression**
+   - If task is in `validating` with active PR/review flow, suppress idle nudge.
+
+3. **Duplicate-cycle suppression**
+   - If same condition fired in prior cycle and no material state change, hold repeat nudge.
+
+4. **Mention rescue cooldown**
+   - After one rescue prompt, hold additional rescue attempts until cooldown expires.
+
+---
+
+## Known failure modes
+
+1. **Blocked-task false positives**
+   - Watchdog nudges even when task is blocked and explicitly waiting.
+
+2. **Contract drift side effects**
+   - Status transitions fail silently; watchdog reads stale state and over-nudges.
+
+3. **Queue-empty confusion**
+   - Agent has no claimable task but is still flagged idle as if work exists.
+
+4. **Thread noise amplification**
+   - Repeated nudges bury real coordination messages.
+
+5. **Missed mention + delayed rescue**
+   - Rescue path runs too late due to stale timing state.
+
+---
+
+## Actionable debug workflow
+
+### 1) Inspect current debug state
+
+```bash
+curl -s http://127.0.0.1:4445/health/idle-nudge/debug
+```
+
+### 2) Run dry-run watchdog ticks
+
+```bash
+curl -s -X POST 'http://127.0.0.1:4445/health/idle-nudge/tick?dryRun=true'
+curl -s -X POST 'http://127.0.0.1:4445/health/cadence-watchdog/tick?dryRun=true'
+curl -s -X POST 'http://127.0.0.1:4445/health/mention-rescue/tick?dryRun=true'
+```
+
+### 3) Compare against live task state
+
+```bash
+curl -s 'http://127.0.0.1:4445/tasks?assignee=echo&status=doing'
+curl -s 'http://127.0.0.1:4445/tasks?assignee=echo&status=validating'
+```
+
+### 4) Verify suppression reason before escalation
+
+Escalate only if:
+- cooldown/suppression flags are absent, and
+- agent state is truly stale against task + message timeline.
+
+---
+
+## Verification checklist
+
+- [ ] All three watchdog paths are documented
+- [ ] Cooldown logic includes concrete examples
+- [ ] Failure modes include false-positive scenarios
+- [ ] Debug steps are copy/paste runnable

--- a/public/docs.md
+++ b/public/docs.md
@@ -15,6 +15,9 @@ Base URL: `http://localhost:4445`
 - [Review Queue SOP](../docs/REVIEW_QUEUE_SOP.md) — validating queue workflow, SLA, and PASS/FAIL discipline.
 - [Task-Close Gate Playbook](../docs/TASK_CLOSE_GATE_PLAYBOOK.md) — required close metadata with pass/fail examples.
 - [Backlog Claim Troubleshooting](../docs/BACKLOG_CLAIM_TROUBLESHOOTING.md) — claim flow, metadata requirements, and common errors.
+- [Health Endpoints Map](../docs/HEALTH_ENDPOINTS_MAP.md) — endpoint selector for /health, /health/team, /health/agents, and debug paths.
+- [Watchdog Behavior Explainer](../docs/WATCHDOG_BEHAVIOR_EXPLAINER.md) — idle/cadence/mention rescue behavior with cooldown + debug flow.
+- [OpenClaw 2026.2.13 Memory Search Rollout Note](../docs/OPENCLAW_2026_2_13_MEMORY_SEARCH_ROLLOUT_NOTE.md) — what changed, impact, caveats, and safe usage pattern.
 - [Research Intake Handbook](../docs/RESEARCH_INTAKE_HANDBOOK.md) — requests/findings flow and handoff protocol.
 - [Dashboard Panel Reference](../docs/DASHBOARD_PANEL_REFERENCE.md) — panel-to-endpoint mapping and refresh behavior.
 - [API Docs Quality Checklist](../docs/API_DOCS_QUALITY_CHECKLIST.md) — pre-merge checks for endpoint-doc consistency.


### PR DESCRIPTION
## Summary
Batches the 3 remaining validating docs tasks into one PR (docs-only) to avoid repeated docs index conflicts.

## Included docs
1. `docs/HEALTH_ENDPOINTS_MAP.md`
2. `docs/WATCHDOG_BEHAVIOR_EXPLAINER.md`
3. `docs/OPENCLAW_2026_2_13_MEMORY_SEARCH_ROLLOUT_NOTE.md`
4. `public/docs.md` quickstarts links update (single index touch)

## Task mapping
- Health endpoints map
- Idle nudge/watchdog behavior explainer
- OpenClaw 2026.2.13 + memory search release note

## QA notes
- Docs-only scope
- No runtime code changes
- Quickstarts links verified in `public/docs.md`
