### PR TITLE
fix(cloud): include host-heartbeat.v1 contractVersion in heartbeats

### DIFF
--- a/process/TASK-task-1771207809338-qdc9oopx3-heartbeat-contract-version-20260216.md
+++ b/process/TASK-task-1771207809338-qdc9oopx3-heartbeat-contract-version-20260216.md
@@ -1,0 +1,19 @@
+# task-1771207809338-qdc9oopx3 — heartbeat contractVersion hotfix (2026-02-16)
+
+## Change
+Updated `src/cloud.ts` heartbeat payload to include:
+
+```ts
+contractVersion: 'host-heartbeat.v1'
+```
+
+## Why
+Cloud heartbeat endpoint now validates the `host-heartbeat.v1` contract and rejects payloads missing `contractVersion` with `INVALID_HEARTBEAT_CONTRACT`.
+
+## Validation
+- `npm run -s build` (pass)
+- CLI still available post-build:
+  - `node dist/cli.js host connect --help`
+
+## Expected effect
+Automated heartbeat loop from `reflectt-node` should no longer be rejected on missing contract version.

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -235,6 +235,7 @@ async function sendHeartbeat(): Promise<void> {
     : 'online'
 
   const result = await cloudPost(`/api/hosts/${state.hostId}/heartbeat`, {
+    contractVersion: 'host-heartbeat.v1',
     status: hostStatus,
     agents: agents.map(a => ({
       name: a.name,


### PR DESCRIPTION
## Summary
- add `contractVersion: 'host-heartbeat.v1'` to `src/cloud.ts` heartbeat POST payload
- include process artifact for task traceability

## Why
Cloud API heartbeat contract validation requires `contractVersion`. Without it, heartbeat loop gets rejected with `INVALID_HEARTBEAT_CONTRACT`, causing dogfood E2E to fail even after host registration succeeds.

## Validation
- `npm run -s build`
- `node dist/cli.js host connect --help`

## Task
- task-1771207809338-qdc9oopx3
- artifact: `process/TASK-task-1771207809338-qdc9oopx3-heartbeat-contract-version-20260216.md`
