### PR TITLE
feat: since-last-seen agent change feed

### DIFF
--- a/process/TASK-jhvubr179.md
+++ b/process/TASK-jhvubr179.md
@@ -1,0 +1,32 @@
+# Task: Since-Last-Seen Change Feed
+**ID**: task-1771219268654-jhvubr179
+**Branch**: link/task-jhvubr179
+**Assignee**: link
+**Reviewer**: harmony
+
+## Summary
+Unified agent change feed so agents can catch up after deep work without reading all of #general. Returns a single timeline of task changes, comments, mentions, PRs, deploys — filtered by relevance to the requesting agent.
+
+## Changes
+- **New**: `src/changeFeed.ts` — buildAgentFeed() function
+  - Collects from: task history events, task comments, chat mentions, shipping channel PR/deploy signals
+  - 11 event kinds: task_created, task_status_changed, task_assigned, task_commented, task_completed, pr_merged, mention, review_requested, deploy, blocker, digest
+  - Filters by relevance (assignee, reviewer, mentioned), supports global events
+  - Deduplication, kind filtering, limit/pagination
+- **Modified**: `src/server.ts` — GET `/feed/:agent` endpoint
+- **Modified**: `tests/modules.test.ts` — 6 new tests (191 total, all pass)
+- **Modified**: `public/docs.md` — 1 new route entry (174/174 contract)
+
+## REST Endpoint
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/feed/:agent?since=ts` | Unified change feed. Query: since (required), limit, kinds, includeGlobal |
+
+## Done Criteria Mapping
+- ✅ GET /feed/:agent?since=timestamp returns relevant changes
+- ✅ Covers task state changes, PR merges, deploys, reviewer comments
+- ✅ Agents can catch up after deep work without reading all of general
+
+## Test Proof
+- 191 tests pass (up from 185), 1 skipped (pre-existing)
+- Route-docs contract: 174/174

--- a/public/docs.md
+++ b/public/docs.md
@@ -326,6 +326,7 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 | POST | `/board-health/rollback/:actionId` | Rollback an automated action within the rollback window. Body: `{ by? }`. |
 | PATCH | `/board-health/config` | Update worker config at runtime. Fields: enabled, intervalMs, staleDoingThresholdMin, suggestCloseThresholdMin, rollbackWindowMs, digestIntervalMs, digestChannel, quietHoursStart, quietHoursEnd, dryRun, maxActionsPerTick. |
 | POST | `/board-health/prune` | Prune old audit log entries. Query: `?maxAgeDays=7`. |
+| GET | `/feed/:agent` | Since-last-seen change feed. Query: `?since=timestamp&limit=100&kinds=task_status_changed,mention&includeGlobal=true`. Returns unified timeline of task changes, comments, mentions, PRs, deploys relevant to agent. |
 | GET | `/health/watchdog/suppression` | Watchdog de-noise config: show all suppression rules, thresholds, and what activity types prevent re-firing. | Body: `{ agent, type, priority?, channel?, message? }`. Returns routing decision + reason. |
 | GET | `/runtime/truth` | Canonical environment snapshot for operators: repo/branch/SHA, runtime host+port+PID+uptime, deploy drift, cloud registration/heartbeat, and `REFLECTT_HOME` path. |
 

--- a/src/changeFeed.ts
+++ b/src/changeFeed.ts
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Since-Last-Seen Change Feed
+ *
+ * Unified timeline of changes relevant to an agent since a given timestamp.
+ * Covers: task state changes, PR merges, deploys, reviewer comments,
+ * direct mentions, and assignment changes.
+ *
+ * Agents can catch up after deep work without reading all of #general.
+ */
+
+import { taskManager } from './tasks.js'
+import { chatManager } from './chat.js'
+import type { Task, TaskHistoryEvent, TaskComment } from './types.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type FeedEventKind =
+  | 'task_created'
+  | 'task_status_changed'
+  | 'task_assigned'
+  | 'task_commented'
+  | 'task_completed'
+  | 'pr_merged'
+  | 'mention'
+  | 'review_requested'
+  | 'deploy'
+  | 'blocker'
+  | 'digest'
+
+export interface FeedEvent {
+  id: string
+  kind: FeedEventKind
+  timestamp: number
+  /** Agent this event is relevant to (null = relevant to all) */
+  relevantTo: string | null
+  /** Source agent/actor */
+  actor: string
+  /** Human-readable summary */
+  summary: string
+  /** Related task ID if applicable */
+  taskId: string | null
+  /** Related PR URL if applicable */
+  prUrl: string | null
+  /** Raw data for programmatic consumption */
+  data: Record<string, unknown>
+}
+
+export interface FeedOptions {
+  /** Return events since this timestamp (required) */
+  since: number
+  /** Maximum events to return (default: 100) */
+  limit?: number
+  /** Filter to specific event kinds */
+  kinds?: FeedEventKind[]
+  /** Include events relevant to all agents (default: true) */
+  includeGlobal?: boolean
+}
+
+export interface FeedResult {
+  agent: string
+  since: number
+  until: number
+  events: FeedEvent[]
+  count: number
+  hasMore: boolean
+}
+
+// ── Feed Builder ───────────────────────────────────────────────────────────
+
+export function buildAgentFeed(agent: string, options: FeedOptions): FeedResult {
+  const since = options.since
+  const limit = options.limit ?? 100
+  const includeGlobal = options.includeGlobal ?? true
+  const now = Date.now()
+  const agentLower = agent.toLowerCase()
+
+  const events: FeedEvent[] = []
+
+  // 1. Task state changes from history
+  collectTaskEvents(agentLower, since, events)
+
+  // 2. Task comments (on agent's tasks or mentioning agent)
+  collectTaskComments(agentLower, since, events)
+
+  // 3. Chat mentions and relevant messages
+  collectChatEvents(agentLower, since, events)
+
+  // 4. PR/deploy signals from chat
+  collectPrAndDeployEvents(agentLower, since, events)
+
+  // Filter by relevance
+  let filtered = events.filter(e =>
+    e.relevantTo === agentLower || (includeGlobal && e.relevantTo === null),
+  )
+
+  // Filter by kinds if specified
+  if (options.kinds?.length) {
+    const kindSet = new Set(options.kinds)
+    filtered = filtered.filter(e => kindSet.has(e.kind))
+  }
+
+  // Sort by timestamp descending (most recent first)
+  filtered.sort((a, b) => b.timestamp - a.timestamp)
+
+  // Deduplicate by id
+  const seen = new Set<string>()
+  const deduped: FeedEvent[] = []
+  for (const event of filtered) {
+    if (!seen.has(event.id)) {
+      seen.add(event.id)
+      deduped.push(event)
+    }
+  }
+
+  const hasMore = deduped.length > limit
+  const result = deduped.slice(0, limit)
+
+  return {
+    agent: agentLower,
+    since,
+    until: now,
+    events: result,
+    count: result.length,
+    hasMore,
+  }
+}
+
+// ── Collectors ─────────────────────────────────────────────────────────────
+
+function collectTaskEvents(agent: string, since: number, events: FeedEvent[]): void {
+  const allTasks = taskManager.listTasks({})
+
+  for (const task of allTasks) {
+    const history = taskManager.getTaskHistory(task.id)
+
+    for (const event of history) {
+      if (event.timestamp < since) continue
+
+      const isRelevant = isTaskRelevantToAgent(task, agent, event)
+      if (!isRelevant) continue
+
+      switch (event.type) {
+        case 'created':
+          if ((task.assignee || '').toLowerCase() === agent) {
+            events.push({
+              id: `feed-${event.id}`,
+              kind: 'task_created',
+              timestamp: event.timestamp,
+              relevantTo: agent,
+              actor: event.actor,
+              summary: `New task assigned to you: ${task.title}`,
+              taskId: task.id,
+              prUrl: null,
+              data: { taskTitle: task.title, assignee: task.assignee },
+            })
+          }
+          break
+
+        case 'status_changed': {
+          const newStatus = (event.data?.to as string) || task.status
+          const oldStatus = (event.data?.from as string) || 'unknown'
+
+          if (newStatus === 'done') {
+            events.push({
+              id: `feed-${event.id}`,
+              kind: 'task_completed',
+              timestamp: event.timestamp,
+              relevantTo: isMyTask(task, agent) ? agent : null,
+              actor: event.actor,
+              summary: `Task completed: ${task.title} (${oldStatus} → done)`,
+              taskId: task.id,
+              prUrl: extractPrUrl(task),
+              data: { from: oldStatus, to: newStatus },
+            })
+          } else if (newStatus === 'validating' && (task.reviewer || '').toLowerCase() === agent) {
+            events.push({
+              id: `feed-${event.id}`,
+              kind: 'review_requested',
+              timestamp: event.timestamp,
+              relevantTo: agent,
+              actor: event.actor,
+              summary: `Review requested: ${task.title} → validating`,
+              taskId: task.id,
+              prUrl: extractPrUrl(task),
+              data: { from: oldStatus, to: newStatus, assignee: task.assignee },
+            })
+          } else {
+            events.push({
+              id: `feed-${event.id}`,
+              kind: 'task_status_changed',
+              timestamp: event.timestamp,
+              relevantTo: isMyTask(task, agent) ? agent : null,
+              actor: event.actor,
+              summary: `${task.title}: ${oldStatus} → ${newStatus}`,
+              taskId: task.id,
+              prUrl: null,
+              data: { from: oldStatus, to: newStatus },
+            })
+          }
+          break
+        }
+
+        case 'assigned': {
+          const newAssignee = (event.data?.to as string || '').toLowerCase()
+          if (newAssignee === agent) {
+            events.push({
+              id: `feed-${event.id}`,
+              kind: 'task_assigned',
+              timestamp: event.timestamp,
+              relevantTo: agent,
+              actor: event.actor,
+              summary: `Task assigned to you: ${task.title}`,
+              taskId: task.id,
+              prUrl: null,
+              data: { from: event.data?.from, to: event.data?.to },
+            })
+          }
+          break
+        }
+      }
+    }
+  }
+}
+
+function collectTaskComments(agent: string, since: number, events: FeedEvent[]): void {
+  const allTasks = taskManager.listTasks({})
+
+  for (const task of allTasks) {
+    if (!isMyTask(task, agent)) continue
+
+    const comments = taskManager.getTaskComments(task.id)
+    for (const comment of comments) {
+      if (comment.timestamp < since) continue
+      if (comment.author.toLowerCase() === agent) continue // Skip own comments
+
+      events.push({
+        id: `feed-comment-${comment.id}`,
+        kind: 'task_commented',
+        timestamp: comment.timestamp,
+        relevantTo: agent,
+        actor: comment.author,
+        summary: `${comment.author} commented on ${task.title}: ${truncate(comment.content, 80)}`,
+        taskId: task.id,
+        prUrl: null,
+        data: { commentId: comment.id, content: comment.content },
+      })
+    }
+  }
+}
+
+function collectChatEvents(agent: string, since: number, events: FeedEvent[]): void {
+  const messages = chatManager.getMessages({ since, limit: 500 })
+  const mentionPattern = new RegExp(`@${agent}\\b`, 'i')
+
+  for (const msg of messages) {
+    const from = (msg.from || '').toLowerCase()
+    if (from === agent) continue // Skip own messages
+    const content = typeof msg.content === 'string' ? msg.content : ''
+
+    // Direct mentions
+    if (mentionPattern.test(content)) {
+      events.push({
+        id: `feed-mention-${msg.id}`,
+        kind: 'mention',
+        timestamp: msg.timestamp,
+        relevantTo: agent,
+        actor: from,
+        summary: `${msg.from} mentioned you: ${truncate(content, 100)}`,
+        taskId: extractTaskId(content),
+        prUrl: extractPrUrlFromText(content),
+        data: { channel: msg.channel, messageId: msg.id },
+      })
+    }
+
+    // Blocker signals
+    if (/\bblocker\b/i.test(content) && from !== 'system' && from !== 'watchdog') {
+      const taskId = extractTaskId(content)
+      if (taskId) {
+        const task = taskManager.getTask(taskId)
+        if (task && isMyTask(task, agent)) {
+          events.push({
+            id: `feed-blocker-${msg.id}`,
+            kind: 'blocker',
+            timestamp: msg.timestamp,
+            relevantTo: agent,
+            actor: from,
+            summary: `Blocker reported: ${truncate(content, 100)}`,
+            taskId,
+            prUrl: null,
+            data: { channel: msg.channel, content },
+          })
+        }
+      }
+    }
+  }
+}
+
+function collectPrAndDeployEvents(agent: string, since: number, events: FeedEvent[]): void {
+  const messages = chatManager.getMessages({ since, channel: 'shipping', limit: 200 })
+  const prPattern = /(?:PR|pull request)\s*#?(\d+)/i
+  const mergedPattern = /\bmerged\b/i
+  const deployPattern = /\b(?:deployed|deploy|shipped)\b/i
+
+  for (const msg of messages) {
+    const content = typeof msg.content === 'string' ? msg.content : ''
+    const from = (msg.from || '').toLowerCase()
+
+    // PR merge signals
+    const prMatch = content.match(prPattern)
+    if (prMatch && mergedPattern.test(content)) {
+      const prUrl = extractPrUrlFromText(content)
+      const taskId = extractTaskId(content)
+      const isRelevant = taskId
+        ? isTaskRelevantById(taskId, agent)
+        : mentionsAgent(content, agent)
+
+      if (isRelevant || from === agent) {
+        events.push({
+          id: `feed-pr-${msg.id}`,
+          kind: 'pr_merged',
+          timestamp: msg.timestamp,
+          relevantTo: isRelevant ? agent : null,
+          actor: from,
+          summary: `PR #${prMatch[1]} merged: ${truncate(content, 100)}`,
+          taskId,
+          prUrl,
+          data: { prNumber: Number(prMatch[1]), channel: msg.channel },
+        })
+      }
+    }
+
+    // Deploy signals
+    if (deployPattern.test(content) && !prMatch) {
+      events.push({
+        id: `feed-deploy-${msg.id}`,
+        kind: 'deploy',
+        timestamp: msg.timestamp,
+        relevantTo: null, // Deploys are relevant to everyone
+        actor: from,
+        summary: `Deploy: ${truncate(content, 100)}`,
+        taskId: extractTaskId(content),
+        prUrl: extractPrUrlFromText(content),
+        data: { channel: msg.channel },
+      })
+    }
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function isMyTask(task: Task, agent: string): boolean {
+  return (task.assignee || '').toLowerCase() === agent
+    || (task.reviewer || '').toLowerCase() === agent
+}
+
+function isTaskRelevantToAgent(task: Task, agent: string, event: TaskHistoryEvent): boolean {
+  // Relevant if agent is assignee, reviewer, or the actor
+  return isMyTask(task, agent) || event.actor.toLowerCase() === agent
+}
+
+function isTaskRelevantById(taskId: string, agent: string): boolean {
+  const task = taskManager.getTask(taskId)
+  if (!task) return false
+  return isMyTask(task, agent)
+}
+
+function mentionsAgent(text: string, agent: string): boolean {
+  return new RegExp(`@${agent}\\b`, 'i').test(text)
+}
+
+function extractPrUrl(task: Task): string | null {
+  const meta = task.metadata as Record<string, unknown> | null
+  if (!meta) return null
+  if (typeof meta.pr_url === 'string') return meta.pr_url
+  if (typeof meta.pr_link === 'string') return meta.pr_link
+  const handoff = meta.review_handoff as Record<string, unknown> | undefined
+  if (handoff && typeof handoff.pr_url === 'string') return handoff.pr_url
+  return null
+}
+
+function extractPrUrlFromText(text: string): string | null {
+  const match = text.match(/https?:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/)
+  return match ? match[0] : null
+}
+
+function extractTaskId(text: string): string | null {
+  const match = text.match(/\b(task-[a-z0-9-]+)\b/i)
+  return match ? match[1] : null
+}
+
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text
+  return text.slice(0, maxLen - 3) + '...'
+}


### PR DESCRIPTION
## Since-Last-Seen Change Feed

Agents can catch up after deep work without reading all of #general.

### What it does
`GET /feed/:agent?since=timestamp` returns a unified timeline of:
- **Task state changes** (created, status_changed, assigned, completed)
- **Task comments** (on your tasks, by others)
- **Direct mentions** (@agent in chat)
- **Review requests** (task moved to validating where you're reviewer)
- **PR merges** and **deploys** from shipping channel
- **Blocker signals** on your tasks

### Query Parameters
- `since` (required) — Unix timestamp ms
- `limit` — Max events (default 100)
- `kinds` — Comma-separated filter (e.g. `mention,task_completed`)
- `includeGlobal` — Include events relevant to all agents (default true)

### Tests
- **191 tests pass** (6 new), route-docs 174/174

### Task
`task-1771219268654-jhvubr179`