### PR TITLE
task: standardize artifact paths to process/ repo-relative

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -88,8 +88,8 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | GET | `/tasks/:id/history` | Task event log (who did what when): create/assign/status changes with timestamps + actor |
 | GET | `/tasks/:id/comments` | List task discussion comments. Returns `{ comments, count }` |
 | POST | `/tasks/:id/comments` | Add task comment. Body: `{ "author": "agent", "content": "text" }` |
-| POST | `/tasks` | Create task. Required: `title`, `createdBy`, `assignee`, `reviewer`, `done_criteria` (string[]), `eta`. Optional: `description`, `priority` (P0-P3), `status`, `tags`, `metadata`. Status contract: `validating` also requires `metadata.artifact_path`. |
-| PATCH | `/tasks/:id` | Update task (partial). Any task field, plus optional `actor` for history attribution. Status contract: `doing` requires reviewer + `metadata.eta`; `validating` requires `metadata.artifact_path`. |
+| POST | `/tasks` | Create task. Required: `title`, `createdBy`, `assignee`, `reviewer`, `done_criteria` (string[]), `eta`. Optional: `description`, `priority` (P0-P3), `status`, `tags`, `metadata`. Status contract: `validating` also requires `metadata.artifact_path` and it must be repo-relative under `process/` (e.g. `process/TASK-...md`). |
+| PATCH | `/tasks/:id` | Update task (partial). Any task field, plus optional `actor` for history attribution. Status contract: `doing` requires reviewer + `metadata.eta`; `validating` requires `metadata.artifact_path` under `process/` (workspace-agnostic). |
 | DELETE | `/tasks/:id` | Delete task |
 | GET | `/tasks/next` | Pull-based assignment. Query: `agent` |
 | GET | `/tasks/search` | Keyword search across task `title` + `description` (case-insensitive). Query: `q`, optional `limit` |


### PR DESCRIPTION
## Summary
Implements a workspace-agnostic artifact path convention to resolve cross-workspace review failures.

### Changes
- Enforce `metadata.artifact_path` format for `status=validating`: must be repo-relative and under `process/`
- Reject absolute paths (`/tmp/...`), home paths (`~/...`), parent traversal (`..`), and Windows separators
- Update public API docs to document canonical convention
- Add integration tests covering reject/accept behavior

## Why
Artifact proofs were failing review when paths were local to one workspace and unreadable in another. Canonical `process/...` paths make proofs portable across agents.

## Validation
- `npm run -s build`
- `npm run -s test -- tests/api.test.ts` (49 passed)

## Task
- task-1771172824249-lydqz1wn4
