### PR TITLE
fix: reject TEST: prefixed tasks in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2116,6 +2116,13 @@ export async function createServer(): Promise<FastifyInstance> {
   app.post('/tasks', async (request, reply) => {
     try {
       const data = CreateTaskSchema.parse(request.body)
+
+      // Reject TEST: prefixed tasks in production to prevent CI pollution
+      if (process.env.NODE_ENV === 'production' && typeof data.title === 'string' && data.title.startsWith('TEST:')) {
+        reply.code(400)
+        return { success: false, error: 'TEST: prefixed tasks are not allowed in production', code: 'TEST_TASK_REJECTED' }
+      }
+
       const { eta, ...rest } = data
       const task = await taskManager.createTask({
         ...rest,


### PR DESCRIPTION
7-line guard: rejects task creation with `TEST:` prefix when `NODE_ENV=production`. CI runs hit production API and leak test tasks — this stops it at the source.

Tests unaffected (don't run with NODE_ENV=production). 80/80 pass.