### PR TITLE
feat(dashboard): add runtime truth card v1

### DIFF
--- a/process/TASK-task-1771218962678-d22xbsghe-runtime-truth-card-v1-20260216.md
+++ b/process/TASK-task-1771218962678-d22xbsghe-runtime-truth-card-v1-20260216.md
@@ -1,0 +1,45 @@
+# task-1771218962678-d22xbsghe — Runtime Truth Card v1 (2026-02-16)
+
+## Shipped
+Implemented a canonical environment state panel for reflectt-node dashboard operators.
+
+### 1) New API endpoint
+- `GET /runtime/truth` in `src/server.ts`
+- Returns one snapshot payload with:
+  - repo identity (`name`, `branch`, `sha`, `shortSha`, `cwd`)
+  - runtime identity (`pid`, `nodeVersion`, `host`, `port`, `uptimeSec`, `startedAt`)
+  - ports (`api`, `dashboard`)
+  - cloud status (`configured`, `registered`, `hostId`, `heartbeatCount`, etc)
+  - deploy drift status (`stale`, reasons, startup/current commit)
+  - local path (`reflecttHome`)
+
+### 2) Dashboard Runtime Truth Card panel
+- Added panel to dashboard HTML in `src/dashboard.ts`:
+  - title: `🧭 Runtime Truth Card`
+  - count chip: `#truth-count`
+  - body container: `#truth-body`
+- Added v1 styling classes for compact facts grid:
+  - `.truth-grid`, `.truth-item`, `.truth-label`, `.truth-value`
+
+### 3) Frontend loader + refresh wiring
+- Added `loadRuntimeTruthCard()` in `public/dashboard.js`
+- Fetches `GET /runtime/truth`
+- Renders canonical sections:
+  - Repo
+  - Runtime
+  - Deploy
+  - Cloud
+  - Paths
+- Wired into dashboard refresh cycle so card updates with other panels.
+
+### 4) API docs update
+- Added `/runtime/truth` to `public/docs.md` Cloud section.
+
+## Validation
+- `npm run -s build` ✅
+- `npm run -s check:route-docs-contract` ✅
+  - server routes: 114
+  - docs routes: 114
+
+## Notes
+This is intentionally v1 read-only truth surface to remove environment ambiguity during ops/debug/review handoffs.

--- a/public/docs.md
+++ b/public/docs.md
@@ -281,6 +281,7 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 |--------|------|-------------|
 | GET | `/cloud/status` | Cloud connection state (registered, heartbeat age, sync status). Only active when `REFLECTT_HOST_TOKEN` is set. |
 | POST | `/cloud/reload` | Hot-reload cloud config from `~/.reflectt/config.json` without server restart. Updates env vars and restarts heartbeat/sync loops. Used by CLI after `host connect` enrollment. |
+| GET | `/runtime/truth` | Canonical environment snapshot for operators: repo/branch/SHA, runtime host+port+PID+uptime, deploy drift, cloud registration/heartbeat, and `REFLECTT_HOME` path. |
 
 ## Other
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -126,6 +126,30 @@ export function getDashboardHTML(): string {
   }
   .panel-header .count { font-size: 12px; color: var(--text-muted); font-weight: 400; }
   .panel-body { padding: 14px 18px; max-height: 450px; overflow-y: auto; }
+  .truth-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px;
+  }
+  .truth-item {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    padding: 10px 12px;
+  }
+  .truth-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+  }
+  .truth-value {
+    font-size: 12px;
+    color: var(--text-bright);
+    line-height: 1.35;
+    word-break: break-word;
+  }
   .project-tabs { display: flex; gap: 2px; padding: 10px 18px 0; border-bottom: 1px solid var(--border); }
   .project-tab {
     padding: 8px 16px; font-size: 13px; font-weight: 500; border: none; background: transparent;
@@ -783,6 +807,11 @@ export function getDashboardHTML(): string {
 <div class="agent-strip" id="agent-strip"></div>
 
 <div class="main">
+  <div class="panel">
+    <div class="panel-header">🧭 Runtime Truth Card <span class="count" id="truth-count">loading…</span></div>
+    <div class="panel-body" id="truth-body"></div>
+  </div>
+
   <div class="panel">
     <div class="panel-header">📋 Task Board <span class="count" id="task-count"></span></div>
     <div class="project-tabs" id="project-tabs"></div>


### PR DESCRIPTION
## Summary
Adds Runtime Truth Card v1 so operators have one canonical environment state view in the dashboard.

### Shipped
- New endpoint: `GET /runtime/truth` (`src/server.ts`)
  - repo: name, branch, sha, shortSha, cwd
  - runtime: pid, nodeVersion, host, port, uptime, startedAt
  - ports: api/dashboard
  - cloud status snapshot
  - deploy drift snapshot (stale + reasons + startup/current commit)
  - paths: reflecttHome
- New dashboard panel in `src/dashboard.ts`
  - `🧭 Runtime Truth Card`
  - `#truth-count`, `#truth-body`
- New frontend loader in `public/dashboard.js`
  - `loadRuntimeTruthCard()`
  - wired into refresh cycle
- Docs update in `public/docs.md`
  - added `/runtime/truth`
- Artifact:
  - `process/TASK-task-1771218962678-d22xbsghe-runtime-truth-card-v1-20260216.md`

## Validation
- `npm run -s build`
- `npm run -s check:route-docs-contract`

## Task
- task-1771218962678-d22xbsghe
