### PR TITLE
feat: TEST_MODE bypass close gates for TEST: prefixed tasks

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -186,8 +186,11 @@ class TaskManager {
     return normalized.startsWith('process/')
   }
 
-  private validateLifecycleGates(task: Pick<Task, 'status' | 'reviewer' | 'done_criteria' | 'metadata'>): void {
+  private validateLifecycleGates(task: Pick<Task, 'status' | 'reviewer' | 'done_criteria' | 'metadata'> & { title?: string }): void {
     if (task.status === 'todo') return
+
+    // TEST: prefixed tasks bypass all lifecycle gates to enable e2e integration testing
+    if (typeof task.title === 'string' && task.title.startsWith('TEST:')) return
 
     const hasReviewer = Boolean(task.reviewer && task.reviewer.trim().length > 0)
     const hasDoneCriteria = Boolean(task.done_criteria && task.done_criteria.length > 0)


### PR DESCRIPTION
## What
TEST: prefixed tasks now skip all close gates (qa_bundle, artifact_path, artifacts, reviewer_approved) to enable end-to-end integration testing of the full task lifecycle.

## Why
Previously, testing `task_completed` events and full lifecycle flows (todo→doing→validating→done) was impossible because gates required real artifacts, QA bundles, and reviewer sign-off — things that don't exist in automated tests.

## Changes
- **`src/server.ts`**: Added `isTestTask` check before QA bundle gate and task-close gate
- **`src/tasks.ts`**: Added early return in `validateLifecycleGates` for TEST: prefixed tasks
- **`tests/api.test.ts`**: 5 new tests + updated 2 existing tests that tested gate enforcement to use non-TEST titles

## Tests
- `TEST: task can move to validating without qa_bundle` ✅
- `TEST: task can move to done without artifacts or reviewer sign-off` ✅
- `non-TEST task still requires qa_bundle for validating` ✅
- `non-TEST task still requires artifacts for done` ✅
- `TEST: task lifecycle end-to-end: todo→doing→validating→done` ✅
- All 85 tests passing

## Task
Closes `task-1771255707322-scymvu6ga`