### PR TITLE
feat(dashboard): Focus Mode — active lane emphasis + QA contract visibility

### DIFF
--- a/process/TASK-task-1770951833737-focus-mode-ux.md
+++ b/process/TASK-task-1770951833737-focus-mode-ux.md
@@ -1,0 +1,32 @@
+# Focus Mode UX — task-1770951833737-odoyuhfsh
+
+## Summary
+Added Focus Mode toggle to the dashboard that highlights the active work lane (doing), collapses noise from stale/paused panels, and shows QA contract details (owner, reviewer, ETA, artifact status) on each task card.
+
+## Changes
+
+### `src/dashboard.ts` (HTML + CSS)
+- Added Focus Mode CSS: `.focus-toggle` button, `body.focus-mode` rules
+- Active lane emphasis: non-doing kanban columns dim to 30% opacity, doing column expands
+- Agent strip: non-active agent cards dim to 25%
+- Collapsible panels: Research, Outcome Feed, Compliance, Promotion SSOT get `focus-collapse` class
+- Click-to-expand on collapsed panels (temporary override)
+- QA contract badge styles: `.qa-contract` with owner/reviewer/ETA/artifact rows
+- 🎯 Focus toggle button in header
+- Respects `prefers-reduced-motion`
+
+### `public/dashboard.js`
+- `toggleFocusMode()`: toggles focus mode, persists to localStorage, re-renders kanban
+- `renderQaContract(task)`: renders owner/reviewer/ETA/artifact badge per task card (only in focus mode)
+- Focus mode state restored on page load from localStorage
+- Click handlers for collapsed panels to temporarily expand
+
+## Done Criteria Verification
+1. ✅ Focus Mode toggle supports single active lane emphasis — doing column expands, others dim
+2. ✅ Collapsed stale/paused lanes reduce dashboard noise — Research, Outcome, Compliance, SSOT panels collapse
+3. ✅ QA contract visible in focus state — owner, reviewer, ETA, artifact status shown per card
+
+## Test Results
+- Build: ✅ clean compile
+- Tests: 98 passed, 4 pre-existing failures (not related)
+- Route-docs: 119/119 ✅

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -6,6 +6,7 @@ let allTasks = [];
 let allEvents = [];
 let taskById = new Map();
 let healthAgentMap = new Map();
+let focusModeActive = false;
 
 const TASK_ID_PATTERN = /\b(task-[a-z0-9-]+)\b/gi;
 
