### PR TITLE
fix: dev-mode port guard + port-specific PID lockfiles

### DIFF
--- a/src/pidlock.ts
+++ b/src/pidlock.ts
@@ -16,6 +16,14 @@ import { execSync } from 'node:child_process'
 
 const DEFAULT_PID_PATH = '/tmp/reflectt-node.pid'
 
+/**
+ * Get port-specific PID path to avoid cross-port lockfile conflicts.
+ * Production (4445) uses the default path for backward compatibility.
+ */
+export function getPidPath(port: number): string {
+  return port === 4445 ? DEFAULT_PID_PATH : `/tmp/reflectt-node-${port}.pid`
+}
+
 export interface PidLockResult {
   previousPid: number | null
   killedPrevious: boolean


### PR DESCRIPTION
## Problem
Agent dev servers (e.g. `npm run dev` from workspace-pixel) were hijacking port 4445, killing the production server via the shared PID lockfile. This happened twice in 10 minutes.

## Fix
1. **Dev-mode port guard**: If `NODE_ENV !== 'production'` and port is 4445, refuse to start with a clear error message suggesting `PORT=4446 npm run dev`
2. **Port-specific PID lockfiles**: Dev servers on port 4446 use `/tmp/reflectt-node-4446.pid`, production uses the default `/tmp/reflectt-node.pid` — prevents cross-port lockfile collisions

## Files Changed
- `src/index.ts` — dev-mode port check before PID lock acquisition, port-aware lockfile paths
- `src/pidlock.ts` — `getPidPath(port)` helper

## Testing
- Dev mode on 4445 → blocked with clear error ✅
- Dev mode on 4446 → works, uses port-specific lockfile ✅
- Production mode on 4445 → works normally ✅
- 73/77 tests pass (4 failures = pre-existing idle-nudge flake)