### PR TITLE
feat(team): TEAM manifest API sourced from ~/.reflectt/TEAM.md

### DIFF
--- a/process/TASK-task-1771261058888-mtuo7mz42-team-manifest-charter-20260216.md
+++ b/process/TASK-task-1771261058888-mtuo7mz42-team-manifest-charter-20260216.md
@@ -1,0 +1,42 @@
+# TASK task-1771261058888-mtuo7mz42 — TEAM.md charter + `/team/manifest` API (data-dir model)
+
+## Scope pivot applied
+Implemented per architecture decision: TEAM charter is loaded from `~/.reflectt/TEAM.md` (via `REFLECTT_HOME`) instead of repo-root files.
+
+## What shipped in code
+
+### 1) `/team/manifest` now serves data-dir TEAM.md
+- Endpoint reads from: `join(REFLECTT_HOME, 'TEAM.md')`
+- Returns:
+  - `raw_markdown`
+  - `sections` (parsed markdown headings/content)
+  - `version` (sha256 content hash)
+  - `updated_at` (mtime)
+  - `path`, `relative_path`, `source`
+- 404 response includes actionable hint when file is missing.
+
+### 2) Parsed structured sections for agent consumption
+- Added markdown section parser in server path.
+- Supports heading-based extraction (`#..######`) into structured blocks.
+
+### 3) API tests updated
+- Added/updated `Team Manifest` integration test to:
+  - write fixture to `join(REFLECTT_HOME, 'TEAM.md')`
+  - verify raw + structured + version metadata response contract.
+
+## Files changed
+- `src/server.ts`
+- `tests/api.test.ts`
+
+## Verification
+Command:
+```bash
+npm test -- --run tests/api.test.ts -t "Team Manifest"
+```
+Result:
+- `Test Files: 1 passed`
+- `Tests: 1 passed, 82 skipped`
+- Exit code `0`
+
+## Notes
+- This aligns with multi-team architecture: product code remains generic while each team defines culture in its own `~/.reflectt/TEAM.md`.


### PR DESCRIPTION
## Summary
Implements `task-1771261058888-mtuo7mz42` with the architecture pivot: team charter is tenant data under `~/.reflectt`, served by API (not hardcoded in repo content).

## What changed
- Added `/team/manifest` endpoint behavior to load from `join(REFLECTT_HOME, 'TEAM.md')`
- Returns both raw and structured content:
  - `raw_markdown`
  - `sections` (parsed by markdown headings)
  - `version` (sha256 hash)
  - `updated_at`, `path`, `relative_path`, `source`
- Added missing-manifest 404 hint pointing operators to `~/.reflectt/TEAM.md`
- Added/updated API test to fixture/write `TEAM.md` under `REFLECTT_HOME` and validate response shape.
- Added task artifact:
  - `process/TASK-task-1771261058888-mtuo7mz42-team-manifest-charter-20260216.md`

## Verification
```bash
npm test -- --run tests/api.test.ts -t "Team Manifest"
```
Result: `1 passed, 82 skipped` (exit 0)

## Notes
This aligns with the multi-team model and the `~/.reflectt/` ops-directory decision from team architecture discussion.
