### PR TITLE
feat: channel hygiene — message router moves ops noise out of #general

### DIFF
--- a/process/TASK-ymnyma7oz.md
+++ b/process/TASK-ymnyma7oz.md
@@ -1,0 +1,35 @@
+# Task: Channel Hygiene
+**ID**: task-1771255534920-ymnyma7oz
+**Branch**: link/task-ymnyma7oz
+**Assignee**: link
+**Reviewer**: kai
+
+## Summary
+Message routing layer that moves routine ops noise out of #general. Watchdog alerts, status updates, and digests now route to #ops or task comments. #general reserved for decisions, escalations, blockers, and ship notices.
+
+## Changes
+- **New**: `src/messageRouter.ts` — Message routing engine
+  - Routes by severity (critical → general) and category (watchdog → ops, digest → ops, etc.)
+  - Task-scoped messages auto-added as task comments
+  - Routing decision log for observability
+  - Stats endpoint showing channel distribution
+  - Dry-run resolve endpoint for previewing routes
+- **New**: `ops` channel added to `src/channels.ts`
+- **Modified**: `src/health.ts` — All 4 `chatManager.sendMessage` calls → `routeMessage`
+  - Trio silence → escalation (stays general)
+  - Stale working → watchdog-alert (→ ops + task comment)
+  - Mention rescue → mention-rescue (stays general)
+  - Idle nudge → watchdog-alert (warn → ops, escalate → general)
+- **Modified**: `src/boardHealthWorker.ts` — All 3 `chatManager.sendMessage` calls → `routeMessage`
+  - Auto-block notification → watchdog-alert (→ ops + task comment)
+  - Digest → digest (→ configured channel)
+  - Rollback notification → system-info (→ ops)
+- **Modified**: `src/server.ts` — 3 routing endpoints
+- **Modified**: `tests/modules.test.ts` — 10 new tests (206 total)
+- **Modified**: `public/docs.md` — 3 new route entries (180/180)
+
+## Done Criteria Mapping
+- ✅ Routine status updates auto-route to task comments by default
+- ✅ #general reserved for decisions, blockers, ship notices with reviewer tags
+- ✅ Watchdog enforcement output moves to #ops or task comments
+- ✅ System notifications filterable by severity (routing log supports severity filter)

--- a/public/docs.md
+++ b/public/docs.md
@@ -330,6 +330,9 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 | GET | `/policy` | Get unified policy config (quiet hours, idle nudge, cadence watchdog, board health, escalation thresholds). |
 | PATCH | `/policy` | Update policy config at runtime (deep-merged, persisted to ~/.reflectt/policy.json). Propagates to running workers. |
 | POST | `/policy/reset` | Reset policy to defaults + env overrides. |
