### PR TITLE
feat(tasks): normalize GET /tasks/:id/history changelog

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -87,7 +87,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 |--------|------|-------------|
 | GET | `/tasks` | List tasks. Query: `status`, `assignee`, `agent`, `priority`, `limit`, `updatedSince` |
 | GET | `/tasks/:id` | Get task by ID. Also accepts unambiguous ID prefixes. Ambiguous prefix returns `400` with full-ID suggestions. |
-| GET | `/tasks/:id/history` | Task event log (who did what when): create/assign/status changes with timestamps + actor |
+| GET | `/tasks/:id/history` | Status changelog for task lifecycle transitions. Returns `history[]` entries shaped as `{ status, changedBy, changedAt, metadata }` for each status transition. |
 | GET | `/tasks/:id/comments` | List task discussion comments. Returns `{ comments, count }` |
 | POST | `/tasks/:id/comments` | Add task comment. Body: `{ "author": "agent", "content": "text" }` |
 | POST | `/tasks/:id/outcome` | Capture 48h checkpoint verdict for completed tasks. Body: `verdict` (`PASS`\|`NO-CHANGE`\|`REGRESSION`), optional `author`, `notes` |

--- a/src/server.ts
+++ b/src/server.ts
@@ -1746,7 +1746,21 @@ export async function createServer(): Promise<FastifyInstance> {
       return { error: 'Task not found', details: { input: request.params.id, suggestions: match.suggestions } }
     }
 
-    const history = taskManager.getTaskHistory(resolved.resolvedId)
+    const events = taskManager.getTaskHistory(resolved.resolvedId)
+    const history = events
+      .filter(event => event.type === 'status_changed')
+      .map(event => ({
+        status: String(event.data?.to ?? 'unknown'),
+        changedBy: event.actor,
+        changedAt: event.timestamp,
+        metadata: {
+          from: event.data?.from ?? null,
+          to: event.data?.to ?? null,
+          eventType: event.type,
+          eventId: event.id,
+        },
+      }))
+
     return { history, count: history.length, resolvedId: resolved.resolvedId }
   })
 


### PR DESCRIPTION
## Summary
Implements a normalized changelog response for task lifecycle history to make auditing/debugging stale tasks easier.

## What changed
- Updated `GET /tasks/:id/history` to return `history[]` entries shaped as:
  - `status`
  - `changedBy`
  - `changedAt`
  - `metadata` (`from`, `to`, `eventType`, `eventId`)
- Endpoint now returns status-transition changelog derived from `status_changed` events.
- Updated docs for `/tasks/:id/history` response contract.
- Added integration test covering multi-transition lifecycle (`todo -> doing -> validating -> done`).

## Validation
- `npm run -s build`
- `npm run -s test -- tests/api.test.ts` (60 passed)

## Task
- task-1771178449654-1ago6jzjw
