### PR TITLE
fix: idle-nudge test flake — bypass quiet hours in time-shifted test

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1194,7 +1194,7 @@ describe('Idle Nudge shipped cooldown', () => {
     await postShippedUpdate(agent)
 
     const staleNowMs = Date.now() + (4 * 60 * 60_000)
-    const { status, body } = await req('POST', `/health/idle-nudge/tick?dryRun=true&nowMs=${staleNowMs}`)
+    const { status, body } = await req('POST', `/health/idle-nudge/tick?dryRun=true&force=true&nowMs=${staleNowMs}`)
     expect(status).toBe(200)
 
     const decision = (body.decisions || []).find((d: any) => d.agent === agent)


### PR DESCRIPTION
## Root Cause
The `does not apply shipped cooldown when doing lane is stale` test shifts `nowMs` 4 hours into the future. When tests run in the evening (PST), this lands in quiet hours (23:00–08:00), which causes the `/health/idle-nudge/tick` endpoint to return `suppressed: true` with 0 decisions.

This is why the test fails intermittently — it only fails when `Date.now() + 4h` falls between 23:00–08:00 PST.

## Fix
Add `force=true` to the tick query to bypass the quiet hours check. This matches the test's intent: validate shipped cooldown logic regardless of time-of-day.

## Impact
- Fixes the test that's been blocking CI on every PR for the past 12+ hours
- 77/77 tests now pass consistently regardless of when they run
- 1 line changed in `tests/api.test.ts`