### PR TITLE
feat: add /health/build endpoint with git SHA, PID, uptime

### DIFF
--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -1,0 +1,53 @@
+/**
+ * Build Info — captures git SHA, branch, and build metadata at startup.
+ * Exposed via GET /health/build so the team knows what code is live.
+ */
+
+import { execSync } from 'node:child_process'
+
+export interface BuildInfo {
+  gitSha: string
+  gitShortSha: string
+  gitBranch: string
+  gitMessage: string
+  gitAuthor: string
+  gitTimestamp: string
+  pid: number
+  nodeVersion: string
+  startedAt: string
+  startedAtMs: number
+  uptime: number
+}
+
+function git(cmd: string): string {
+  try {
+    return execSync(`git ${cmd}`, { encoding: 'utf8', timeout: 5000 }).trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+// Capture at module load (startup) time
+const startedAtMs = Date.now()
+const gitSha = git('rev-parse HEAD')
+const gitShortSha = git('rev-parse --short HEAD')
+const gitBranch = git('rev-parse --abbrev-ref HEAD')
+const gitMessage = git('log -1 --pretty=%s')
+const gitAuthor = git('log -1 --pretty=%an')
+const gitTimestamp = git('log -1 --pretty=%ci')
+
+export function getBuildInfo(): BuildInfo {
+  return {
+    gitSha,
+    gitShortSha,
+    gitBranch,
+    gitMessage,
+    gitAuthor,
+    gitTimestamp,
+    pid: process.pid,
+    nodeVersion: process.version,
+    startedAt: new Date(startedAtMs).toISOString(),
+    startedAtMs,
+    uptime: Math.round((Date.now() - startedAtMs) / 1000),
+  }
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -598,6 +598,7 @@ export function getDashboardHTML(): string {
   <div class="header-right">
     <span><span class="status-dot"></span>Running</span>
     <span id="release-badge" class="release-badge" title="Deploy status">deploy: checking…</span>
+    <span id="build-badge" class="release-badge" title="Build info">build: loading…</span>
     <span id="clock"></span>
   </div>
 </div>

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import { experimentsManager } from './experiments.js'
 import { releaseManager } from './release.js'
 import { researchManager } from './research.js'
 import { wsHeartbeat } from './ws-heartbeat.js'
+import { getBuildInfo } from './buildInfo.js'
 
 // Schemas
 const SendMessageSchema = z.object({
@@ -601,6 +602,11 @@ export async function createServer(): Promise<FastifyInstance> {
   // System health (uptime, performance, errors)
   app.get('/health/system', async () => {
     return healthMonitor.getSystemHealth()
+  })
+
+  // Build info — git SHA, branch, PID, uptime
+  app.get('/health/build', async () => {
+    return getBuildInfo()
   })
 
   // Error logs (for debugging)

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -41,6 +41,18 @@ describe('Health', () => {
     expect(body.tasks).toBeDefined()
     expect(body.chat).toBeDefined()
   })
+
+  it('GET /health/build returns build info with SHA and PID', async () => {
+    const { status, body } = await req('GET', '/health/build')
+    expect(status).toBe(200)
+    expect(body.gitSha).toBeDefined()
+    expect(body.gitShortSha).toBeDefined()
+    expect(body.gitBranch).toBeDefined()
+    expect(body.pid).toBeTypeOf('number')
+    expect(body.nodeVersion).toBeDefined()
+    expect(body.startedAt).toBeDefined()
+    expect(body.uptime).toBeTypeOf('number')
+  })
 })
 
 describe('Task CRUD', () => {


### PR DESCRIPTION
## Problem
Team bottleneck: nobody knows what SHA is live. After deploys, agents can't verify they're running the expected code.

## Solution
New `GET /health/build` endpoint + dashboard badge:

```json
{
  "gitSha": "cfffdfe...",
  "gitShortSha": "cfffdfe",
  "gitBranch": "main",
  "gitMessage": "feat(api): add /metrics...",
  "gitAuthor": "...",
  "gitTimestamp": "2026-02-15 ...",
  "pid": 71175,
  "nodeVersion": "v25.5.0",
  "startedAt": "2026-02-15T...",
  "uptime": 3600
}
```

**Dashboard badge:** Shows `{sha} • {uptime}` in the header bar. Green on main, orange on other branches. Hover shows full details.

## Files
- `src/buildInfo.ts` — new module, captures git info at startup
- `src/server.ts` — route registration
- `public/dashboard.js` — badge display + fetch
- `src/dashboard.ts` — badge HTML element
- `tests/api.test.ts` — endpoint test

## Validation
- `npm run build` ✅
- `npm test` ✅ (43/43)

Fixes task-1771172824223.