### PR TITLE
feat(tasks): add recurring task PATCH/DELETE endpoints + persistence guard

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -123,6 +123,8 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 |--------|------|-------------|
 | GET | `/tasks/recurring` | List recurring task definitions |
 | POST | `/tasks/recurring` | Create recurring task definition |
+| PATCH | `/tasks/recurring/:id` | Update recurring task definition (supports `enabled` toggle and schedule updates) |
+| DELETE | `/tasks/recurring/:id` | Delete recurring task definition |
 | POST | `/tasks/recurring/materialize` | Materialize due recurring tasks; skips creation when previous instance is still open. Query: `force=true` to override skip guard |
 
 ## Backlog (Self-Serve)


### PR DESCRIPTION
## Summary
Adds recurring-task management endpoints so operators can disable/delete recurring definitions without killing the server or editing JSONL by hand.

## What shipped
- Added `PATCH /tasks/recurring/:id`
  - supports `enabled` toggle
  - supports schedule updates
- Added `DELETE /tasks/recurring/:id`
- Added recurring persistence guard in task manager:
  - normalizes loaded recurring `enabled` to boolean (default `true` when missing)
  - persists `enabled` explicitly as boolean to disk to keep file state aligned with in-memory state
- Added integration coverage for recurring endpoint lifecycle:
  - create recurring
  - disable via PATCH
  - verify persisted JSONL line has `enabled: false`
  - delete via DELETE
- Updated API docs (`public/docs.md`) with new recurring endpoints

## Done criteria mapping
- PATCH endpoint disables/enables recurring tasks ✅
- DELETE endpoint removes recurring tasks ✅
- File serialization matches in-memory state ✅ (covered by integration test assertion against `tasks.recurring.jsonl`)

## Validation
- `npm run build`
- `npm run test -- tests/api.test.ts`

## Task
- task-1771195113772-g3a6d17td
