### PR TITLE
feat(api): structured field-level errors for Zod validation

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -91,6 +91,34 @@ describe('Quiet Hours Watchdog Suppression', () => {
   })
 })
 
+describe('Validation Error Shape', () => {
+  it('returns structured fields for malformed POST /tasks payload', async () => {
+    const { status, body } = await req('POST', '/tasks', {
+      title: 'bad task',
+      description: 'missing required fields',
+    })
+    expect(status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('Validation failed')
+    expect(Array.isArray(body.fields)).toBe(true)
+    expect(body.fields.length).toBeGreaterThan(0)
+    expect(body.fields[0]).toHaveProperty('path')
+    expect(body.fields[0]).toHaveProperty('message')
+  })
+
+  it('returns structured fields for malformed POST /tasks/recurring payload', async () => {
+    const { status, body } = await req('POST', '/tasks/recurring', {
+      title: 'recurring bad',
+      assignee: 'harmony',
+    })
+    expect(status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.error).toBe('Validation failed')
+    expect(Array.isArray(body.fields)).toBe(true)
+    expect(body.fields.length).toBeGreaterThan(0)
+  })
+})
+
 describe('Task CRUD', () => {
   let taskId: string
 


### PR DESCRIPTION
## Summary
Normalize Zod validation failures into structured field-level errors so agents can self-correct malformed API calls without parsing raw Zod output.

## Changes
- Added server-side Zod error extraction helper in `src/server.ts`
- Pre-serialization error normalization now maps Zod parse errors to:
  - `error: "Validation failed"`
  - `fields: [{ path, message }]`
- Non-Zod errors keep existing error envelope behavior
- Added integration tests for malformed inputs on two endpoints:
  - `POST /tasks`
  - `POST /tasks/recurring`

## Validation
- `npm run build` (PASS)
- `npm test -- tests/api.test.ts --silent` (PASS, 53 tests)

## Task
- task-1771177168933-uzyqr8i5p
