### PR TITLE
feat: watchdog focus windows + task-comment suppression (enhancement to #126)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2581,6 +2581,14 @@ export async function createServer(): Promise<FastifyInstance> {
       }
       // ── End branch tracking ──
 
+      // Start per-task focus window on doing transition (45m deep work suppression)
+      if (parsed.status === 'doing' && existing.status !== 'doing') {
+        const focusAgent = (parsed.assignee || existing.assignee || '').toLowerCase()
+        if (focusAgent) {
+          healthMonitor.startTaskFocusWindow(focusAgent, lookup.resolvedId, 45)
+        }
+      }
+
       const { actor, ...rest } = parsed
 
       const nextMetadata: Record<string, unknown> = {


### PR DESCRIPTION
## What
Follow-up to PR #126 (Echo's watchdog improvements). Adds two features Echo's PR didn't include:

### 1. Per-task focus windows
- 45-minute deep work suppression auto-starts when task moves to `doing`
- `startTaskFocusWindow()` called from server.ts doing transition
- `getTaskFocusWindow()` checks remaining time, auto-expires
- New suppression reason: `task-focus-window`

### 2. Task-comment suppression (standalone)
- `getTaskCommentAgeForAgent()` — checks if agent posted task comment in last 30m
- Independent of chat message suppression (works even if agent hasn't posted in #general)
- New suppression reason: `recent-task-comment`

### Tests
- `suppresses nudges when task comment posted recently` ✅
- `starts task focus window on doing transition` ✅

**Note:** May need rebase after #126 merges due to overlapping changes in health.ts.