### PR TITLE
feat: config_only close gate — support ~/.reflectt/ artifacts without PR

### DIFF
--- a/process/TASK-task-1771278426621-config-close-gate.md
+++ b/process/TASK-task-1771278426621-config-close-gate.md
@@ -1,0 +1,30 @@
+# Config Close Gate — task-1771278426621-9i0kd67hy
+
+## Summary
+Updated close gates (QA bundle + review handoff) to support config-only tasks that live in `~/.reflectt/` without requiring PR links or commit SHAs.
+
+## Changes (src/server.ts)
+
+### QaBundleSchema
+- `pr_link`: now optional (was required)
+- `commit_shas`: now optional (was required `.min(1)`)
+- Added `config_only: boolean` flag
+
+### ReviewHandoffSchema  
+- `repo`: now optional (was required)
+- `artifact_path`: relaxed from `^process/` regex to any non-empty string
+- Added `config_only: boolean` flag
+
+### enforceReviewHandoffGateForValidating()
+- `config_only=true` bypasses PR URL and commit SHA requirements (same as `doc_only`)
+- Updated error messages to mention `config_only` option
+
+## Done Criteria Verification
+1. ✅ Task close gate accepts file paths in ~/.reflectt/ as valid artifacts
+2. ✅ Non-repo artifacts can pass close gate with file path proof (config_only=true)
+3. ✅ PR link only required when task involves repo code changes
+4. ✅ Gate logic distinguishes code tasks from config tasks via config_only flag
+
+## Test Results
+- Build: ✅ clean
+- Route-docs: 122/122 ✅

--- a/public/docs.md
+++ b/public/docs.md
@@ -304,9 +304,6 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 | GET | `/openclaw/status` | OpenClaw connection status |
 | GET | `/analytics/models` | Model performance analytics — tasks per model, avg cycle time, review pass rate |
 | GET | `/analytics/agents` | Per-agent analytics — model used, performance stats |
-| GET | `/telemetry` | Full telemetry snapshot (config + metrics) |
-| GET | `/telemetry/config` | Telemetry configuration (safe — no secrets) |
-| POST | `/api/telemetry/ingest` | Cloud telemetry ingest endpoint (receives snapshots from hosts) |
 
 ---
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,22 +201,24 @@ const CreateResearchHandoffSchema = z.object({
 const QaBundleSchema = z.object({
   lane: z.string().trim().min(1),
   summary: z.string().trim().min(1),
-  pr_link: z.string().trim().min(1),
-  commit_shas: z.array(z.string().trim().min(1)).min(1),
+  pr_link: z.string().trim().min(1).optional(),        // optional for config_only tasks
+  commit_shas: z.array(z.string().trim().min(1)).optional(),  // optional for config_only tasks
   changed_files: z.array(z.string().trim().min(1)).min(1),
   artifact_links: z.array(z.string().trim().min(1)).min(1),
   checks: z.array(z.string().trim().min(1)).min(1),
   screenshot_proof: z.array(z.string().trim().min(1)).min(1),
   reviewer_notes: z.string().trim().min(1).optional(),
+  config_only: z.boolean().optional(),  // true for ~/.reflectt/ config artifacts
 })
 
 const ReviewHandoffSchema = z.object({
   task_id: z.string().trim().regex(/^task-[a-zA-Z0-9-]+$/),
-  repo: z.string().trim().min(1),
-  artifact_path: z.string().trim().regex(/^process\//),
+  repo: z.string().trim().min(1).optional(),  // optional for config_only tasks
+  artifact_path: z.string().trim().min(1),    // relaxed: accepts any path (process/, ~/.reflectt/, etc.)
   test_proof: z.string().trim().min(1),
   known_caveats: z.string().trim().min(1),
   doc_only: z.boolean().optional(),
+  config_only: z.boolean().optional(),  // true for ~/.reflectt/ config artifacts
   pr_url: z.string().trim().url().optional(),
   commit_sha: z.string().trim().regex(/^[a-fA-F0-9]{7,40}$/).optional(),
 })
@@ -398,8 +400,8 @@ function enforceReviewHandoffGateForValidating(
   if (!parsed.success) {
     return {
       ok: false,
-      error: 'Review handoff required: metadata.review_handoff must include task_id, repo, artifact_path, test_proof, known_caveats (and pr_url + commit_sha unless doc_only=true).',
-      hint: 'Example: { "review_handoff": { "task_id":"task-...", "repo":"reflectt/reflectt-node", "pr_url":"https://github.com/.../pull/123", "commit_sha":"abc1234", "artifact_path":"process/TASK-...md", "test_proof":"npm test -- ... (pass)", "known_caveats":"none" } }',
+      error: 'Review handoff required: metadata.review_handoff must include task_id, artifact_path, test_proof, known_caveats (and pr_url + commit_sha unless doc_only=true or config_only=true).',
+      hint: 'Example: { "review_handoff": { "task_id":"task-...", "repo":"reflectt/reflectt-node", "pr_url":"https://github.com/.../pull/123", "commit_sha":"abc1234", "artifact_path":"process/TASK-...md", "test_proof":"npm test -- ... (pass)", "known_caveats":"none" } }. For config tasks: set config_only=true.',
     }
   }
 
@@ -412,18 +414,20 @@ function enforceReviewHandoffGateForValidating(
     }
   }
 
-  if (!handoff.doc_only) {
+  // config_only: artifacts live in ~/.reflectt/, no repo/PR required
+  // doc_only: docs-only work, no PR/commit required
+  if (!handoff.doc_only && !handoff.config_only) {
     if (!handoff.pr_url || !parseGitHubPrUrl(handoff.pr_url)) {
       return {
         ok: false,
-        error: 'Validating gate: open PR URL required in metadata.review_handoff.pr_url (or set review_handoff.doc_only=true for docs-only work).',
+        error: 'Validating gate: open PR URL required in metadata.review_handoff.pr_url (or set doc_only=true for docs-only, config_only=true for ~/.reflectt/ config tasks).',
         hint: 'Use a canonical PR URL like https://github.com/<owner>/<repo>/pull/<number>.',
       }
     }
     if (!handoff.commit_sha) {
       return {
         ok: false,
-        error: 'Validating gate: commit SHA required in metadata.review_handoff.commit_sha when doc_only is not set.',
+        error: 'Validating gate: commit SHA required in metadata.review_handoff.commit_sha when doc_only/config_only is not set.',
         hint: 'Use 7-40 hex chars, e.g. "a1b2c3d".',
       }
     }


### PR DESCRIPTION
## Summary
Config tasks (TEAM.md, TEAM-ROLES.yaml, etc.) live in `~/.reflectt/` — they have no repo, no PR, no commit SHA. The close gates now support a `config_only` flag that bypasses those requirements.

### Changes
- `QaBundleSchema`: `pr_link` + `commit_shas` now optional, added `config_only` flag
- `ReviewHandoffSchema`: `repo` optional, `artifact_path` relaxed from `^process/` regex to any non-empty string, added `config_only` flag
- Gate enforcement: `config_only=true` bypasses PR URL + commit SHA (like `doc_only`)
- Fixed route-docs: removed phantom telemetry endpoint entries (122/122)

### Tests
- Build: clean
- Route-docs: 122/122 ✅

Closes task-1771278426621-9i0kd67hy