### PR TITLE
feat: add /health/deploy endpoint for deploy attestation

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -62,7 +62,8 @@ Operationally:
 | GET | `/health/agents` | Per-agent health summary (`last_seen`, `active_task`, `heartbeat_age_ms`, `last_shipped_at`, `stale_reason`, state) |
 | GET | `/health/compliance` | Compliance check results |
 | GET | `/health/system` | System info (uptime, memory, versions) |
-| GET | `/health/build` | Build/runtime identity (git SHA, branch, PID, uptime) |
+| GET | `/health/build` | Build/runtime identity (version, git SHA, branch, build timestamp, PID, uptime) |
+| GET | `/health/deploy` | Deploy attestation payload for dashboards (`version`, `gitSha`, `branch`, `buildTimestamp`, `startedAt`, `pid`) |
 | GET | `/health/team/summary` | Compact team health summary |
 | GET | `/health/team/history` | Historical team health data |
 | GET | `/health/workflow` | Unified per-agent workflow state: doing-task age, last shipped timestamp, blocker flag, artifact path, and linked PR state |

--- a/src/server.ts
+++ b/src/server.ts
@@ -1161,6 +1161,23 @@ export async function createServer(): Promise<FastifyInstance> {
     return getBuildInfo()
   })
 
+  // Deploy identity — version + SHA + build timestamp for attestation workflows
+  app.get('/health/deploy', async () => {
+    const build = getBuildInfo()
+    return {
+      version: build.appVersion,
+      gitSha: build.gitSha,
+      gitShortSha: build.gitShortSha,
+      branch: build.gitBranch,
+      buildTimestamp: build.buildTimestamp,
+      startedAt: build.startedAt,
+      startedAtMs: build.startedAtMs,
+      pid: build.pid,
+      nodeVersion: build.nodeVersion,
+      uptime: build.uptime,
+    }
+  })
+
   // Error logs (for debugging)
   app.get('/logs', async (request, reply) => {
     const parsedQuery = LogsQuerySchema.safeParse(request.query ?? {})

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -48,12 +48,28 @@ describe('Health', () => {
   it('GET /health/build returns build info with SHA and PID', async () => {
     const { status, body } = await req('GET', '/health/build')
     expect(status).toBe(200)
+    expect(body.appVersion).toBeDefined()
     expect(body.gitSha).toBeDefined()
     expect(body.gitShortSha).toBeDefined()
     expect(body.gitBranch).toBeDefined()
+    expect(body.buildTimestamp).toBeDefined()
     expect(body.pid).toBeTypeOf('number')
     expect(body.nodeVersion).toBeDefined()
     expect(body.startedAt).toBeDefined()
+    expect(body.uptime).toBeTypeOf('number')
+  })
+
+  it('GET /health/deploy returns deploy attestation payload', async () => {
+    const { status, body } = await req('GET', '/health/deploy')
+    expect(status).toBe(200)
+    expect(body.version).toBeDefined()
+    expect(body.gitSha).toBeDefined()
+    expect(body.gitShortSha).toBeDefined()
+    expect(body.branch).toBeDefined()
+    expect(body.buildTimestamp).toBeDefined()
+    expect(body.startedAt).toBeDefined()
+    expect(body.pid).toBeTypeOf('number')
+    expect(body.nodeVersion).toBeDefined()
     expect(body.uptime).toBeTypeOf('number')
   })
 


### PR DESCRIPTION
## Summary
Adds `/health/deploy` endpoint for deploy-state attestation and extends build metadata for version-aware diagnostics.

## What changed
- `src/buildInfo.ts`
  - Added `appVersion` from `package.json`
  - Added `buildTimestamp`
- `src/server.ts`
  - Added `GET /health/deploy` endpoint returning:
    - version
    - gitSha / gitShortSha
    - branch
    - buildTimestamp
    - startedAt / startedAtMs
    - pid / nodeVersion / uptime
- `public/docs.md`
  - Documented `/health/deploy` contract
  - Updated `/health/build` description to include version/build timestamp
- `tests/api.test.ts`
  - Expanded `/health/build` assertions
  - Added `/health/deploy` contract test

## Validation
- `npm run build` ✅
- `npx vitest run tests/api.test.ts -t "GET /health/build|GET /health/deploy"` ✅

## Task
- task-1771202987474-uhdc90aic
