### PR TITLE
test: coverage for vault, provisioning, webhooks, portability, notifications

### DIFF
--- a/process/TASK-a1m81544u.md
+++ b/process/TASK-a1m81544u.md
@@ -1,0 +1,12 @@
+# Task: Integration Wiring
+**ID**: task-1771287906311-a1m81544u
+**PR**: https://github.com/reflectt/reflectt-node/pull/149
+**Branch**: link/task-a1m81544u
+**Commit**: 26aeef6
+
+## Test Proof
+- tsc: clean | route-docs: 161/161 | tests: 122/122
+
+## Known Caveats
+- Notification routing is best-effort (non-blocking catch)
+- Webhook incoming route doesn't verify signatures yet (deferred)


### PR DESCRIPTION
## task-1771287936436-prfpbeo8t

### Done Criteria
- [x] Unit tests for SecretVault create/read/rotate/export/import (9 tests)
- [x] Unit tests for ProvisioningManager state machine (5 tests)
- [x] Unit tests for WebhookDeliveryManager enqueue/retry/DLQ/replay (11 tests)
- [x] Unit tests for portability export/import (5 tests)
- [x] Unit tests for notification preferences routing (8 tests + 5 integration)
- [x] All new tests pass in CI

### Impact
- **Test count: 122 → 165 (+43 new tests)**
- All 5 modules shipped today now have test coverage
- Zero test failures

### Test Summary
```
  ✅ tests/api.test.ts (114 tests: 114 passed)
  ✅ tests/embeddings.test.ts (4 tests: 3 passed, 1 skipped)
  ✅ tests/modules.test.ts (43 tests: 43 passed)
  ✅ tests/vector-store.test.ts (5 tests: 5 passed)

  ✅ PASS  165 passed, 0 failed, 1 skipped (166 total)
```