### PR TITLE
ci: add test suite to CI workflow + fix error envelope gate passthrough

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/src/server.ts
+++ b/src/server.ts
@@ -394,6 +394,7 @@ export async function createServer(): Promise<FastifyInstance> {
 
     if (hint) envelope.hint = hint
     if (body.details !== undefined) envelope.details = body.details
+    if (body.gate !== undefined) envelope.gate = body.gate
     if (alreadyEnvelope && body.data !== undefined) envelope.data = body.data
 
     return envelope


### PR DESCRIPTION
## CI Test Suite

### What
- Adds `.github/workflows/test.yml` — runs `npm test` (vitest) on every PR and main push
- Fixes error envelope bug where `gate` field was stripped by preSerialization hook

### Changes

**New: `.github/workflows/test.yml`**
- Build + test on Node 22
- Runs on push to main, all PRs, and manual dispatch

**Fix: `src/server.ts` preSerialization hook**  
- The error envelope normalizer (PR #29) was stripping the `gate` field from task close gate errors
- Added `if (body.gate !== undefined) envelope.gate = body.gate`
- This fixes 2 pre-existing test failures (25/25 now pass)

### Testing
- `npm test` → 25/25 pass (was 23/25 before the gate fix)
- `npx tsc` → clean build