### PR TITLE
fix(tests): auto-cleanup TEST: tasks after test runs

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -20,6 +20,19 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  // Clean up all TEST: prefixed tasks created during this run
+  // to prevent pollution across test runs sharing the same DB
+  try {
+    const res = await app.inject({ method: 'GET', url: '/tasks?limit=500' })
+    const tasks = JSON.parse(res.body)?.tasks || []
+    for (const task of tasks) {
+      if (typeof task.title === 'string' && task.title.startsWith('TEST:')) {
+        await app.inject({ method: 'DELETE', url: `/tasks/${task.id}` })
+      }
+    }
+  } catch {
+    // Best-effort cleanup — don't fail the suite if cleanup errors
+  }
   await app.close()
 })
 


### PR DESCRIPTION
## Problem
Tests and production share `~/.reflectt/data/reflectt.db`. TEST: prefixed tasks accumulate across runs — currently **190 in production DB**.

## Fix
Global `afterAll` purges all TEST: prefixed tasks after each test suite run. Best-effort (won't fail the suite on cleanup errors).

Combined with PR #97's per-test `cleanupAgentTasks()`:
1. Each test starts clean (per-test cleanup)
2. DB doesn't accumulate test artifacts (global afterAll)

## Closes
task-1771217921853-szl2xbhgr

80/80 pass.