### PR TITLE
feat(tasks): add POST /tasks/:id/review-bundle

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -90,7 +90,8 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | GET | `/tasks/:id/history` | Task event log (who did what when): create/assign/status changes with timestamps + actor |
 | GET | `/tasks/:id/comments` | List task discussion comments. Returns `{ comments, count }` |
 | POST | `/tasks/:id/comments` | Add task comment. Body: `{ "author": "agent", "content": "text" }` |
-| POST | `/tasks/:id/outcome` | Capture post-ship outcome verdict for a `done` task. Body: `{ "verdict": "success|partial|miss", "notes": "...", "author": "agent" }` |
+| POST | `/tasks/:id/outcome` | Capture 48h checkpoint verdict for completed tasks. Body: `verdict` (`PASS`\|`NO-CHANGE`\|`REGRESSION`), optional `author`, `notes` |
+| POST | `/tasks/:id/review-bundle` | Auto-build reviewer packet by resolving PR URL + CI + artifact evidence from task metadata. Returns normalized `verdict` (`pass`/`fail`) and reasons. Optional body: `author`, `strict` (default `true`, requires CI=`success`). |
 | POST | `/tasks` | Create task. Required: `title`, `createdBy`, `assignee`, `reviewer`, `done_criteria` (string[]), `eta`. Optional: `description`, `priority` (P0-P3), `status`, `tags`, `metadata`. Status contract: `validating` also requires `metadata.artifact_path` and it must be repo-relative under `process/` (e.g. `process/TASK-...md`). |
 | PATCH | `/tasks/:id` | Update task (partial). Any task field, plus optional `actor` for history attribution. Status contract: `doing` requires reviewer + `metadata.eta`; `validating` requires `metadata.artifact_path` under `process/` (workspace-agnostic). |
 | DELETE | `/tasks/:id` | Delete task |


### PR DESCRIPTION
## Summary
Adds a reviewer-handoff automation endpoint that resolves PR/CI/artifact evidence directly from task metadata and returns a normalized review packet.

## What shipped
- New endpoint: `POST /tasks/:id/review-bundle`
  - auto-resolves PR URL from `metadata.artifacts` + `metadata.qa_bundle.artifact_links`
  - resolves CI status from GitHub commit status API
  - resolves artifact evidence from canonical `process/...` paths
  - returns normalized `verdict` (`pass`/`fail`) + machine-readable reasons
  - posts a compact review-bundle comment on the task
- Docs update in `public/docs.md`
- Integration test: `Task review bundle` in `tests/api.test.ts`

## Example response shape
```json
{
  "success": true,
  "bundle": {
    "taskId": "task-...",
    "verdict": "pass|fail",
    "reasons": ["..."],
    "pr": { "url": "...", "owner": "...", "repo": "...", "pullNumber": 123, "headSha": "..." },
    "ci": { "state": "success|failure|pending|unknown" },
    "artifacts": [{ "path": "process/...", "exists": true }]
  }
}
```

## Validation
- `npm run -s build`
- `npm run -s test -- tests/api.test.ts` (59 passed)

## Task
- task-1771175443026-9soh45364
