### PR TITLE
chore: add Apache-2.0 SPDX headers to src

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Analytics Manager
  * 

--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Build Info — captures git SHA, branch, and build metadata at startup.
  * Exposed via GET /health/build so the team knows what code is live.

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Agent-to-agent messaging system
  */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
 /**
  * reflectt CLI - Command line interface for reflectt-node
  */

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Configuration loader
  */

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Content tracking: publication log + content calendar
  * Enables data-driven content decisions and coordination

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Dashboard HTML — self-contained page served at /dashboard
  * v2: Pixel's redesign + chat input for Ryan

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Server-Sent Events (SSE) Event Bus
  * 

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Experiment tracking manager
  * Stores experiment records in JSONL and provides active experiment queries.

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Team Health Monitoring
  *

--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Agent Inbox/Mailbox System
  * 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * reflectt-node - Local node server for agent communication via OpenClaw
  * 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * MCP HTTP Server for reflectt-node
  * 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Memory management system
  * Persists agent memories as markdown files

--- a/src/mention-ack.ts
+++ b/src/mention-ack.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Mention Ack Reliability Rail
  *

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * OpenClaw Gateway integration
  */

--- a/src/pidlock.ts
+++ b/src/pidlock.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * PID Lockfile Manager
  * 

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Agent Presence Manager
  * 

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 import { execSync } from 'child_process'
 import { promises as fs } from 'fs'
 import { join } from 'path'

--- a/src/research.ts
+++ b/src/research.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import { DATA_DIR } from './config.js'

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Fastify server with REST + WebSocket endpoints
  */

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Task management system
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * Core types for reflectt-node
  */

--- a/src/watchdog/idleNudgeLane.ts
+++ b/src/watchdog/idleNudgeLane.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 export type IdleNudgeLaneReason =
   | 'no-active-lane'
   | 'stale-lane'

--- a/src/ws-heartbeat.ts
+++ b/src/ws-heartbeat.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
 /**
  * WebSocket Heartbeat Manager
  * 


### PR DESCRIPTION
## Summary
Adds Apache 2.0 short-form SPDX headers to all `src/**/*.ts` files.

## Header format
```ts
// SPDX-License-Identifier: Apache-2.0
// Copyright (c) Reflectt AI
```

## Scope
- Updated all TypeScript source files under `src/`
- No test files changed for this task scope

## Validation
- `npm run build` ✅

## Task
- task-1771182219953-io5pyr8hg