+| GET | `/routing/stats` | Message routing stats: total routed, by channel/category/severity, general vs ops count. |
+| GET | `/routing/log` | Recent routing decisions. Query: `?limit=50&since=timestamp&category=watchdog-alert&severity=warning`. |
+| POST | `/routing/resolve` | Dry-run route resolution. Body: `{ from, content, severity?, category?, taskId?, mentions? }`. Returns where message would go. |
 | GET | `/health/watchdog/suppression` | Watchdog de-noise config: show all suppression rules, thresholds, and what activity types prevent re-firing. | Body: `{ agent, type, priority?, channel?, message? }`. Returns routing decision + reason. |
 | GET | `/runtime/truth` | Canonical environment snapshot for operators: repo/branch/SHA, runtime host+port+PID+uptime, deploy drift, cloud registration/heartbeat, and `REFLECTT_HOME` path. |
 

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -7,6 +7,7 @@ export const CHANNEL_DEFINITIONS = [
   { id: 'shipping', name: 'Shipping' },
   { id: 'reviews', name: 'Reviews' },
   { id: 'blockers', name: 'Blockers' },
+  { id: 'ops', name: 'Ops' },
   // Legacy channels retained for compatibility with historical workflows.
   { id: 'problems', name: 'Problems & Ideas' },
   { id: 'dev', name: 'Development' },

--- a/src/messageRouter.ts
+++ b/src/messageRouter.ts
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Message Router
+ *
+ * Routes system messages to the appropriate channel based on severity
+ * and message type. Keeps #general clean for decisions, blockers,
+ * and ship notices only.
+ *
+ * Routing rules:
+ * - critical/escalation → #general (human attention required)
+ * - routine watchdog/status → #ops
+ * - task-scoped updates → task comments (when task ID available)
+ * - ship notices → #shipping
+ * - review requests → #reviews
+ * - blocker alerts → #blockers
+ *
+ * All routing decisions are logged for observability.
+ */
+
+import { chatManager } from './chat.js'
+import { taskManager } from './tasks.js'
+import { policyManager } from './policy.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type MessageSeverity = 'critical' | 'warning' | 'info' | 'debug'
+
+export type MessageCategory =
+  | 'escalation'       // Human attention required NOW
+  | 'blocker'          // Active blocker reported
+  | 'ship-notice'      // Artifact shipped
+  | 'review-request'   // Review needed
+  | 'watchdog-alert'   // Watchdog enforcement (idle nudge, cadence, etc.)
+  | 'status-update'    // Routine status update
+  | 'digest'           // Periodic digest
+  | 'system-info'      // System-level informational
+  | 'mention-rescue'   // Fallback nudge for unresponded mentions
+
+export interface RoutedMessage {
+  from: string
+  content: string
+  /** Explicit severity override */
+  severity?: MessageSeverity
+  /** Message category for routing */
+  category?: MessageCategory
+  /** Related task ID — if present, may route to task comment instead */
+  taskId?: string | null
+  /** Force a specific channel (bypass routing) */
+  forceChannel?: string
+  /** Mentioned agents (used for escalation detection) */
+  mentions?: string[]
+}
+
+export interface RoutingDecision {
+  channel: string
+  alsoComment: boolean
+  reason: string
+}
+
+export interface RoutingResult {
+  decision: RoutingDecision
+  messageId: string | null
+  commentId: string | null
+}
+
+// ── Router ─────────────────────────────────────────────────────────────────
+
+const routingLog: Array<{
+  timestamp: number
+  category: string
+  severity: string
+  channel: string
+  reason: string
+  taskId: string | null
+}> = []
+const MAX_ROUTING_LOG = 500
+
+/**
+ * Route a system message to the appropriate channel + optionally add task comment.
+ */
+export async function routeMessage(msg: RoutedMessage): Promise<RoutingResult> {
+  const decision = resolveRoute(msg)
+
+  let messageId: string | null = null
+  let commentId: string | null = null
+
+  // Send to resolved channel
+  try {
+    const sent = await chatManager.sendMessage({
+      from: msg.from,
+      channel: decision.channel,
+      content: msg.content,
+    })
+    messageId = sent?.id || null
+  } catch {
+    // Non-fatal
+  }
+
+  // Also add as task comment if applicable
+  if (decision.alsoComment && msg.taskId) {
+    try {
+      const comment = await taskManager.addTaskComment(
+        msg.taskId,
+        msg.from,
+        msg.content,
+      )
+      commentId = comment?.id || null
+    } catch {
+      // Non-fatal — task might not exist
+    }
+  }
+
+  // Log routing decision
+  routingLog.push({
+    timestamp: Date.now(),
+    category: msg.category || 'unknown',
+    severity: msg.severity || 'info',
+    channel: decision.channel,
+    reason: decision.reason,
+    taskId: msg.taskId || null,
+  })
+  if (routingLog.length > MAX_ROUTING_LOG) {
+    routingLog.splice(0, routingLog.length - MAX_ROUTING_LOG)
+  }
+
+  return { decision, messageId, commentId }
+}
+
+/**
+ * Resolve routing without sending — for dry-run/preview.
+ */
+export function resolveRoute(msg: RoutedMessage): RoutingDecision {
+  // Explicit channel override
+  if (msg.forceChannel) {
+    return { channel: msg.forceChannel, alsoComment: false, reason: 'force-channel' }
+  }
+
+  const category = msg.category || classifyMessage(msg)
+  const severity = msg.severity || 'info'
+  const policy = policyManager.get()
+
+  // Critical severity always goes to #general
+  if (severity === 'critical') {
+    return {
+      channel: policy.escalation.criticalChannel,
+      alsoComment: Boolean(msg.taskId),
+      reason: 'critical-severity',
+    }
+  }
+
+  switch (category) {
+    case 'escalation':
+      return {
+        channel: policy.escalation.criticalChannel,
+        alsoComment: Boolean(msg.taskId),
+        reason: 'escalation-to-general',
+      }
+
+    case 'blocker':
+      return {
+        channel: 'blockers',
+        alsoComment: Boolean(msg.taskId),
+        reason: 'blocker-to-blockers-channel',
+      }
+
+    case 'ship-notice':
+      return {
+        channel: 'shipping',
+        alsoComment: Boolean(msg.taskId),
+        reason: 'ship-to-shipping-channel',
+      }
+
+    case 'review-request':
+      return {
+        channel: 'reviews',
+        alsoComment: Boolean(msg.taskId),
+        reason: 'review-to-reviews-channel',
+      }
+
+    case 'watchdog-alert':
+      // Watchdog alerts go to ops — unless they're escalations (tier 2)
+      if (severity === 'warning' && msg.mentions?.length) {
+        return {
+          channel: policy.escalation.defaultChannel,
+          alsoComment: Boolean(msg.taskId),
+          reason: 'watchdog-escalation-to-general',
+        }
+      }
+      return {
+        channel: 'ops',
+        alsoComment: Boolean(msg.taskId),
+        reason: 'watchdog-to-ops',
+      }
+
+    case 'status-update':
+      // Routine status updates → task comment if possible, else ops
+      if (msg.taskId) {
+        return {
+          channel: 'ops',
+          alsoComment: true,
+          reason: 'status-update-to-task-comment',
+        }
+      }
+      return {
+        channel: 'ops',
+        alsoComment: false,
+        reason: 'status-update-to-ops',
+      }
+
+    case 'digest':
+      return {
+        channel: policy.escalation.digestChannel,
+        alsoComment: false,
+        reason: 'digest-to-configured-channel',
+      }
+
+    case 'mention-rescue':
+      // Mention rescue stays in general — it's a user-facing nudge
+      return {
+        channel: policy.escalation.defaultChannel,
+        alsoComment: false,
+        reason: 'mention-rescue-to-general',
+      }
+
+    case 'system-info':
+    default:
+      return {
+        channel: 'ops',
+        alsoComment: false,
+        reason: 'system-info-to-ops',
+      }
+  }
+}
+
+/**
+ * Auto-classify message content when no explicit category given.
+ */
+function classifyMessage(msg: RoutedMessage): MessageCategory {
+  const content = msg.content.toLowerCase()
+
+  if (/\bescalat/i.test(content)) return 'escalation'
+  if (/\bblocker\b/i.test(content) && !/blocker:\s*none/i.test(content)) return 'blocker'
+  if (/\bshipped\b|\bmerged\b|\bartifact\b/i.test(content)) return 'ship-notice'
+  if (/\breview\s*(request|needed|required)/i.test(content)) return 'review-request'
+  if (/system\s*(watchdog|reminder|fallback|nudge)/i.test(content)) return 'watchdog-alert'
+  if (/\bdigest\b/i.test(content)) return 'digest'
+  if (/\bstatus\b.*\bupdate\b/i.test(content)) return 'status-update'
+
+  return 'system-info'
+}
+
+// ── Query ──────────────────────────────────────────────────────────────────
+
+export function getRoutingLog(options?: {
+  limit?: number
+  since?: number
+  category?: MessageCategory
+  severity?: MessageSeverity
+}): typeof routingLog {
+  let log = routingLog
+
+  if (options?.since) {
+    log = log.filter(e => e.timestamp >= options.since!)
+  }
+  if (options?.category) {
+    log = log.filter(e => e.category === options.category)
+  }
+  if (options?.severity) {
+    log = log.filter(e => e.severity === options.severity)
+  }
+
+  // Most recent first
+  log = log.slice().sort((a, b) => b.timestamp - a.timestamp)
+
+  if (options?.limit) {
+    log = log.slice(0, options.limit)
+  }
+
+  return log
+}
+
+export function getRoutingStats(): {
+  totalRouted: number
+  byChannel: Record<string, number>
+  byCategory: Record<string, number>
+  bySeverity: Record<string, number>
+  generalCount: number
+  opsCount: number
+  taskCommentCount: number
+} {
+  const byChannel: Record<string, number> = {}
+  const byCategory: Record<string, number> = {}
+  const bySeverity: Record<string, number> = {}
+  let taskCommentCount = 0
+
+  for (const entry of routingLog) {
+    byChannel[entry.channel] = (byChannel[entry.channel] || 0) + 1
+    byCategory[entry.category] = (byCategory[entry.category] || 0) + 1
+    bySeverity[entry.severity] = (bySeverity[entry.severity] || 0) + 1
+    if (entry.taskId) taskCommentCount++
+  }
+
+  return {
+    totalRouted: routingLog.length,
+    byChannel,
+    byCategory,
+    bySeverity,
+    generalCount: byChannel['general'] || 0,
+    opsCount: byChannel['ops'] || 0,
+    taskCommentCount,
+  }
+}


### PR DESCRIPTION
## Channel Hygiene

Moves routine ops noise out of #general. Decisions, escalations, and ship notices stay.

### Routing Rules
| Category | Severity | Channel | Task Comment |
|----------|----------|---------|-------------|
| escalation | any | #general | if task ID |
| blocker | any | #blockers | if task ID |
| ship-notice | any | #shipping | if task ID |
| review-request | any | #reviews | if task ID |
| watchdog-alert | info | #ops | if task ID |
| watchdog-alert | warning + mentions | #general | if task ID |
| status-update | any | #ops | ✅ always |
| digest | any | configured | no |
| mention-rescue | any | #general | no |
| critical severity | any | #general | if task ID |

### What Changed
- `src/messageRouter.ts` — new routing engine
- `src/channels.ts` — added `#ops` channel
- `src/health.ts` — all 4 sendMessage → routeMessage
- `src/boardHealthWorker.ts` — all 3 sendMessage → routeMessage
- 3 new endpoints: stats, log, dry-run resolve

### Tests
- **206 tests pass** (10 new), route-docs 180/180

### Task
`task-1771255534920-ymnyma7oz`