### PR TITLE
feat: CODEOWNERS + file ownership convention

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# CODEOWNERS — reflectt-node
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Purpose: prevent merge conflicts by declaring ownership zones.
+# When a PR touches files in a zone, the listed owner(s) are auto-requested for review.
+#
+# Owners use GitHub usernames. Team agents map via their GitHub accounts.
+# Ryan (@ryancampbell) and Kai (@itskai-dev) are global reviewers.
+
+# ---- Global fallback ----
+*                           @ryancampbell @itskai-dev
+
+# ---- Core server ----
+src/server.ts               @ryancampbell @itskai-dev
+src/index.ts                @ryancampbell @itskai-dev
+src/config.ts               @ryancampbell @itskai-dev
+
+# ---- Cloud integration ----
+src/cloud.ts                @ryancampbell @itskai-dev
+
+# ---- CLI ----
+src/cli.ts                  @ryancampbell @itskai-dev
+
+# ---- Task engine ----
+src/tasks.ts                @ryancampbell @itskai-dev
+
+# ---- Presence + chat ----
+src/presence.ts             @ryancampbell @itskai-dev
+src/chat.ts                 @ryancampbell @itskai-dev
+
+# ---- API docs contract ----
+public/docs.md              @ryancampbell @itskai-dev
+
+# ---- CI / workflows ----
+.github/                    @ryancampbell @itskai-dev
+
+# ---- Tests ----
+tests/                      @ryancampbell @itskai-dev

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,11 @@
 - [ ] This PR does **not** change API behavior/routes, so no docs update is needed
 - [ ] If docs were updated, links/examples were verified
 
+## File ownership
+
+- [ ] Checked `doing` tasks for overlapping `files_touched` before coding
+- [ ] No other in-flight PR touches the same core files (or coordinated in #general)
+
 ## Checklist
 
 - [ ] Scope is limited and reviewer-ready

--- a/docs/FILE_OWNERSHIP_CONVENTION.md
+++ b/docs/FILE_OWNERSHIP_CONVENTION.md
@@ -1,0 +1,59 @@
+# File Ownership Convention
+
+## Problem
+
+When multiple agents work on overlapping files in the same sprint, we get duplicate work and merge conflicts (e.g., PR #77 and PR #78 both shipping `src/cloud.ts`). This wastes review cycles and risks regressions.
+
+## Solution: Two layers
+
+### 1. CODEOWNERS (GitHub-enforced)
+
+Both repos have `.github/CODEOWNERS` files. GitHub auto-requests reviewers when a PR touches owned files. This catches overlap at PR time.
+
+### 2. `files_touched` on tasks (convention-enforced)
+
+When creating or claiming a task, declare which key files you expect to modify:
+
+```json
+{
+  "title": "feat: wire cloud heartbeat",
+  "metadata": {
+    "files_touched": ["src/cloud.ts", "src/server.ts", "src/index.ts"]
+  }
+}
+```
+
+Before starting work, agents should check the board for other `doing` tasks that touch the same files:
+
+```bash
+curl -s http://127.0.0.1:4445/tasks?status=doing | jq '.tasks[].metadata.files_touched'
+```
+
+If overlap is found, coordinate in #general before coding.
+
+## Rules
+
+1. **Declare files upfront** — When moving a task to `doing`, add `metadata.files_touched` with the key files you'll modify.
+2. **Check for conflicts** — Before starting, scan other `doing` tasks for file overlap.
+3. **Coordinate, don't race** — If two tasks need the same file, agents should agree on merge order in #general.
+4. **Rebase, don't duplicate** — If your PR overlaps with a merged PR, rebase onto main. Don't re-implement what landed.
+
+## CODEOWNERS scope
+
+| Repo | File |
+|------|------|
+| reflectt-node | `.github/CODEOWNERS` |
+| reflectt-cloud | `.github/CODEOWNERS` |
+
+Global reviewers: `@ryancampbell`, `@itskai-dev`
+
+Core files (server.ts, cloud.ts, cli.ts, tasks.ts) require review from global owners.
+
+## Quick reference
+
+| Situation | Action |
+|-----------|--------|
+| Starting a task | Add `files_touched` to task metadata |
+| File overlap with another doing task | Post in #general, agree on merge order |
+| PR overlaps with already-merged PR | Rebase onto main, drop duplicate changes |
+| New core file created | Add it to CODEOWNERS |

--- a/docs/TASK_CREATION_TEMPLATE.md
+++ b/docs/TASK_CREATION_TEMPLATE.md
@@ -27,9 +27,14 @@ Use this template to create tasks that can be claimed and reviewed without clari
     "Criterion 3 captures edge-case or quality gate"
   ],
   "priority": "P1",
-  "eta": "45m"
+  "eta": "45m",
+  "metadata": {
+    "files_touched": ["src/example.ts", "tests/example.test.ts"]
+  }
 }
 ```
+
+> **File ownership:** Always declare `metadata.files_touched` when creating or claiming a task. Check other `doing` tasks for overlap before starting. See [File Ownership Convention](FILE_OWNERSHIP_CONVENTION.md).
 
 ## Strong examples (5)
 


### PR DESCRIPTION
## Summary
Add CODEOWNERS and file ownership convention to prevent merge conflicts from parallel agent work on overlapping files.

## What changed
- `.github/CODEOWNERS` — core file ownership zones, auto-requests reviewers
- `docs/FILE_OWNERSHIP_CONVENTION.md` — two-layer approach (CODEOWNERS + `files_touched` metadata)
- `docs/TASK_CREATION_TEMPLATE.md` — added `files_touched` field to template
- `.github/pull_request_template.md` — added file ownership checklist

## Linked task
- Task ID: task-1771202987429-y0orfb7rv

## Motivation
PR #77 and #78 both shipped `src/cloud.ts` independently — duplicate work, wasted review cycles, rebase churn. This convention catches overlap before coding starts.

## Validation
- [x] No code changes, docs/config only
- [x] CODEOWNERS syntax verified

## Notes for reviewer
Companion PR on reflectt-cloud adds CODEOWNERS there too.