### PR TITLE
feat(health): actionable_reason block for flagged agents in /health/team

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -58,7 +58,7 @@ Operationally:
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health` | System health — task counts, chat stats, inbox stats |
-| GET | `/health/team` | Team health metrics with compliance + `staleDoing` snapshot (count + tasks stale in `doing` over threshold) |
+| GET | `/health/team` | Team health metrics with compliance + `staleDoing` snapshot. Flagged agents also include `actionable_reason` (last comment age, last transition, last mention age, suggested action). |
 | GET | `/health/agents` | Per-agent health summary (`last_seen`, `active_task`, `heartbeat_age_ms`, `last_shipped_at`, `stale_reason`, state) |
 | GET | `/health/compliance` | Compliance check results |
 | GET | `/health/system` | System info (uptime, memory, versions) |


### PR DESCRIPTION
## Summary
Adds actionable reason context to `/health/team` for flagged agents so triage can move from alerting to action quickly.

## Changes
- `src/health.ts`
  - Added `actionable_reason` block on `AgentHealthStatus` for flagged agents (`blocked`, `silent`, `offline`, or idle with active task).
  - Includes:
    - `task_id`
    - `last_task_comment_age_min`
    - `last_transition` (`type`, `actor`, `age_min`)
    - `last_mention_age_min`
    - `suggested_action`
  - Added helpers to compute latest task-comment age and latest @mention age.
- `public/docs.md`
  - Updated `/health/team` contract docs to mention `actionable_reason`.

## Validation
- `npm run build` ✅

## Task
- task-1771170698646-rgmnell6l
