### PR TITLE
docs: add PR template with docs-impact checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- What changed and why? Keep this concise. -->
+
+## Linked task
+
+- Task ID: <!-- e.g., task-1771172824241-797gbg86g -->
+
+## Validation
+
+- [ ] Local tests run (or not needed)
+- [ ] Relevant endpoint/manual checks run
+
+## Docs impact (required)
+
+- [ ] This PR changes API behavior/routes and `public/docs.md` was updated
+- [ ] This PR does **not** change API behavior/routes, so no docs update is needed
+- [ ] If docs were updated, links/examples were verified
+
+## Checklist
+
+- [ ] Scope is limited and reviewer-ready
+- [ ] No unrelated refactors bundled
+- [ ] Follows current status/metadata contract where applicable
+
+## Notes for reviewer
+
+<!-- Anything risky, ambiguous, or still needing follow-up -->


### PR DESCRIPTION
## Summary
Adds a repository PR template so every PR explicitly confirms docs impact.

Includes a required docs-impact section to reduce API/docs drift:
- route/behavior changed + docs updated
- or no route/behavior change (no docs update needed)
- docs links/examples verified when updated

## Linked task
- task-1771172824241-797gbg86g

## Done criteria mapping
- [x] `.github/pull_request_template.md` created
- [x] Includes docs-impact checklist item
- [x] PR opened against `main`
