### PR TITLE
feat: reflectt init — bootstrap team ops directory

### DIFF
--- a/defaults/.gitignore
+++ b/defaults/.gitignore
@@ -1,0 +1,23 @@
+# reflectt team ops — git-tracked config, excluded runtime data
+
+# Database files
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+
+# Secrets and credentials
+secrets/
+*.key
+*.pem
+*.cert
+
+# Runtime
+logs/
+cache/
+*.pid
+server.pid
+
+# OS artifacts
+.DS_Store
+Thumbs.db

--- a/defaults/TEAM-STANDARDS.md
+++ b/defaults/TEAM-STANDARDS.md
@@ -1,0 +1,32 @@
+# Team Standards
+
+> Operational rules and quality gates for your team.
+> Edit to match your workflow.
+
+## Code Quality
+
+- All changes require tests
+- PRs should be focused and reviewable (< 500 lines preferred)
+- No shipping without verifying it works
+
+## Task Lifecycle
+
+- **todo** → **doing**: requires assignee, reviewer, ETA
+- **doing** → **validating**: requires artifact path under `process/`
+- **validating** → **done**: requires reviewer approval + QA bundle
+
+## Reviews
+
+- Every task has a designated reviewer
+- Reviews check: correctness, test coverage, documentation
+- Reviewer approves or requests changes with specific feedback
+
+## Naming Conventions
+
+- Branches: `<agent>/task-<shortId>`
+- PR titles: `feat:`, `fix:`, `docs:`, `chore:` prefixes
+- Task artifacts: `process/TASK-<id>-<description>.md`
+
+---
+
+*This file is served by reflectt-node via `GET /team/standards`. Edit to match your team.*

--- a/defaults/TEAM.md
+++ b/defaults/TEAM.md
@@ -1,0 +1,32 @@
+# Team Culture
+
+> Edit this file to define your team's mission, values, and working principles.
+> Every agent reads this on startup. It's your team's shared identity.
+
+## Mission
+
+<!-- What does your team exist to do? -->
+
+## Principles
+
+1. **Ship working software.** Features that don't work aren't features.
+2. **Reflect and improve.** When something breaks, find the root cause, fix it, and share what you learned.
+3. **Read before writing.** Understand what exists before changing it.
+4. **Small changes, shipped often.** Easier to review, easier to revert, easier to understand.
+
+## How We Work
+
+- Quality over quantity
+- Test before shipping
+- Document decisions
+- Be honest about what's broken
+
+## Communication
+
+- Status updates go in task comments
+- Blockers get escalated immediately
+- Ship announcements include what changed and why
+
+---
+
+*This file is served by reflectt-node via `GET /team/culture`. Edit it to match your team.*


### PR DESCRIPTION
## What
Enhanced `reflectt init` to bootstrap a complete team ops directory at `~/.reflectt/` with default team files, git tracking, and idempotent behavior.

## Why
Multi-team support requires each team to have their own identity, roles, and standards. `reflectt init` is the first command a new team runs — it needs to set up everything they need to get started.

**EnjoyVancouverIsland.com test:** `docker run reflectt-node && reflectt init` → get a fully configured team directory with sensible defaults, ready to customize.

## What init does now
1. Creates `~/.reflectt/` directory structure (data/, data/inbox/)
2. Copies default team files (idempotent — won't overwrite existing):
   - `TEAM.md` — team culture and principles template
   - `TEAM-ROLES.yaml` — agent role registry (already existed)
   - `TEAM-STANDARDS.md` — operational standards template
   - `.gitignore` — excludes *.db, secrets/, *.key, logs/, cache/
   - `config.json` — default server config
3. `git init` + initial commit (skip with `--no-git`)
4. Prints next steps

## Flags
- `--no-git`: skip git initialization
- `--force`: overwrite existing team files with defaults

## Files
- `defaults/TEAM.md`: culture template (32 lines)
- `defaults/TEAM-STANDARDS.md`: ops standards template (32 lines)
- `defaults/.gitignore`: runtime exclusions (23 lines)
- `src/cli.ts`: enhanced init command (177 additions, 28 removals)

## Tests
93 passing. Route-docs: 118/118.

## Task
Closes `task-1771262329467-1y3osfyut`