### PR TITLE
feat: task transition UX — precheck + auto-defaults + PR helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src --ext .ts",
     "test": "vitest run",
     "test:summary": "node tools/test-summary.mjs",
+    "pr:create": "node tools/pr-create.mjs",
     "test:idle-nudge:fixtures": "tsx tools/test-idle-nudge-lane-fixtures.ts",
     "test:idle-nudge:coherence": "tsx tools/idle-nudge-coherence-harness.ts",
     "test:task-linkify:regression": "tsx tools/task-linkify-regression-harness.ts",

--- a/process/TASK-zawb9d463.md
+++ b/process/TASK-zawb9d463.md
@@ -1,0 +1,31 @@
+# Task: Task Transition UX
+**ID**: task-1771255540884-zawb9d463
+**Branch**: link/task-zawb9d463
+**Assignee**: link
+**Reviewer**: kai
+
+## Summary
+Precheck endpoint + auto-defaults + PR helper so agents know what's needed before a transition attempt, instead of getting rejected at gate time.
+
+## Changes
+- **New**: `src/taskPrecheck.ts` — runPrecheck() + applyAutoDefaults()
+  - Surfaces all required fields before PATCH attempt
+  - Auto-fills ETA by priority (P0→~30m, P1→~2h, P2→~4h, etc.)
+  - Auto-fills artifact_path from task ID
+  - Generates PATCH template for doing/validating transitions
+  - QA bundle requirements surfaced proactively as warnings
+- **New**: `tools/pr-create.mjs` — PR create helper script
+  - Fetches task details, runs precheck, creates standardized PR
+  - Usage: `npm run pr:create -- --task <id>`
+- **Modified**: `src/server.ts`
+  - POST `/tasks/:id/precheck` endpoint
+  - Auto-defaults wired into PATCH /tasks/:id (ETA auto-fill)
+- **Modified**: `package.json` — `pr:create` script
+- **Modified**: `tests/modules.test.ts` — 6 new tests (212 total)
+- **Modified**: `public/docs.md` — 1 new route (181/181)
+
+## Done Criteria Mapping
+- ✅ API precheck endpoint shows required fields before PATCH
+- ✅ Auto-fill default ETA policy when not provided
+- ✅ qa_bundle requirements surfaced before validating transition, not at rejection time
+- ✅ PR create helper script: npm run pr:create -- --task <id>

--- a/public/docs.md
+++ b/public/docs.md
@@ -333,6 +333,7 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 | GET | `/routing/stats` | Message routing stats: total routed, by channel/category/severity, general vs ops count. |
 | GET | `/routing/log` | Recent routing decisions. Query: `?limit=50&since=timestamp&category=watchdog-alert&severity=warning`. |
 | POST | `/routing/resolve` | Dry-run route resolution. Body: `{ from, content, severity?, category?, taskId?, mentions? }`. Returns where message would go. |
+| POST | `/tasks/:id/precheck` | Precheck task transition. Body: `{ targetStatus }`. Returns required fields, auto-defaults, and a PATCH template. |
 | GET | `/health/watchdog/suppression` | Watchdog de-noise config: show all suppression rules, thresholds, and what activity types prevent re-firing. | Body: `{ agent, type, priority?, channel?, message? }`. Returns routing decision + reason. |
 | GET | `/runtime/truth` | Canonical environment snapshot for operators: repo/branch/SHA, runtime host+port+PID+uptime, deploy drift, cloud registration/heartbeat, and `REFLECTT_HOME` path. |
 

