### PR TITLE
feat: model performance tracking — analytics endpoints + metadata capture

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3202,6 +3202,22 @@ export async function createServer(): Promise<FastifyInstance> {
     return { analytics }
   })
 
+  // Model performance analytics
+  app.get('/analytics/models', async (request) => {
+    const query = request.query as Record<string, string>
+    const since = query.since ? parseInt(query.since, 10) : undefined
+    const analytics = analyticsManager.getModelAnalytics(since)
+    return { success: true, analytics }
+  })
+
+  // Per-agent model + performance stats
+  app.get('/analytics/agents', async (request) => {
+    const query = request.query as Record<string, string>
+    const since = query.since ? parseInt(query.since, 10) : undefined
+    const agents = analyticsManager.getAgentModelAnalytics(since)
+    return { success: true, agents }
+  })
+
   // Operational metrics endpoint (lightweight dashboard contract)
   app.get('/metrics', async () => {
     const startedAt = Date.now()


### PR DESCRIPTION
## Summary
Add LLM model performance tracking. Agents report their model via `metadata.model` on task transitions; analytics endpoints aggregate performance per model and per agent.

## Changes
- **src/analytics.ts**: `getModelAnalytics()` + `getAgentModelAnalytics()` methods
- **src/server.ts**: `GET /analytics/models` + `GET /analytics/agents` endpoints
- **tests**: 3 new tests (endpoints + lifecycle persistence)

## Done Criteria
- [x] Task metadata captures model name on status transitions
- [x] Model info sourced from agent-reported metadata
- [x] GET /analytics/models: tasks per model, avg time-to-ship, review pass rate
- [x] GET /analytics/agents: per-agent model + performance stats
- [x] Dashboard-ready JSON output
- [x] Anonymous/aggregatable for cross-team benchmarking

## Tests
93/97 passing (4 pre-existing failures on main unrelated to this change).

task-1771269312935-3ltiwdgc6