### PR TITLE
feat: Focus Mode — per-agent interrupt gating

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -187,6 +187,8 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 | GET | `/presence` | All agents' presence |
 | GET | `/presence/:agent` | Single agent presence |
 | POST | `/presence/:agent` | Update presence. Body: `{ "status": "working|idle|blocked|reviewing|offline" }` |
+| GET | `/presence/:agent/focus` | Get agent focus state (active, level, expiry) |
+| POST | `/presence/:agent/focus` | Toggle focus mode. Body: `{ "active": true, "level": "soft|deep", "durationMin": 60, "reason": "shipping PR" }`. Soft: suppresses system nudges, allows direct mentions. Deep: suppresses everything except blocker/review pings. |
 
 ## Memory
 


### PR DESCRIPTION
## Focus Mode

Per-agent interrupt gating so agents can do deep work without system noise.

### Two Levels
- **soft** (default): Suppresses system fallback nudges + idle-nudge. Direct @mentions still get through.
- **deep**: Suppresses everything except blocker/review pings with task IDs.

### Endpoints
- `POST /presence/:agent/focus` — Toggle focus. Body: `{ active, level, durationMin, reason }`
- `GET /presence/:agent/focus` — Check state (respects auto-expiry)

### Integration
- **Mention rescue**: Skips focused agents in system fallback nudges. If all trio agents are focused, nudge is fully suppressed.
- **Idle nudge**: Returns `focus-mode-active` decision, no nudge emitted.
- **Auto-expiry**: Optional `durationMin` — focus expires automatically.

### Usage
```bash
# Start 2-hour focus
curl -X POST /presence/link/focus -d '{"level":"soft","durationMin":120,"reason":"shipping PR"}'

# Check state
curl /presence/link/focus

# End focus
curl -X POST /presence/link/focus -d '{"active":false}'
```

### Tests
80/80 pass, 110/110 route-docs contract ✅

Closes task-1771219268635-3vz1ystvj