--- a/src/taskPrecheck.ts
+++ b/src/taskPrecheck.ts
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Task Transition Precheck
+ *
+ * Surfaces required fields BEFORE a status transition attempt,
+ * so agents don't get rejected at gate time.
+ *
+ * Also provides auto-defaults for common fields (ETA, artifact path).
+ */
+
+import { taskManager } from './tasks.js'
+import { policyManager } from './policy.js'
+import type { Task } from './types.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type PrecheckSeverity = 'error' | 'warning' | 'info'
+
+export interface PrecheckItem {
+  field: string
+  severity: PrecheckSeverity
+  message: string
+  hint?: string
+  autoDefault?: unknown
+}
+
+export interface PrecheckResult {
+  taskId: string
+  currentStatus: string
+  targetStatus: string
+  ready: boolean
+  items: PrecheckItem[]
+  autoDefaults: Record<string, unknown>
+  template: Record<string, unknown> | null
+}
+
+// ── Default ETA by priority ────────────────────────────────────────────────
+
+const DEFAULT_ETA_BY_PRIORITY: Record<string, string> = {
+  P0: '~30m',
+  P1: '~2h',
+  P2: '~4h',
+  P3: '~1d',
+  P4: '~3d',
+}
+
+// ── Precheck ───────────────────────────────────────────────────────────────
+
+export function runPrecheck(taskId: string, targetStatus: string): PrecheckResult {
+  const task = taskManager.getTask(taskId)
+  if (!task) {
+    return {
+      taskId,
+      currentStatus: 'unknown',
+      targetStatus,
+      ready: false,
+      items: [{ field: 'task', severity: 'error', message: `Task ${taskId} not found` }],
+      autoDefaults: {},
+      template: null,
+    }
+  }
+
+  const items: PrecheckItem[] = []
+  const autoDefaults: Record<string, unknown> = {}
+  const meta = (task.metadata as Record<string, unknown>) || {}
+
+  // ── Common gates (all non-todo statuses) ────────────────────────────
+
+  if (targetStatus !== 'todo') {
+    if (!task.done_criteria || task.done_criteria.length === 0) {
+      items.push({
+        field: 'done_criteria',
+        severity: 'error',
+        message: 'done_criteria required (at least 1 item)',
+        hint: 'Add specific, verifiable completion criteria.',
+      })
+    }
+
+    if (!task.reviewer?.trim()) {
+      items.push({
+        field: 'reviewer',
+        severity: 'error',
+        message: 'reviewer required before starting work',
+        hint: 'Assign a reviewer who can validate the work.',
+      })
+    }
+  }
+
+  // ── doing ───────────────────────────────────────────────────────────
+
+  if (targetStatus === 'doing') {
+    const eta = meta.eta as string | undefined
+    if (!eta?.trim()) {
+      const defaultEta = DEFAULT_ETA_BY_PRIORITY[task.priority || 'P2'] || '~4h'
+      items.push({
+        field: 'metadata.eta',
+        severity: 'warning',
+        message: `ETA required. Auto-default available: "${defaultEta}" (based on ${task.priority || 'P2'} priority)`,
+        hint: 'Provide explicit ETA or accept the auto-default.',
+        autoDefault: defaultEta,
+      })
+      autoDefaults['metadata.eta'] = defaultEta
+    }
+  }
+
+  // ── validating ──────────────────────────────────────────────────────
+
+  if (targetStatus === 'validating') {
+    // Artifact path
+    const artifactPath = meta.artifact_path as string | undefined
+    if (!artifactPath?.trim()) {
+      const suggestedPath = `process/TASK-${taskId.split('-').pop()}.md`
+      items.push({
+        field: 'metadata.artifact_path',
+        severity: 'error',
+        message: 'artifact_path required under process/',
+        hint: `Suggested: "${suggestedPath}"`,
+        autoDefault: suggestedPath,
+      })
+      autoDefaults['metadata.artifact_path'] = suggestedPath
+    } else if (!artifactPath.startsWith('process/')) {
+      items.push({
+        field: 'metadata.artifact_path',
+        severity: 'error',
+        message: 'artifact_path must be under process/ (repo-relative)',
+      })
+    }
+
+    // Review handoff
+    const handoff = meta.review_handoff as Record<string, unknown> | undefined
+    if (!handoff) {
+      items.push({
+        field: 'metadata.review_handoff',
+        severity: 'error',
+        message: 'review_handoff object required for validating transition',
+        hint: 'Must include: task_id, artifact_path, test_proof, known_caveats. Also pr_url + commit_sha unless doc_only or config_only.',
+      })
+    } else {
+      if (!handoff.task_id) {
+        items.push({ field: 'metadata.review_handoff.task_id', severity: 'error', message: 'task_id required in review_handoff' })
+      } else if (handoff.task_id !== taskId) {
+        items.push({ field: 'metadata.review_handoff.task_id', severity: 'error', message: `task_id must match: expected "${taskId}"` })
+      }
+      if (!handoff.artifact_path) {
+        items.push({ field: 'metadata.review_handoff.artifact_path', severity: 'error', message: 'artifact_path required in review_handoff' })
+      }
+      if (!handoff.test_proof) {
+        items.push({ field: 'metadata.review_handoff.test_proof', severity: 'error', message: 'test_proof required (e.g. "vitest run: 206 pass")' })
+      }
+      if (handoff.known_caveats === undefined) {
+        items.push({ field: 'metadata.review_handoff.known_caveats', severity: 'error', message: 'known_caveats required (use "none" if none)' })
+      }
+
+      const isDocOnly = handoff.doc_only === true
+      const isConfigOnly = handoff.config_only === true
+      if (!isDocOnly && !isConfigOnly) {
+        if (!handoff.pr_url) {
+          items.push({ field: 'metadata.review_handoff.pr_url', severity: 'error', message: 'PR URL required (or set doc_only/config_only=true)' })
+        }
+        if (!handoff.commit_sha) {
+          items.push({ field: 'metadata.review_handoff.commit_sha', severity: 'error', message: 'commit SHA required (or set doc_only/config_only=true)' })
+        }
+      }
+    }
+
+    // QA bundle
+    const qaBundle = meta.qa_bundle as Record<string, unknown> | undefined
+    if (!qaBundle) {
+      items.push({
+        field: 'metadata.qa_bundle',
+        severity: 'warning',
+        message: 'qa_bundle recommended for validating (summary, artifact_links, checks, lane, changed_files, screenshot_proof)',
+        hint: 'Include: { summary, artifact_links: [], checks: [], lane, pr_link, commit_shas: [], changed_files: [], screenshot_proof: [] }',
+      })
+    } else {
+      if (!qaBundle.summary) items.push({ field: 'metadata.qa_bundle.summary', severity: 'warning', message: 'qa_bundle.summary recommended' })
+      if (!Array.isArray(qaBundle.checks) || qaBundle.checks.length === 0) {
+        items.push({ field: 'metadata.qa_bundle.checks', severity: 'warning', message: 'qa_bundle.checks recommended (e.g. ["tsc clean", "vitest 206 pass"])' })
+      }
+      if (!Array.isArray(qaBundle.changed_files) || qaBundle.changed_files.length === 0) {
+        items.push({ field: 'metadata.qa_bundle.changed_files', severity: 'warning', message: 'qa_bundle.changed_files recommended' })
+      }
+    }
+  }
+
+  // ── done ────────────────────────────────────────────────────────────
+
+  if (targetStatus === 'done') {
+    if (!meta.reviewer_approved) {
+      items.push({
+        field: 'metadata.reviewer_approved',
+        severity: 'error',
+        message: 'reviewer_approved must be true before marking done',
+      })
+    }
+    if (!meta.artifact_path && !meta.artifacts) {
+      items.push({
+        field: 'metadata.artifact_path',
+        severity: 'error',
+        message: 'artifact_path or artifacts required for done status',
+      })
+    }
+  }
+
+  // ── Build template ──────────────────────────────────────────────────
+
+  const template = buildTemplate(task, targetStatus, autoDefaults)
+  const hasErrors = items.some(i => i.severity === 'error')
+
+  return {
+    taskId,
+    currentStatus: task.status,
+    targetStatus,
+    ready: !hasErrors,
+    items,
+    autoDefaults,
+    template,
+  }
+}
+
+// ── Auto-defaults application ──────────────────────────────────────────────
+
+export function applyAutoDefaults(
+  taskId: string,
+  targetStatus: string,
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  const task = taskManager.getTask(taskId)
+  if (!task) return metadata
+
+  const result = { ...metadata }
+
+  // Auto-fill ETA for doing
+  if (targetStatus === 'doing' && !result.eta) {
+    const priority = task.priority || 'P2'
+    result.eta = DEFAULT_ETA_BY_PRIORITY[priority] || '~4h'
+  }
+
+  // Auto-fill artifact_path for validating
+  if (targetStatus === 'validating' && !result.artifact_path) {
+    const shortId = taskId.split('-').pop()
+    result.artifact_path = `process/TASK-${shortId}.md`
+  }
+
+  return result
+}
+
+// ── Template builder ───────────────────────────────────────────────────────
+
+function buildTemplate(
+  task: Task,
+  targetStatus: string,
+  autoDefaults: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const shortId = task.id.split('-').pop()
+
+  if (targetStatus === 'doing') {
+    return {
+      status: 'doing',
+      metadata: {
+        eta: autoDefaults['metadata.eta'] || '<required>',
+        branch: `link/task-${shortId}`,
+      },
+    }
+  }
+
+  if (targetStatus === 'validating') {
+    return {
+      status: 'validating',
+      metadata: {
+        artifact_path: autoDefaults['metadata.artifact_path'] || `process/TASK-${shortId}.md`,
+        review_handoff: {
+          task_id: task.id,
+          repo: 'reflectt/reflectt-node',
+          pr_url: '<required: https://github.com/reflectt/reflectt-node/pull/NNN>',
+          commit_sha: '<required: 7+ hex chars>',
+          artifact_path: `process/TASK-${shortId}.md`,
+          test_proof: '<required: e.g. "vitest run: 206 pass, tsc clean">',
+          known_caveats: '<required: "none" or description>',
+        },
+        qa_bundle: {
+          summary: '<recommended>',
+          artifact_links: ['<PR URL>'],
+          checks: ['<e.g. tsc clean>', '<vitest NNN pass>'],
+          lane: '<feature name>',
+          pr_link: '<PR URL>',
+          commit_shas: ['<sha>'],
+          changed_files: ['<file1>', '<file2>'],
+          screenshot_proof: ['<test output summary>'],
+        },
+      },
+    }
+  }
+
+  return null
+}

