### PR TITLE
fix(cli): wire host connect to current cloud enrollment API paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ You should see the live dashboard with task board, team health, chat, and activi
 If you have a Reflectt Cloud host join token, you can enroll this node and start heartbeats in one command:
 
 ```bash
-reflectt host connect --join-token <token>
+reflectt host connect --join-token <token> --cloud-url http://127.0.0.1:3001
+```
+
+If your cloud API still requires a user JWT for `/api/hosts/claim`, use temporary compatibility mode:
+
+```bash
+reflectt host connect --join-token <token> --cloud-url http://127.0.0.1:3001 --auth-token <jwt>
 ```
 
 This command:

--- a/process/TASK-task-1771207809338-qdc9oopx3-cli-host-connect-wiring-20260216.md
+++ b/process/TASK-task-1771207809338-qdc9oopx3-cli-host-connect-wiring-20260216.md
@@ -1,0 +1,50 @@
+# task-1771207809338-qdc9oopx3 — CLI host connect wiring + API compatibility (2026-02-16)
+
+## Scope
+Fix dogfood blocker #2 directly in `reflectt-node` CLI by ensuring `host connect` is wired and compatible with current cloud enrollment endpoints.
+
+## What changed
+
+### 1) Kept `host connect` wired under CLI entrypoint
+- Verified registration path is active in `src/cli.ts` under `program.command('host')`.
+
+### 2) Made host enrollment API-compatible across cloud shapes
+Updated `registerHostWithCloud(...)` in `src/cli.ts`:
+- Added compatibility attempts in order:
+  1. `POST /api/hosts/claim` with join-token bearer
+  2. `POST /api/hosts/claim` with optional `--auth-token` bearer (JWT fallback)
+  3. `POST /v1/hosts/register` legacy path
+- Added response-shape compatibility parsing:
+  - New shape: `host.id` + `credential.token`
+  - Legacy shape: `data.hostId` + `data.credential`
+- Error output now includes per-attempt failure details.
+
+### 3) Added temporary JWT fallback CLI option
+`reflectt host connect` now accepts:
+- `--auth-token <jwt>`
+
+Used only when `/api/hosts/claim` still enforces user JWT in environments pending host-bearer auth middleware fix.
+
+### 4) Updated docs
+`README.md` dogfood enrollment section now includes:
+- explicit local cloud URL usage
+- optional `--auth-token` compatibility example
+
+## Verification
+
+### Command surface
+```bash
+npx tsx src/cli.ts host connect --help
+```
+Includes `host connect` and `--auth-token` option.
+
+### Build
+```bash
+npm install
+npm run -s build
+```
+Build succeeds after dependency sync.
+
+## Notes
+- This unblocks CLI-side wiring/compat for bug #2.
+- Full end-to-end enrollment still depends on cloud-side host auth model fix (bug #3) for join-token-only bearer on machine routes.


### PR DESCRIPTION
## Summary
- keeps `reflectt host connect` wired in `src/cli.ts` under `program.command('host')`
- updates cloud enrollment request flow to support both current and legacy APIs:
  - `/api/hosts/claim` (join-token bearer)
  - `/api/hosts/claim` with optional `--auth-token` JWT fallback
  - `/v1/hosts/register` legacy path fallback
- parses both response shapes (`host.id` + `credential.token` and `data.hostId` + `data.credential`)
- updates README dogfood examples for local cloud URL + temporary JWT fallback

## Why
Dogfood blocker #2 showed `host connect` path was brittle relative to cloud API shape/endpoint drift, making enrollment fail even when command exists. This hardens CLI-side compatibility so we can continue E2E verification while host-auth middleware (#3) lands.

## Validation
- `npx tsx src/cli.ts host connect --help`
- `npm install`
- `npm run -s build`

## Task
- task-1771207809338-qdc9oopx3
- artifact: `process/TASK-task-1771207809338-qdc9oopx3-cli-host-connect-wiring-20260216.md`
