### PR TITLE
feat(cli): add dogfood smoke end-to-end verification command

### DIFF
--- a/process/TASK-task-1771202987453-lze8whfxo-DOGFOOD-SMOKE-COMMAND-20260215-1722.md
+++ b/process/TASK-task-1771202987453-lze8whfxo-DOGFOOD-SMOKE-COMMAND-20260215-1722.md
@@ -1,0 +1,30 @@
+# TASK task-1771202987453-lze8whfxo — dogfood smoke command (e2e chain)
+
+## Need / bottleneck
+We lacked a single CLI command to validate the full cloud enrollment chain in one run, which caused verification drift between registration, heartbeat, API visibility, and dashboard-level confidence.
+
+## Shipped
+Added a new CLI command:
+
+```bash
+reflectt dogfood smoke --team-id <teamId> --token <bearerToken> [--cloud-url ...] [--dashboard-url ...]
+```
+
+### Command behavior
+1. Creates one-time host join token (`POST /api/hosts/register-token`)
+2. Claims host using join token (`POST /api/hosts/claim`)
+3. Sends host heartbeat (`POST /api/hosts/:id/heartbeat`)
+4. Verifies cloud sees host (`GET /api/hosts?teamId=...`)
+5. Probes dashboard route reachability and confirms source endpoint contains host
+6. Prints pass/fail per step and exits non-zero on any failure
+
+## File changed
+- `src/cli.ts`
+
+## Verification
+- `npm run -s build` ✅
+- `node dist/cli.js dogfood smoke --help` ✅
+
+## Notes
+- Designed for CI/local dogfood flow with explicit bearer token + team id inputs.
+- Keeps failure semantics strict so it can be used as a gate command.


### PR DESCRIPTION
## Summary
Adds a single command to run the full dogfood enrollment verification chain end-to-end.

### New command
```bash
reflectt dogfood smoke --team-id <teamId> --token <bearerToken>
```

### What it validates (in order)
1. Register host token (`POST /api/hosts/register-token`)
2. Claim host (`POST /api/hosts/claim`)
3. Heartbeat (`POST /api/hosts/:id/heartbeat`)
4. Cloud receipt (`GET /api/hosts?teamId=...`)
5. Dashboard reflection path (dashboard route probe + source endpoint presence)

### Behavior
- Prints pass/fail per step
- Exits non-zero on any failed step (gate-friendly)

## Done criteria mapping
- [x] CLI command runs full registration → heartbeat → verify chain
- [x] Reports pass/fail per step
- [x] Exits non-zero on any failure
- [x] Build passes

## Verification
- `npm run -s build`
- `node dist/cli.js dogfood smoke --help`

## Artifact
- `process/TASK-task-1771202987453-lze8whfxo-DOGFOOD-SMOKE-COMMAND-20260215-1722.md`