--- a/tools/pr-create.mjs
+++ b/tools/pr-create.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * PR Create Helper
+ *
+ * Usage: npm run pr:create -- --task <task-id> [--title "custom title"]
+ *
+ * Standardizes PR creation with:
+ * - Auto-fetches task title for PR title
+ * - Generates PR body with task ID, done criteria, and checklist
+ * - Runs precheck to surface any missing fields
+ * - Creates the PR via `gh pr create`
+ */
+
+import { execSync } from 'node:child_process'
+
+const args = process.argv.slice(2)
+const taskIdx = args.indexOf('--task')
+const titleIdx = args.indexOf('--title')
+
+if (taskIdx === -1 || !args[taskIdx + 1]) {
+  console.error('Usage: npm run pr:create -- --task <task-id> [--title "custom title"]')
+  process.exit(1)
+}
+
+const taskId = args[taskIdx + 1]
+const customTitle = titleIdx !== -1 ? args[titleIdx + 1] : null
+const API_BASE = process.env.REFLECTT_API || 'http://127.0.0.1:4445'
+
+async function main() {
+  // 1. Fetch task details
+  console.log(`📋 Fetching task ${taskId}...`)
+  const taskRes = await fetch(`${API_BASE}/tasks/${taskId}`)
+  const taskData = await taskRes.json()
+
+  if (!taskData.task) {
+    console.error(`❌ Task not found: ${taskId}`)
+    process.exit(1)
+  }
+
+  const task = taskData.task
+  console.log(`   Title: ${task.title}`)
+  console.log(`   Status: ${task.status}`)
+  console.log(`   Assignee: ${task.assignee || 'unassigned'}`)
+
+  // 2. Run precheck for validating
+  console.log(`\n🔍 Running precheck for validating...`)
+  const precheckRes = await fetch(`${API_BASE}/tasks/${taskId}/precheck`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ targetStatus: 'validating' }),
+  })
+  const precheck = await precheckRes.json()
+
+  if (precheck.items?.length > 0) {
+    console.log(`\n⚠️  Precheck items:`)
+    for (const item of precheck.items) {
+      const icon = item.severity === 'error' ? '❌' : item.severity === 'warning' ? '⚠️' : 'ℹ️'
+      console.log(`   ${icon} [${item.field}] ${item.message}`)
+      if (item.hint) console.log(`      Hint: ${item.hint}`)
+    }
+  }
+
+  if (precheck.ready) {
+    console.log(`\n✅ Task is ready for validating transition`)
+  } else {
+    console.log(`\n⚠️  Task has unmet requirements — PR can still be created`)
+  }
+
+  // 3. Get current branch and commit
+  const branch = execSync('git branch --show-current', { encoding: 'utf8' }).trim()
+  const commitSha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
+  const shortId = taskId.split('-').pop()
+
+  console.log(`\n🔀 Branch: ${branch}`)
+  console.log(`   Commit: ${commitSha}`)
+
+  // 4. Build PR title and body
+  const prTitle = customTitle || `feat: ${task.title.toLowerCase()}`
+
+  const doneCriteria = (task.done_criteria || [])
+    .map(c => `- [ ] ${c}`)
+    .join('\n')
+
+  const prBody = `## ${task.title}
+
+### Task
+\`${taskId}\`
+
+### Done Criteria
+${doneCriteria || '- [ ] (none specified)'}
+
+### Checklist
+- [ ] Tests pass (\`npx vitest run\`)
+- [ ] TypeScript compiles (\`npx tsc --noEmit\`)
+- [ ] Route-docs contract (\`node tools/check-route-docs-contract.mjs\`)
+- [ ] Process artifact created (\`process/TASK-${shortId}.md\`)
+
+### Review Handoff
+\`\`\`json
+{
+  "task_id": "${taskId}",
+  "repo": "reflectt/reflectt-node",
+  "pr_url": "<will be filled after PR creation>",
+  "commit_sha": "${commitSha}",
+  "artifact_path": "process/TASK-${shortId}.md",
+  "test_proof": "<fill in>",
+  "known_caveats": "<fill in or 'none'>"
+}
+\`\`\`
+`
+
+  // 5. Create PR
+  console.log(`\n🚀 Creating PR: "${prTitle}"...`)
+  try {
+    const result = execSync(
+      `gh pr create --title ${JSON.stringify(prTitle)} --body ${JSON.stringify(prBody)} --base main`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+    console.log(`\n✅ PR created: ${result}`)
+
+    // Extract PR number
+    const prMatch = result.match(/\/pull\/(\d+)/)
+    if (prMatch) {
+      console.log(`\n📝 Update task metadata with:`)
+      console.log(`   pr_url: ${result}`)
+      console.log(`   commit_sha: ${commitSha}`)
+    }
+  } catch (err) {
+    console.error(`\n❌ PR creation failed:`, err.stderr || err.message)
+    process.exit(1)
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Task Transition UX

Agents can precheck transitions before attempting, get auto-defaults, and use a standardized PR creation flow.

### Features
- **`POST /tasks/:id/precheck`** — surfaces required fields, auto-defaults, and PATCH template
- **Auto-fill ETA** by priority (P0→~30m, P1→~2h, P2→~4h, P3→~1d, P4→~3d)
- **Auto-fill artifact_path** from task ID
- **QA bundle requirements** surfaced proactively (warnings, not rejections)
- **`npm run pr:create -- --task <id>`** — standardized PR creation

### Tests
- **212 tests pass** (6 new), route-docs 181/181

### Task
`task-1771255540884-zawb9d463`