### PR TITLE
feat(cli): --api-key enrollment + fix quiet-hours test flake

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1087,7 +1087,8 @@ describe('Idle Nudge lane-state transitions', () => {
   }
 
   async function getDecision(agent: string): Promise<any> {
-    const { status, body } = await req('POST', '/health/idle-nudge/tick?dryRun=true')
+    // force=true bypasses quiet hours — tests must work at any time of day
+    const { status, body } = await req('POST', '/health/idle-nudge/tick?dryRun=true&force=true')
     expect(status).toBe(200)
     const decision = (body.decisions || []).find((d: any) => d.agent === agent)
     expect(decision).toBeDefined()
@@ -1199,7 +1200,8 @@ describe('Idle Nudge shipped cooldown', () => {
     await postShippedUpdate(agent)
 
     const tickNowMs = Date.now() + (10 * 60_000)
-    const { status, body } = await req('POST', `/health/idle-nudge/tick?dryRun=true&nowMs=${tickNowMs}`)
+    // force=true bypasses quiet hours — tests must work at any time of day
+    const { status, body } = await req('POST', `/health/idle-nudge/tick?dryRun=true&force=true&nowMs=${tickNowMs}`)
     expect(status).toBe(200)
 
     const decision = (body.decisions || []).find((d: any) => d.agent === agent)


### PR DESCRIPTION
## Two changes

### 1. Agent-friendly CLI enrollment
`reflectt host connect --api-key rk_live_... --name my-host`

Single step, no browser/join-token needed. Uses `POST /api/hosts/enroll` (companion: reflectt-cloud PR #46).

Either `--join-token` or `--api-key` is required. Both paths share the same config-save + hot-reload logic.

### 2. Fix quiet-hours test flake (the REAL root cause)
Added `force=true` to idle-nudge tick calls in tests. Root cause: tests run during quiet hours (23:00-08:00 Pacific) return empty decisions because the tick short-circuits.

This was the actual root cause of the 'flaky' tests:
- PR #93 fixed one timing variant
- PR #97 fixed task pollution
- This PR fixes the quiet hours issue — tests now work at any time of day

### Companion
reflectt-cloud PR #46: `POST /api/hosts/enroll` endpoint

80/80 pass ✅