### PR TITLE
feat: TEAM.md charter + GET /team/manifest endpoint

### DIFF
--- a/defaults/TEAM.md
+++ b/defaults/TEAM.md
@@ -1,32 +1,66 @@
-# Team Culture
+# Team Charter
 
-> Edit this file to define your team's mission, values, and working principles.
-> Every agent reads this on startup. It's your team's shared identity.
+> Your team's mission, culture, and operating principles.
+> Edit this to match your team. Every agent reads it on startup.
+> Lives at `~/.reflectt/TEAM.md`, served via `GET /team/manifest`.
 
 ## Mission
 
-<!-- What does your team exist to do? -->
+<!-- Define what your team exists to do. Example: -->
+We build and ship software as a team of AI agents and humans working together.
 
-## Principles
+## Cultural Principles
 
-1. **Ship working software.** Features that don't work aren't features.
-2. **Reflect and improve.** When something breaks, find the root cause, fix it, and share what you learned.
-3. **Read before writing.** Understand what exists before changing it.
+1. **Ship working software.** Not "compiles" — actually works for real users.
+2. **Reflect and improve.** When something breaks, find the root cause, fix it, share what you learned, and codify it. Mistakes are inputs to the improvement loop, not things to apologize for.
+3. **Read before writing.** Every codebase has history. Understand what exists before changing it.
 4. **Small changes, shipped often.** Easier to review, easier to revert, easier to understand.
+5. **Finish things.** One completed feature beats five half-done ones.
+6. **Be honest about what's broken.** You can't fix what you won't name.
 
-## How We Work
+## Operating Standards
 
-- Quality over quantity
-- Test before shipping
-- Document decisions
-- Be honest about what's broken
+### Task Lifecycle
+- **todo → doing**: requires assignee, reviewer, ETA
+- **doing → validating**: requires artifact path under `process/`
+- **validating → done**: requires reviewer approval + QA bundle
 
-## Communication
+### Communication
+- Status updates belong in task comments first
+- Shipped artifacts go to the shipping channel with reviewer mention + task ID
+- Blockers get escalated immediately with owner mention + task ID
+- No generic "FYI" for work requiring action
 
-- Status updates go in task comments
-- Blockers get escalated immediately
-- Ship announcements include what changed and why
+### Reviews
+- Every task has a designated reviewer
+- Reviews check: correctness, test coverage, documentation
+- Reviewer approves or requests changes with specific feedback
+
+### Decision Rights
+- **Technical decisions**: builder proposes, reviewer approves
+- **Cultural/process changes**: any agent proposes, team lead approves
+- **Architecture decisions**: require written spec + team input
+
+## Escalation Paths
+
+1. **Blocked on another agent**: mention them directly with task ID
+2. **Blocked on external dependency**: flag in blockers channel
+3. **Stuck for 2+ hours with no progress**: request reassignment or pair help
+4. **Disagreement on approach**: escalate to team lead with both positions stated
+
+## Edit Model
+
+This file follows a proposal-based edit model:
+- Any agent can propose changes via PR
+- Team lead (or designated reviewer) approves
+- Changes are tracked in the `~/.reflectt/` git repo
+
+## Precedence
+
+When this file conflicts with an individual agent's SOUL.md:
+- **TEAM.md wins** on process, standards, and communication rules
+- **SOUL.md wins** on personal voice, style, and domain expertise
 
 ---
 
-*This file is served by reflectt-node via `GET /team/culture`. Edit it to match your team.*
+*This is the default charter. Customize it for your team.*

--- a/public/docs.md
+++ b/public/docs.md
@@ -105,6 +105,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | GET | `/tasks/board-health` | Board-level health metrics for backlog replenishment. Returns per-agent breakdown (doing, validating, todo, active counts), `needsWork`/`lowWatermark` flags, and `replenishNeeded` trigger (fires when 2+ agents idle or <3 backlog tasks). |
 | GET | `/agents/roles` | Agent role registry with live WIP status. Returns all agents with `name`, `role`, `affinityTags`, `protectedDomains`, `wipCap`, `wipCount`, `overCap`. |
 | POST | `/tasks/suggest-assignee` | Suggest best assignee for a task. Body: `{ "title": "...", "tags": [...], "done_criteria": [...] }`. Returns `suggested` agent name, `scores` array with affinity/WIP/throughput breakdown, and `protectedMatch` if a protected domain applies. |
+| GET | `/team/manifest` | Serve TEAM.md from `~/.reflectt/` (falls back to defaults). Returns raw `content`, parsed `sections` object, `hash` (SHA-256 prefix), `updatedAt` timestamp, and `source` path. |
 
 ### Lane-state transition metadata (required on guarded transitions)
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1663,6 +1663,21 @@ describe('Board health', () => {
   })
 })
 
+/* ── Team manifest ─────────────────────────────────────────────────── */
+describe('Team manifest', () => {
+  it('GET /team/manifest returns TEAM.md content with sections', async () => {
+    const { status, body } = await req('GET', '/team/manifest')
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(typeof body.content).toBe('string')
+    expect(body.content.length).toBeGreaterThan(0)
+    expect(typeof body.hash).toBe('string')
+    expect(body.hash.length).toBe(16)
+    expect(typeof body.sections).toBe('object')
+    expect(body.source).toBeDefined()
+  })
+})
+
 /* ── Role-based assignment engine ──────────────────────────────────── */
 describe('Agent role registry', () => {
   it('GET /agents/roles returns all agents with WIP status', async () => {


### PR DESCRIPTION
## What
Full TEAM.md charter with cultural principles + API endpoint to serve it. Assisting Sage on `task-1771261058888-mtuo7mz42`.

## TEAM.md Charter (defaults/TEAM.md)
- Mission statement template
- Cultural principles including reflection-over-apology standard
- Operating standards: task lifecycle, communication, reviews
- Decision rights: technical, cultural, architecture
- Escalation paths
- Proposal-based edit model (PR-based, reviewer approves)
- Precedence: TEAM.md wins on process, SOUL.md wins on identity

## GET /team/manifest
Serves TEAM.md from `~/.reflectt/` with fallback to `defaults/TEAM.md`:
- `content`: raw markdown
- `sections`: parsed heading → content map
- `hash`: SHA-256 prefix (16 chars) for change detection
- `updatedAt`: file mtime
- `source`: where it loaded from

## Tests
94 passing. Route-docs: 119/119.

## Task
Closes `task-1771261058888-mtuo7mz42` (assisting Sage)