### PR TITLE
ci: gate reflectt-node contract changes on docs updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -31,3 +33,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Docs contract gate
+        run: node tools/check-docs-contract-gate.mjs

--- a/tools/check-docs-contract-gate.mjs
+++ b/tools/check-docs-contract-gate.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process'
+
+const CONTRACT_PATTERNS = [
+  /^src\/server\.ts$/,
+  /^src\/tasks\.ts$/,
+  /^src\/types\.ts$/,
+  /^src\/mcp\.ts$/,
+  /^src\/health\.ts$/,
+]
+
+const DOC_PATTERNS = [
+  /^public\/docs\.md$/,
+  /^docs\//,
+  /^README\.md$/,
+]
+
+function run(command) {
+  return execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+}
+
+function tryRun(command) {
+  try {
+    return run(command)
+  } catch {
+    return ''
+  }
+}
+
+function getChangedFiles() {
+  const baseRef = process.env.GITHUB_BASE_REF
+
+  if (baseRef) {
+    tryRun(`git fetch --no-tags --depth=1 origin ${baseRef}`)
+    const out = tryRun(`git diff --name-only origin/${baseRef}...HEAD`)
+    if (out) return out.split('\n').filter(Boolean)
+  }
+
+  const out = tryRun('git diff --name-only HEAD~1..HEAD')
+  if (out) return out.split('\n').filter(Boolean)
+
+  return []
+}
+
+const changedFiles = getChangedFiles()
+if (changedFiles.length === 0) {
+  console.log('docs-contract-gate: no changed files detected; skipping')
+  process.exit(0)
+}
+
+const contractTouched = changedFiles.some((file) => CONTRACT_PATTERNS.some((re) => re.test(file)))
+if (!contractTouched) {
+  console.log('docs-contract-gate: no API/schema contract changes detected')
+  process.exit(0)
+}
+
+const docsTouched = changedFiles.some((file) => DOC_PATTERNS.some((re) => re.test(file)))
+if (docsTouched) {
+  console.log('docs-contract-gate: docs update detected alongside contract changes ✅')
+  process.exit(0)
+}
+
+console.error('docs-contract-gate: API contract changed but no docs files were updated.')
+console.error('Changed files:')
+for (const file of changedFiles) console.error(` - ${file}`)
+console.error('Expected docs update in public/docs.md, docs/*, or README.md')
+process.exit(1)


### PR DESCRIPTION
## Summary
Adds a CI docs-contract gate for reflectt-node so API-contract changes require docs updates.

## What this enforces
If contract-surface files change:
- `src/server.ts`
- `src/tasks.ts`
- `src/types.ts`
- `src/mcp.ts`
- `src/health.ts`

then CI requires docs changes in at least one of:
- `public/docs.md`
- `docs/**`
- `README.md`

## Changes
- Added `tools/check-docs-contract-gate.mjs`
- Updated `.github/workflows/test.yml`:
  - checkout now uses `fetch-depth: 0`
  - added `Docs contract gate` step

## Why
Prevents backend/API changes from drifting away from docs and closes the recurring docs-sync gap.
