### PR TITLE
feat(cli): add reflectt host connect one-command enrollment

### DIFF
--- a/process/TASK-task-1771182602959-reflectt-cloud-monorepo-20260215.md
+++ b/process/TASK-task-1771182602959-reflectt-cloud-monorepo-20260215.md
@@ -1,0 +1,30 @@
+# Task Artifact — task-1771182602959
+
+## Title
+Create reflectt-cloud private monorepo with Turborepo scaffold
+
+## Repo
+- https://github.com/reflectt/reflectt-cloud (private)
+- Commit: 41d8016
+
+## What shipped
+- **apps/web**: Next.js 15 dashboard app (future app.reflectt.ai)
+- **apps/api**: Cloud API placeholder with TypeScript
+- **packages/sdk**: Typed client + shared types (Team, User, Agent, TaskSummary)
+- **packages/ui**: Shared React component library (Button component starter)
+- **turbo.json**: Pipeline config (build, dev, lint, type-check, clean)
+- **tsconfig.base.json**: Shared TypeScript config (strict, ES2022)
+- **CI workflow**: GitHub Actions — build + type-check + lint on push/PR
+
+## Validation
+- `npx turbo build` — 4/4 packages succeed ✅
+- `npx turbo type-check` — 6/6 tasks succeed ✅
+- `npm install` — 0 vulnerabilities ✅
+- GitHub CI triggered on push ✅
+
+## Done criteria coverage
+1. ✅ Private repo reflectt/reflectt-cloud created on GitHub
+2. ✅ Turborepo config with apps/web, apps/api, packages/sdk, packages/ui
+3. ✅ apps/web is a Next.js app that builds
+4. ✅ Basic README with architecture overview
+5. ✅ CI workflow for build + type-check

--- a/process/TASK-task-1771193019154-host-agent-sdk-20260215.md
+++ b/process/TASK-task-1771193019154-host-agent-sdk-20260215.md
@@ -1,0 +1,32 @@
+# Task Artifact — task-1771193019154
+
+## Title
+v1: Host agent SDK package (heartbeat + state sync client)
+
+## PR
+- https://github.com/reflectt/reflectt-cloud/pull/23
+- Commit: d85d945
+
+## What shipped
+- `packages/host-agent` in reflectt-cloud monorepo
+- Registration flow: join token → host credential
+- Heartbeat loop with configurable interval (default 30s)
+- Task state sync with configurable interval (default 60s)
+- Provider pattern: onAgents() and onTasks() callbacks
+- Env var configuration (REFLECTT_CLOUD_URL, REFLECTT_HOST_TOKEN, etc.)
+- Custom fetch support for non-Node environments
+- setVersionInfo() for build SHA/version in heartbeats
+
+## Tests
+- 11 integration tests with mock cloud API — all pass
+- Covers: registration, heartbeat, task sync, error handling, start/stop loops
+
+## Done criteria coverage
+1. ✅ packages/host-agent created in monorepo
+2. ✅ Registration flow: claim join token → receive credential
+3. ✅ Heartbeat loop: POST status + agents + tasks on interval
+4. ✅ Task state sync: push local task changes to cloud
+5. ✅ Configurable via env vars (cloud URL, token)
+6. ✅ Works as importable npm package
+7. ✅ Integration test with mock cloud API (11 tests)
+8. ✅ PR with passing build

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -38,7 +38,7 @@ interface TaskStateEntry {
 
 interface CloudConfig {
   cloudUrl: string
-  token?: string
+  token: string
   hostName: string
   hostType: string
   heartbeatIntervalMs: number
@@ -112,7 +112,7 @@ export async function startCloudIntegration(): Promise<void> {
 
   config = {
     cloudUrl: (process.env.REFLECTT_CLOUD_URL || 'https://api.reflectt.ai').replace(/\/+$/, ''),
-    token: process.env.REFLECTT_HOST_TOKEN,
+    token: process.env.REFLECTT_HOST_TOKEN!,
     hostName: process.env.REFLECTT_HOST_NAME || 'unnamed-host',
     hostType: process.env.REFLECTT_HOST_TYPE || 'openclaw',
     heartbeatIntervalMs: Number(process.env.REFLECTT_HEARTBEAT_MS) || DEFAULT_HEARTBEAT_MS,
@@ -285,10 +285,8 @@ async function cloudPost<T = unknown>(path: string, body: unknown): Promise<Clou
     // Use credential if registered, otherwise join token for enrollment
     if (state.credential) {
       headers['Authorization'] = `Bearer ${state.credential}`
-    } else if (config.token) {
-      headers['Authorization'] = `Bearer ${config.token}`
     } else {
-      return { success: false, error: 'Missing cloud credential/token' }
+      headers['Authorization'] = `Bearer ${config.token}`
     }
 
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary
Implements one-command host enrollment for dogfooding: `reflectt host connect --join-token ...`.

## What shipped
- Added cloud runtime integration wiring for reflectt-node startup:
  - `src/cloud.ts`
  - `src/index.ts` startup/shutdown hooks
  - `GET /cloud/status` endpoint in `src/server.ts`
- Added CLI host enrollment commands in `src/cli.ts`:
  - `reflectt host connect --join-token <token>`
    - accepts join token arg
    - calls cloud register API and confirms host credential receipt
    - persists cloud config (`url`, `hostId`, `credential`, host metadata) into `~/.reflectt/config.json`
    - restarts/starts reflectt-node
    - verifies heartbeat via local `/cloud/status`
    - clear success/error output
  - `reflectt host status`
    - prints persisted enrollment + runtime heartbeat status
- Updated server startup env wiring to read persisted cloud config and run cloud loop.
- Added README dogfood usage snippet for one-command cloud enrollment.
- Route/docs contract updated for `/cloud/status`.

## Done criteria mapping
- CLI command accepts join token as argument ✅
- Writes cloud config to persistent location ✅ (`~/.reflectt/config.json`)
- Calls register and confirms credential received ✅
- Verifies heartbeat reaches cloud ✅ (`waitForCloudHeartbeat` checks `/cloud/status`)
- Clear success/error output ✅
- PR with passing build ✅

## Validation
- `npm run build` ✅
- `npm run test -- tests/api.test.ts -t "GET /cloud/status returns cloud state"` ✅

## Notes
- Full `tests/api.test.ts` suite still has a known pre-existing flaky `idle nudge shipped cooldown` assertion on this branch baseline; targeted cloud-status contract test is green.

## Task
- task-1771199551851-hzkxfanmc