@@ -610,6 +611,7 @@ function renderKanban() {
           ${renderBlockedByLinks(t, { compact: true })}
           ${renderStatusContractWarning(t)}
           ${renderLaneTransitionMeta(t)}
+          ${renderQaContract(t)}
         </div>`;
       }).join('');
     const extra = isDone && items.length > 3
@@ -1704,6 +1706,84 @@ async function updateTaskAssignee() {
     console.error('Failed to update task assignee:', e);
   }
 }
+
+// ============ FOCUS MODE ============
+
+function toggleFocusMode() {
+  focusModeActive = !focusModeActive;
+  document.body.classList.toggle('focus-mode', focusModeActive);
+  const btn = document.getElementById('focus-toggle');
+  if (btn) btn.classList.toggle('active', focusModeActive);
+
+  // Persist preference
+  try { localStorage.setItem('reflectt-focus-mode', focusModeActive ? '1' : '0'); } catch {}
+
+  // Re-render kanban to add/remove QA contract details
+  renderKanban();
+
+  // Toggle collapsed panels — allow click to temporarily expand
+  document.querySelectorAll('.panel.focus-collapse').forEach(panel => {
+    if (!panel.dataset.focusClickBound) {
+      panel.addEventListener('click', () => {
+        if (!focusModeActive) return;
+        panel.classList.toggle('focus-expanded');
+        if (panel.classList.contains('focus-expanded')) {
+          panel.style.opacity = '1';
+          panel.querySelectorAll('.panel-body, .channel-tabs, .chat-input-bar, .project-tabs, .kanban').forEach(el => {
+            el.style.display = '';
+          });
+        } else {
+          panel.style.opacity = '';
+          // CSS will re-hide via focus-collapse rules
+        }
+      });
+      panel.dataset.focusClickBound = 'true';
+    }
+    // Reset expanded state when toggling focus mode
+    panel.classList.remove('focus-expanded');
+    panel.style.opacity = '';
+  });
+}
+
+function renderQaContract(task) {
+  if (!focusModeActive) return '';
+  const meta = task.metadata || {};
+  const reviewer = task.reviewer || null;
+  const eta = meta.eta || null;
+  const hasArtifact = !!(meta.artifact_path || (Array.isArray(meta.artifacts) && meta.artifacts.length > 0));
+  const prUrl = extractTaskPrLink(task);
+
+  return `<div class="qa-contract">
+    <div class="qa-row">
+      <span class="qa-label">Owner</span>
+      <span class="qa-value">${task.assignee ? esc(task.assignee) : '<span class="missing">unassigned</span>'}</span>
+    </div>
+    <div class="qa-row">
+      <span class="qa-label">Reviewer</span>
+      <span class="qa-value${!reviewer ? ' missing' : ''}">${reviewer ? esc(reviewer) : 'none'}</span>
+    </div>
+    <div class="qa-row">
+      <span class="qa-label">ETA</span>
+      <span class="qa-value${!eta ? ' missing' : ''}">${eta ? esc(String(eta)) : 'not set'}</span>
+    </div>
+    <div class="qa-row">
+      <span class="qa-label">Artifact</span>
+      <span class="qa-value${hasArtifact ? ' has-artifact' : ' missing'}">${hasArtifact ? (prUrl ? '<a href="' + esc(prUrl) + '" target="_blank" style="color:var(--green)">PR ↗</a>' : '✓ present') : 'none'}</span>
+    </div>
+  </div>`;
+}
+
+// Restore focus mode from localStorage
+(function restoreFocusMode() {
+  try {
+    if (localStorage.getItem('reflectt-focus-mode') === '1') {
+      focusModeActive = true;
+      document.body.classList.add('focus-mode');
+      const btn = document.getElementById('focus-toggle');
+      if (btn) btn.classList.add('active');
+    }
+  } catch {}
+})();
 
 updateClock();
 setInterval(updateClock, 30000);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -787,6 +787,85 @@ export function getDashboardHTML(): string {
       transition-duration: 0.01ms !important;
     }
   }
+
+  /* ============================================
+     Focus Mode — single active lane emphasis
+     ============================================ */
+  .focus-toggle {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 5px 12px; border-radius: 999px; font-size: 12px; font-weight: 600;
+    cursor: pointer; border: 1px solid var(--border); background: var(--surface-raised);
+    color: var(--text-muted); transition: all var(--transition-base) var(--easing-smooth);
+    user-select: none;
+  }
+  .focus-toggle:hover { border-color: var(--accent); color: var(--text); }
+  .focus-toggle.active {
+    background: var(--accent-dim); border-color: var(--accent); color: var(--accent);
+  }
+  .focus-toggle .focus-icon { font-size: 14px; }
+
+  /* Focus mode active: dim non-active kanban columns */
+  body.focus-mode .kanban-col:not([data-status="doing"]) {
+    opacity: 0.3;
+    transform: scale(0.97);
+    transition: all var(--transition-slow) var(--easing-smooth);
+    pointer-events: none;
+  }
+  body.focus-mode .kanban-col:not([data-status="doing"]):hover {
+    opacity: 0.6;
+    pointer-events: auto;
+  }
+  body.focus-mode .kanban-col[data-status="doing"] {
+    flex: 2;
+    transition: flex var(--transition-slow) var(--easing-smooth);
+  }
+  body.focus-mode .kanban-col[data-status="doing"] .kanban-col-header {
+    border-bottom-color: var(--accent);
+    color: var(--accent);
+  }
+
+  /* QA contract badge on task cards in focus mode */
+  .qa-contract {
+    margin-top: 8px; padding: 6px 8px; border-radius: var(--radius-sm);
+    background: var(--surface-raised); border: 1px solid var(--border-subtle);
+    font-size: 11px; line-height: 1.5;
+  }
+  .qa-contract .qa-row { display: flex; justify-content: space-between; align-items: center; gap: 6px; }
+  .qa-contract .qa-row + .qa-row { margin-top: 3px; }
+  .qa-contract .qa-label { color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; font-size: 10px; }
+  .qa-contract .qa-value { color: var(--text-bright); font-weight: 500; }
+  .qa-contract .qa-value.missing { color: var(--yellow); font-style: italic; }
+  .qa-contract .qa-value.has-artifact { color: var(--green); }
+
+  /* Focus mode: dim agent cards not working on active tasks */
+  body.focus-mode .agent-card:not(.active) {
+    opacity: 0.25;
+    transition: opacity var(--transition-base) var(--easing-smooth);
+  }
+  body.focus-mode .agent-card:not(.active):hover {
+    opacity: 0.7;
+  }
+
+  /* Focus mode: collapse non-essential panels */
+  body.focus-mode .panel.focus-collapse .panel-body,
+  body.focus-mode .panel.focus-collapse .channel-tabs,
+  body.focus-mode .panel.focus-collapse .chat-input-bar,
+  body.focus-mode .panel.focus-collapse .project-tabs,
+  body.focus-mode .panel.focus-collapse .kanban {
+    display: none;
+  }
+  body.focus-mode .panel.focus-collapse {
+    opacity: 0.5;
+    transition: opacity var(--transition-base) var(--easing-smooth);
+    cursor: pointer;
+  }
+  body.focus-mode .panel.focus-collapse:hover {
+    opacity: 0.8;
+  }
+  body.focus-mode .panel.focus-collapse .panel-header::after {
+    content: ' (click to expand)';
+    font-size: 11px; color: var(--text-muted); font-weight: 400; font-style: italic;
+  }
 </style>
 <link rel="stylesheet" href="/dashboard-animations.css">
 </head>
@@ -798,6 +877,9 @@ export function getDashboardHTML(): string {
   </div>
   <div class="header-right">
     <span><span class="status-dot"></span>Running</span>
+    <button class="focus-toggle" id="focus-toggle" onclick="toggleFocusMode()" title="Focus Mode: highlight active work, collapse noise">
+      <span class="focus-icon">🎯</span> Focus
+    </button>
     <span id="release-badge" class="release-badge" title="Deploy status">deploy: checking…</span>
     <span id="build-badge" class="release-badge" title="Build info">build: loading…</span>
     <span id="clock"></span>
@@ -828,12 +910,12 @@ export function getDashboardHTML(): string {
     <div class="panel-body" id="backlog-body" style="max-height:300px;overflow-y:auto"></div>
   </div>
 
-  <div class="panel">
+  <div class="panel focus-collapse">
     <div class="panel-header">🔍 Research Intake <span class="count" id="research-count"></span></div>
     <div class="panel-body" id="research-body" style="max-height:260px;overflow-y:auto"></div>
   </div>
 
-  <div class="panel">
+  <div class="panel focus-collapse">
     <div class="panel-header">🏁 Outcome Feed <span class="count" id="outcome-count"></span></div>
     <div class="panel-body" id="outcome-body" style="max-height:320px;overflow-y:auto"></div>
   </div>
@@ -843,12 +925,12 @@ export function getDashboardHTML(): string {
     <div class="panel-body" id="health-body"></div>
   </div>
 
-  <div class="panel">
+  <div class="panel focus-collapse">
     <div class="panel-header">🛡️ Collaboration Compliance <span class="count" id="compliance-count"></span></div>
     <div class="panel-body" id="compliance-body"></div>
   </div>
 
-  <div class="panel">
+  <div class="panel focus-collapse">
     <div class="panel-header">🧭 Promotion SSOT <span class="count" id="ssot-count"></span></div>
     <div class="panel-body" id="ssot-body"></div>
   </div>


### PR DESCRIPTION
## Summary
Focus Mode toggle for the dashboard that highlights active work and reduces noise.

### Changes
- 🎯 Focus toggle in header (persists via localStorage)
- Doing column expands, other kanban lanes dim to 30%
- Non-active agent cards dim to 25%
- Research, Outcome, Compliance, SSOT panels collapse (click to expand)
- QA contract badge per task card: owner, reviewer, ETA, artifact status
- Respects `prefers-reduced-motion`

### Done Criteria
- [x] Focus Mode toggle supports single active lane emphasis
- [x] Collapsed stale/paused lanes reduce dashboard noise
- [x] QA contract (owner/reviewer/artifact ETA visibility) visible in focus state

### Tests
- Build: clean
- 98/102 passed (4 pre-existing failures)
- Route-docs: 119/119

Closes task-1770951833737-odoyuhfsh