### PR TITLE
feat: pre-checkout hook blocks non-main checkout in shared repo

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Install git hooks for reflectt-node
 # Run once: bash scripts/install-hooks.sh
+#
+# For the SHARED production repo only — installs:
+#   - post-merge: auto-rebuild + restart on git pull
+#   - pre-checkout: blocks checkout to non-main branches
 
 set -euo pipefail
 
@@ -9,10 +13,23 @@ HOOKS_DIR="$REPO_DIR/.git/hooks"
 
 echo "Installing git hooks for reflectt-node..."
 
-# Install post-merge hook
+# Install post-merge hook (auto-rebuild)
 ln -sf "$REPO_DIR/scripts/post-merge-rebuild.sh" "$HOOKS_DIR/post-merge"
 chmod +x "$HOOKS_DIR/post-merge"
 echo "  ✓ post-merge hook installed (auto-rebuild on git pull)"
 
-echo "Done. After git pull, the service will auto-rebuild and restart."
-echo "Rebuild logs: /tmp/reflectt-node-rebuild.log"
+# Install pre-checkout guard (production safety)
+# Only install if this is the shared production repo (not agent workspaces)
+if echo "$REPO_DIR" | grep -q "workspace/projects/reflectt-node"; then
+  ln -sf "$REPO_DIR/scripts/pre-checkout-guard.sh" "$HOOKS_DIR/pre-checkout"
+  chmod +x "$HOOKS_DIR/pre-checkout"
+  echo "  ✓ pre-checkout hook installed (blocks non-main checkout in shared repo)"
+else
+  echo "  ⊘ pre-checkout hook skipped (not the shared production repo)"
+fi
+
+echo ""
+echo "Done."
+echo "  Post-merge: auto-rebuild + restart on git pull"
+echo "  Pre-checkout: rejects feature branch checkouts in production"
+echo "  Rebuild logs: /tmp/reflectt-node-rebuild.log"

--- a/scripts/pre-checkout-guard.sh
+++ b/scripts/pre-checkout-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# pre-checkout-guard.sh — Prevent checkout of non-main branches in the shared production repo
+# Installed as .git/hooks/pre-checkout
+#
+# The shared repo at ~/.openclaw/workspace/projects/reflectt-node is PRODUCTION ONLY.
+# Agents must use their own workspace-{agent}/ directories for feature branch work.
+#
+# This hook receives three args from git:
+#   $1 = ref of previous HEAD
+#   $2 = ref of new HEAD
+#   $3 = flag (1 = branch checkout, 0 = file checkout)
+
+PREVIOUS_HEAD="$1"
+NEW_HEAD="$2"
+IS_BRANCH_CHECKOUT="$3"
+
+# Only guard branch checkouts (not file checkouts like git checkout -- file)
+if [ "$IS_BRANCH_CHECKOUT" != "1" ]; then
+  exit 0
+fi
+
+# Get the branch name being checked out
+TARGET_BRANCH=$(git rev-parse --abbrev-ref "$NEW_HEAD" 2>/dev/null || echo "")
+
+# Allow main and HEAD (detached state during rebase/merge internals)
+if [ "$TARGET_BRANCH" = "main" ] || [ "$TARGET_BRANCH" = "HEAD" ]; then
+  exit 0
+fi
+
+# Block everything else
+echo ""
+echo "🚫 BLOCKED: Cannot checkout '$TARGET_BRANCH' in the shared production repo."
+echo ""
+echo "   This repo is PRODUCTION ONLY — it must stay on 'main'."
+echo "   Feature branch work must happen in your own workspace:"
+echo ""
+echo "     cd ~/.openclaw/workspace-{your-agent}/reflectt-node"
+echo "     git checkout $TARGET_BRANCH"
+echo ""
+echo "   If you need to deploy, just: git pull origin main"
+echo ""
+
+exit 1


### PR DESCRIPTION
## Problem
Agents keep switching the shared production repo to feature branches (happened 3x today). This breaks diff detection in the post-merge hook and causes stale code + SSE drops.

## Solution
New `scripts/pre-checkout-guard.sh` — git pre-checkout hook that:
- Blocks `git checkout`/`git switch` to any branch except `main`
- Shows clear error message directing agents to their own workspace
- Allows file checkouts (`git checkout -- file`) and detached HEAD (rebase internals)
- Only installed in the shared production repo (`install-hooks.sh` detects the path based on `workspace/projects/reflectt-node`)

## Setup
```bash
npm run hooks:install  # re-run in shared repo to add pre-checkout hook
```

## Validation
- `npm test` ✅ (64/64)

Fixes task-1771181431025.