### PR TITLE
feat: GitHub webhook integration for PR/branch linking

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -594,8 +594,14 @@ function renderKanban() {
         const assigneeDisplay = t.assignee 
           ? `<span class="assignee-tag">👤 ${esc(t.assignee)}${assigneeAgent ? ' <span class="role-small">' + esc(assigneeAgent.role) + '</span>' : ''}</span>`
           : '<span class="assignee-tag" style="color:var(--yellow)">unassigned</span>';
-        const branchDisplay = t.metadata?.branch && t.status === 'doing'
+        const branchDisplay = t.metadata?.branch && (t.status === 'doing' || t.status === 'validating')
           ? `<div style="margin-top:4px"><span class="assignee-tag" style="font-family:monospace;font-size:10px;color:var(--accent)">🌿 ${esc(t.metadata.branch)}</span></div>`
+          : '';
+        const prUrl = t.metadata?.pr_url;
+        const prState = t.metadata?.pr_state || (prUrl ? 'open' : null);
+        const prNumber = t.metadata?.pr_number;
+        const prDisplay = prUrl
+          ? `<div style="margin-top:2px"><a href="${esc(prUrl)}" target="_blank" rel="noopener" class="assignee-tag" style="font-size:10px;color:${prState === 'merged' ? 'var(--green)' : 'var(--accent)'};text-decoration:none">🔗 PR${prNumber ? ' #' + prNumber : ''} (${esc(prState)})</a></div>`
           : '';
         return `
         <div class="task-card" data-task-id="${t.id}">
@@ -607,6 +613,7 @@ function renderKanban() {
             ${renderTaskTags(t.tags)}
           </div>
           ${branchDisplay}
+          ${prDisplay}
           ${renderBlockedByLinks(t, { compact: true })}
           ${renderStatusContractWarning(t)}
           ${renderLaneTransitionMeta(t)}
@@ -1627,6 +1634,22 @@ function openTaskModal(taskId) {
       branchSection.style.display = '';
     } else {
       branchSection.style.display = 'none';
+    }
+  }
+
+  // PR display
+  const prSection = document.getElementById('modal-pr-section');
+  const prEl = document.getElementById('modal-task-pr');
+  if (prSection && prEl) {
+    const prUrl = currentTask.metadata?.pr_url;
+    const prState = currentTask.metadata?.pr_state || (prUrl ? 'open' : null);
+    const prNumber = currentTask.metadata?.pr_number;
+    if (prUrl) {
+      const stateColor = prState === 'merged' ? 'var(--green)' : prState === 'closed' ? 'var(--red)' : 'var(--accent)';
+      prEl.innerHTML = `<a href="${esc(prUrl)}" target="_blank" rel="noopener" style="color:${stateColor};text-decoration:none">PR${prNumber ? ' #' + prNumber : ''}</a> <span style="color:${stateColor}">(${esc(prState)})</span>`;
+      prSection.style.display = '';
+    } else {
+      prSection.style.display = 'none';
     }
   }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -928,6 +928,11 @@ export function getDashboardHTML(): string {
         <div class="modal-label">Branch</div>
         <div class="modal-value" id="modal-task-branch" style="font-family:monospace;font-size:12px;color:var(--accent)"></div>
       </div>
+
+      <div class="modal-section" id="modal-pr-section" style="display:none">
+        <div class="modal-label">Pull Request</div>
+        <div class="modal-value" id="modal-task-pr"></div>
+      </div>
       
       <div class="modal-section">
         <div class="modal-label">Created</div>


### PR DESCRIPTION
## What
GitHub webhook endpoint that auto-links PRs to tasks based on branch matching, plus dashboard display of active PRs per task.

## Why
Agents currently can't see each other's PRs from the dashboard, and PR metadata has to be manually added to tasks. With this webhook, GitHub PR events automatically populate `pr_url`, `pr_number`, `pr_title`, and `pr_state` on matching tasks. Prevents duplicate work when agents don't know what others shipped.

## Changes
- **`src/server.ts`**: `POST /webhooks/github` endpoint — parses `pull_request` events, matches `head.ref` to task `metadata.branch`, auto-populates PR metadata, emits SSE `task_updated` event
- **`public/dashboard.js`**: Task cards show PR link with state badge (open/merged/closed), branch display extended to validating tasks
- **`src/dashboard.ts`**: Added PR section to task modal
- **`tests/api.test.ts`**: 4 new tests

## How it works
1. GitHub webhook fires on PR open/update/merge
2. `POST /webhooks/github` receives the event
3. Matches PR `head.ref` against `metadata.branch` on doing/validating tasks
4. Updates matching tasks with PR metadata
5. Dashboard updates via SSE

## Tests
- `POST /webhooks/github requires x-github-event header` ✅
- `ignores non-pull_request events` ✅
- `links PR to task when branch matches` ✅
- `returns matched=0 when no branch matches` ✅
- All 84 tests passing

## Task
Closes `task-1771255713375-r6gd6pkqo`