### PR TITLE
feat: canvas primitives — Screen Contract v0 implementation

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -382,3 +382,9 @@ If missing/invalid, API returns `400` with `Lane-state lock: ...` validation err
 | GET | `/telemetry` | Full telemetry snapshot (config + metrics) |
 | GET | `/telemetry/config` | Telemetry configuration (safe — no secrets) |
 | POST | `/api/telemetry/ingest` | Cloud telemetry ingest endpoint (receives snapshots from hosts) |
+| POST | `/canvas/render` | Push content to a canvas slot (Screen Contract v0 validated) |
+| GET | `/canvas/slots` | Current active (non-stale) slots |
+| GET | `/canvas/slots/all` | All slots including stale (debug) |
+| GET | `/canvas/history` | Recent render history (?slot=&limit=) |
+| GET | `/canvas/rejections` | Recent contract validation rejections |
+| GET | `/canvas/stream` | SSE stream of canvas render events |

--- a/src/canvas-multiplexer.ts
+++ b/src/canvas-multiplexer.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * StreamMultiplexer — validates render events against Screen Contract v0
+ * and broadcasts them as SSE events to canvas subscribers.
+ *
+ * Gate checks (from contract):
+ * 1. Relevance: slot must be in allowed list
+ * 2. Content type: must be in allowed list
+ * 3. Decision signal: required on all renders
+ * 4. Evidence: required for claims/recommendations
+ * 5. Actionability: action slots must include next step
+ */
+
+import {
+  ALLOWED_SLOTS,
+  ALLOWED_CONTENT_TYPES,
+  AGENT_LANE_PREFIX,
+  type SlotEvent,
+  type SlotType,
+  type ContentType,
+} from './canvas-types.js'
+import { slotManager } from './canvas-slots.js'
+
+// ── Validation ───────────────────────────────────────────────────────
+
+export interface ValidationResult {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+}
+
+function isAllowedSlot(slot: string): slot is SlotType {
+  if ((ALLOWED_SLOTS as readonly string[]).includes(slot)) return true
+  if (slot.startsWith(AGENT_LANE_PREFIX)) return true
+  return false
+}
+
+function isAllowedContentType(ct: string): ct is ContentType {
+  return (ALLOWED_CONTENT_TYPES as readonly string[]).includes(ct)
+}
+
+/** Content types that make claims requiring evidence */
+const CLAIM_CONTENT_TYPES = new Set([
+  'metric.single', 'metric.delta', 'task.card',
+  'code.diff.summary', 'cta.button',
+])
+
+/** Decision signal kinds that require actionability */
+const ACTIONABLE_KINDS = new Set(['action'])
+
+export function validateSlotEvent(event: SlotEvent): ValidationResult {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  // 1. Slot type
+  if (!event.slot || !isAllowedSlot(event.slot)) {
+    errors.push(`Invalid slot: "${event.slot}". Allowed: ${[...ALLOWED_SLOTS, 'agent_lane:<id>'].join(', ')}`)
+  }
+
+  // 2. Content type
+  if (!event.content_type || !isAllowedContentType(event.content_type)) {
+    errors.push(`Invalid content_type: "${event.content_type}". Allowed: ${ALLOWED_CONTENT_TYPES.join(', ')}`)
+  }
+
+  // 3. Payload basics
+  if (!event.payload) {
+    errors.push('payload is required')
+    return { valid: false, errors, warnings }
+  }
+
+  if (!event.payload.id) {
+    errors.push('payload.id is required')
+  }
+
+  if (!event.payload.priority || !['p0', 'p1', 'p2', 'p3'].includes(event.payload.priority)) {
+    errors.push('payload.priority must be p0|p1|p2|p3')
+  }
+
+  if (!event.payload.updated_at) {
+    errors.push('payload.updated_at is required (ISO8601)')
+  }
+
+  // 4. Decision signal gate
+  if (!event.payload.decision_signal) {
+    errors.push('payload.decision_signal is required (contract gate)')
+  } else {
+    if (!event.payload.decision_signal.kind ||
+        !['status', 'risk', 'change', 'action'].includes(event.payload.decision_signal.kind)) {
+      errors.push('decision_signal.kind must be status|risk|change|action')
+    }
+    if (!event.payload.decision_signal.why_now || event.payload.decision_signal.why_now.trim().length === 0) {
+      errors.push('decision_signal.why_now is required (explain why this is on screen now)')
+    }
+  }
+
+  // 5. Evidence gate — required for claims/recommendations
+  const evidence = event.payload.evidence || []
+  if (CLAIM_CONTENT_TYPES.has(event.content_type) && evidence.length === 0) {
+    warnings.push(`Content type "${event.content_type}" should include evidence links for claims`)
+  }
+
+  // Validate evidence link shapes
+  for (const ev of evidence) {
+    if (!ev.label || !ev.href || !ev.kind) {
+      errors.push('Each evidence entry requires label, href, and kind')
+      break
+    }
+  }
+
+  // 6. Actionability gate
+  if (event.payload.decision_signal?.kind === 'action') {
+    if (!event.payload.body && !event.payload.action_url && !event.payload.label) {
+      warnings.push('Action signal should include a concrete next step (body, label, or action_url)')
+    }
+  }
+
+  // 7. Priority field
+  if (!event.priority || !['background', 'normal', 'dominant'].includes(event.priority)) {
+    errors.push('priority must be background|normal|dominant')
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}
+
+// ── SSE Broadcasting ─────────────────────────────────────────────────
+
+type CanvasSubscriber = (event: SlotEvent, slot: ReturnType<typeof slotManager.get>) => void
+
+const subscribers = new Set<CanvasSubscriber>()
+
+/**
+ * Subscribe to canvas render events (SSE connections call this).
+ */
+export function subscribeCanvas(callback: CanvasSubscriber): () => void {
+  subscribers.add(callback)
+  return () => { subscribers.delete(callback) }
+}
+
+/**
+ * Get current subscriber count.
+ */
+export function getCanvasSubscriberCount(): number {
+  return subscribers.size
+}
+
+/**
+ * Process a render event: validate → store in slot manager → broadcast.
+ * Returns validation result (callers can check .valid).
+ */
+export function processRender(event: SlotEvent): ValidationResult & { slot?: ReturnType<typeof slotManager.get> } {
+  const validation = validateSlotEvent(event)
+
+  if (!validation.valid) {
+    return validation
+  }
+
+  // Store in slot manager
+  const slot = slotManager.upsert(event)
+
+  // Broadcast to all canvas subscribers
+  for (const sub of subscribers) {
+    try {
+      sub(event, slot)
+    } catch (err) {
+      console.error('[Canvas] Subscriber error:', err)
+    }
+  }
+
+  return { ...validation, slot }
+}
+
+// ── Rejection log (for contract tuning) ──────────────────────────────
+
+interface RejectionEntry {
+  event: Partial<SlotEvent>
+  errors: string[]
+  timestamp: number
+}
+
+const rejections: RejectionEntry[] = []
+const MAX_REJECTIONS = 50
+
+export function logRejection(event: Partial<SlotEvent>, errors: string[]): void {
+  rejections.push({
+    event: { slot: event.slot, content_type: event.content_type, priority: event.priority },
+    errors,
+    timestamp: Date.now(),
+  })
+  if (rejections.length > MAX_REJECTIONS) {
+    rejections.splice(0, rejections.length - MAX_REJECTIONS)
+  }
+}
+
+export function getRecentRejections(limit = 10): RejectionEntry[] {
+  return rejections.slice(-limit)
+}

--- a/src/canvas-slots.ts
+++ b/src/canvas-slots.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * SlotManager — tracks active slots, ownership, priority, staleness.
+ *
+ * Each slot has an owner (agent), content, and a last-update timestamp.
+ * Stale slots (no update in STALE_THRESHOLD_MS) are auto-faded from
+ * the active set but preserved for history/drilldown.
+ */
+
+import type { SlotType, ContentType, RenderPayload, SlotEvent } from './canvas-types.js'
+
+const STALE_THRESHOLD_MS = 60_000  // 60s — slots fade after this
+
+export interface ActiveSlot {
+  slot: SlotType
+  content_type: ContentType
+  payload: RenderPayload
+  priority: 'background' | 'normal' | 'dominant'
+  agent_id: string
+  updated_at: number
+  created_at: number
+  version: number       // increments on each update
+}
+
+class SlotManager {
+  private slots = new Map<string, ActiveSlot>()
+  private history: Array<{ event: SlotEvent; timestamp: number }> = []
+  private maxHistory = 200
+
+  /**
+   * Update or create a slot with new content.
+   */
+  upsert(event: SlotEvent): ActiveSlot {
+    const key = event.slot
+    const existing = this.slots.get(key)
+    const now = Date.now()
+
+    const slot: ActiveSlot = {
+      slot: event.slot,
+      content_type: event.content_type,
+      payload: event.payload,
+      priority: event.priority,
+      agent_id: event.payload.agent_id || 'unknown',
+      updated_at: now,
+      created_at: existing?.created_at || now,
+      version: (existing?.version || 0) + 1,
+    }
+
+    this.slots.set(key, slot)
+
+    // Record history
+    this.history.push({ event, timestamp: now })
+    if (this.history.length > this.maxHistory) {
+      this.history = this.history.slice(-this.maxHistory)
+    }
+
+    return slot
+  }
+
+  /**
+   * Get all currently active (non-stale) slots.
+   * Sorted by priority (dominant first) then recency.
+   */
+  getActive(): ActiveSlot[] {
+    const now = Date.now()
+    const active: ActiveSlot[] = []
+
+    for (const [key, slot] of this.slots) {
+      if (now - slot.updated_at > STALE_THRESHOLD_MS) {
+        continue // skip stale
+      }
+      active.push(slot)
+    }
+
+    // Sort: dominant > normal > background, then by recency
+    const priorityOrder = { dominant: 0, normal: 1, background: 2 }
+    active.sort((a, b) => {
+      const pd = priorityOrder[a.priority] - priorityOrder[b.priority]
+      if (pd !== 0) return pd
+      return b.updated_at - a.updated_at // newest first
+    })
+
+    return active
+  }
+
+  /**
+   * Get a specific slot by key.
+   */
+  get(slotKey: string): ActiveSlot | undefined {
+    return this.slots.get(slotKey)
+  }
+
+  /**
+   * Remove a slot entirely.
+   */
+  remove(slotKey: string): boolean {
+    return this.slots.delete(slotKey)
+  }
+
+  /**
+   * Get all slots (including stale) for debug/audit.
+   */
+  getAll(): ActiveSlot[] {
+    return Array.from(this.slots.values())
+  }
+
+  /**
+   * Get recent history for a slot or all slots.
+   */
+  getHistory(slotKey?: string, limit = 20): Array<{ event: SlotEvent; timestamp: number }> {
+    let entries = this.history
+    if (slotKey) {
+      entries = entries.filter(h => h.event.slot === slotKey)
+    }
+    return entries.slice(-limit)
+  }
+
+  /**
+   * Get stats for ops/debug.
+   */
+  getStats() {
+    const now = Date.now()
+    const all = Array.from(this.slots.values())
+    const active = all.filter(s => now - s.updated_at <= STALE_THRESHOLD_MS)
+    const stale = all.filter(s => now - s.updated_at > STALE_THRESHOLD_MS)
+
+    return {
+      total: all.length,
+      active: active.length,
+      stale: stale.length,
+      historySize: this.history.length,
+      slots: active.map(s => ({
+        slot: s.slot,
+        agent: s.agent_id,
+        content_type: s.content_type,
+        priority: s.priority,
+        age_ms: now - s.updated_at,
+        version: s.version,
+      })),
+    }
+  }
+
+  /**
+   * Clean up stale slots older than maxAge.
+   */
+  prune(maxAgeMs = 5 * 60_000): number {
+    const now = Date.now()
+    let pruned = 0
+    for (const [key, slot] of this.slots) {
+      if (now - slot.updated_at > maxAgeMs) {
+        this.slots.delete(key)
+        pruned++
+      }
+    }
+    return pruned
+  }
+}
+
+export const slotManager = new SlotManager()

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Screen Contract v0 — Types
+ *
+ * Defines the render primitive and all allowed slot/content types
+ * per docs/SCREEN_CONTRACT_V0.md
+ */
+
+// ── Allowed slot types (v0) ──────────────────────────────────────────
+
+export const ALLOWED_SLOTS = [
+  'objective',
+  'narrative',
+  'risk',
+  'action',
+  'evidence',
+  'input',
+  'status',
+] as const
+
+/** Agent lane slots: agent_lane:<agent_id> */
+export const AGENT_LANE_PREFIX = 'agent_lane:'
+
+export type SlotType = (typeof ALLOWED_SLOTS)[number] | `agent_lane:${string}`
+
+// ── Allowed content types (v0) ───────────────────────────────────────
+
+export const ALLOWED_CONTENT_TYPES = [
+  'text.brief',
+  'text.list',
+  'metric.single',
+  'metric.delta',
+  'task.card',
+  'chat.message',
+  'code.diff.summary',
+  'state.badge',
+  'cta.button',
+  'evidence.link',
+  'timeline.event',
+] as const
+
+export type ContentType = (typeof ALLOWED_CONTENT_TYPES)[number]
+
+// ── Decision signal ──────────────────────────────────────────────────
+
+export interface DecisionSignal {
+  kind: 'status' | 'risk' | 'change' | 'action'
+  why_now: string
+}
+
+// ── Evidence link ────────────────────────────────────────────────────
+
+export interface EvidenceLink {
+  label: string
+  href: string
+  kind: 'pr' | 'task' | 'metric' | 'message' | 'doc' | 'log'
+}
+
+// ── Render payload ───────────────────────────────────────────────────
+
+export interface RenderPayload {
+  id: string
+  title?: string
+  body?: string
+  priority: 'p0' | 'p1' | 'p2' | 'p3'
+  confidence?: number
+  freshness_ms?: number
+  agent_id?: string
+  decision_signal: DecisionSignal
+  evidence: EvidenceLink[]
+  updated_at: string
+
+  // Content-type-specific data
+  html?: string
+  text?: string
+  data?: unknown
+  target?: string       // for annotations — which slot to overlay on
+  items?: string[]       // for text.list
+  value?: number         // for metric.single / metric.delta
+  delta?: number         // for metric.delta
+  label?: string         // for state.badge / cta.button
+  action_url?: string    // for cta.button
+  diff_summary?: string  // for code.diff.summary
+  files_changed?: number
+  additions?: number
+  deletions?: number
+}
+
+// ── Slot event (the render primitive) ────────────────────────────────
+
+export interface SlotEvent {
+  slot: SlotType
+  content_type: ContentType
+  payload: RenderPayload
+  priority: 'background' | 'normal' | 'dominant'
+  append?: boolean
+}
+
+// ── Agent identity (from Pixel's spec) ───────────────────────────────
+
+export const AGENT_COLORS: Record<string, string> = {
+  pixel: '#a78bfa',   // violet
+  link: '#60a5fa',    // blue
+  kai: '#f59e0b',     // amber
+  harmony: '#34d399', // green
+  sage: '#9eb3ca',    // slate
+  echo: '#f87171',    // red
+  scout: '#fb923c',   // orange
+}
+
+export const AGENT_DEFAULT_EXPRESSION: Record<string, ContentType> = {
+  pixel: 'text.brief',       // component / annotation
+  link: 'code.diff.summary', // code diff / stream
+  kai: 'text.brief',         // narrative / directive
+  harmony: 'text.brief',     // audio pulse / ambient
+  sage: 'text.brief',        // document / policy
+  echo: 'text.brief',        // alert / narration
+  scout: 'text.brief',       // intelligence / briefing
+}

--- a/tests/canvas.test.ts
+++ b/tests/canvas.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { validateSlotEvent, processRender, logRejection, getRecentRejections, subscribeCanvas } from '../src/canvas-multiplexer.js'
+import { slotManager } from '../src/canvas-slots.js'
+import type { SlotEvent } from '../src/canvas-types.js'
+
+function makeValidEvent(overrides?: Partial<SlotEvent>): SlotEvent {
+  return {
+    slot: 'agent_lane:link',
+    content_type: 'text.brief',
+    priority: 'normal',
+    payload: {
+      id: `test-${Date.now()}`,
+      priority: 'p1',
+      updated_at: new Date().toISOString(),
+      decision_signal: {
+        kind: 'status',
+        why_now: 'Agent is active and working',
+      },
+      evidence: [],
+      body: 'Building canvas primitives',
+    },
+    ...overrides,
+  }
+}
+
+describe('Canvas Contract Validation', () => {
+  it('accepts a valid render event', () => {
+    const result = validateSlotEvent(makeValidEvent())
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('rejects invalid slot type', () => {
+    const result = validateSlotEvent(makeValidEvent({ slot: 'invalid_slot' as any }))
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('Invalid slot')
+  })
+
+  it('accepts agent_lane:<id> slots', () => {
+    const result = validateSlotEvent(makeValidEvent({ slot: 'agent_lane:pixel' }))
+    expect(result.valid).toBe(true)
+  })
+
+  it('accepts all allowed slot types', () => {
+    for (const slot of ['objective', 'narrative', 'risk', 'action', 'evidence', 'input', 'status']) {
+      const result = validateSlotEvent(makeValidEvent({ slot: slot as any }))
+      expect(result.valid).toBe(true)
+    }
+  })
+
+  it('rejects invalid content type', () => {
+    const result = validateSlotEvent(makeValidEvent({ content_type: 'video.full' as any }))
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('Invalid content_type')
+  })
+
+  it('rejects missing decision_signal', () => {
+    const event = makeValidEvent()
+    delete (event.payload as any).decision_signal
+    const result = validateSlotEvent(event)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('decision_signal'))).toBe(true)
+  })
+
+  it('rejects empty why_now', () => {
+    const event = makeValidEvent()
+    event.payload.decision_signal.why_now = ''
+    const result = validateSlotEvent(event)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('why_now'))).toBe(true)
+  })
+
+  it('warns on claims without evidence', () => {
+    const event = makeValidEvent({ content_type: 'metric.single' })
+    const result = validateSlotEvent(event)
+    expect(result.valid).toBe(true)
+    expect(result.warnings.some(w => w.includes('evidence'))).toBe(true)
+  })
+
+  it('rejects malformed evidence entries', () => {
+    const event = makeValidEvent()
+    event.payload.evidence = [{ label: 'test', href: '', kind: 'pr' }]
+    const result = validateSlotEvent(event)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('evidence entry'))).toBe(true)
+  })
+
+  it('rejects missing payload.id', () => {
+    const event = makeValidEvent()
+    delete (event.payload as any).id
+    const result = validateSlotEvent(event)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('id'))).toBe(true)
+  })
+
+  it('rejects invalid priority', () => {
+    const result = validateSlotEvent(makeValidEvent({ priority: 'urgent' as any }))
+    expect(result.valid).toBe(false)
+  })
+})
+
+describe('SlotManager', () => {
+  beforeEach(() => {
+    // Clean up slots between tests
+    for (const slot of slotManager.getAll()) {
+      slotManager.remove(slot.slot)
+    }
+  })
+
+  it('upserts and retrieves slots', () => {
+    const event = makeValidEvent({ slot: 'agent_lane:link' })
+    slotManager.upsert(event)
+    const active = slotManager.getActive()
+    expect(active.length).toBeGreaterThanOrEqual(1)
+    expect(active.some(s => s.slot === 'agent_lane:link')).toBe(true)
+  })
+
+  it('increments version on update', () => {
+    const event = makeValidEvent({ slot: 'agent_lane:test' })
+    slotManager.upsert(event)
+    const v1 = slotManager.get('agent_lane:test')
+    expect(v1?.version).toBe(1)
+
+    slotManager.upsert(event)
+    const v2 = slotManager.get('agent_lane:test')
+    expect(v2?.version).toBe(2)
+  })
+
+  it('sorts by priority then recency', () => {
+    slotManager.upsert(makeValidEvent({ slot: 'agent_lane:a', priority: 'background' }))
+    slotManager.upsert(makeValidEvent({ slot: 'agent_lane:b', priority: 'dominant' }))
+    slotManager.upsert(makeValidEvent({ slot: 'agent_lane:c', priority: 'normal' }))
+
+    const active = slotManager.getActive()
+    expect(active[0]?.priority).toBe('dominant')
+  })
+
+  it('removes slots', () => {
+    slotManager.upsert(makeValidEvent({ slot: 'agent_lane:remove-me' }))
+    expect(slotManager.get('agent_lane:remove-me')).toBeDefined()
+    slotManager.remove('agent_lane:remove-me')
+    expect(slotManager.get('agent_lane:remove-me')).toBeUndefined()
+  })
+
+  it('records history', () => {
+    const event = makeValidEvent({ slot: 'agent_lane:hist' })
+    slotManager.upsert(event)
+    const history = slotManager.getHistory('agent_lane:hist')
+    expect(history.length).toBe(1)
+  })
+
+  it('returns stats', () => {
+    slotManager.upsert(makeValidEvent({ slot: 'agent_lane:stats' }))
+    const stats = slotManager.getStats()
+    expect(stats.active).toBeGreaterThanOrEqual(1)
+    expect(stats.total).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('StreamMultiplexer', () => {
+  it('processes valid events and stores in slot manager', () => {
+    const event = makeValidEvent({ slot: 'agent_lane:mux-test' })
+    const result = processRender(event)
+    expect(result.valid).toBe(true)
+    expect(result.slot).toBeDefined()
+  })
+
+  it('rejects invalid events without storing', () => {
+    const event = makeValidEvent({ slot: 'bogus' as any })
+    const result = processRender(event)
+    expect(result.valid).toBe(false)
+    expect(result.slot).toBeUndefined()
+  })
+
+  it('broadcasts to subscribers', () => {
+    let received: SlotEvent | null = null
+    const unsub = subscribeCanvas((event) => { received = event })
+
+    const event = makeValidEvent({ slot: 'agent_lane:broadcast' })
+    processRender(event)
+    expect(received).not.toBeNull()
+    expect(received?.slot).toBe('agent_lane:broadcast')
+
+    unsub()
+  })
+
+  it('logs rejections', () => {
+    logRejection({ slot: 'bad' as any }, ['test error'])
+    const recent = getRecentRejections()
+    expect(recent.length).toBeGreaterThanOrEqual(1)
+    expect(recent[recent.length - 1]?.errors[0]).toBe('test error')
+  })
+})


### PR DESCRIPTION
## One screen, infinite expression

Node-side primitives for the AI-driven canvas surface per Screen Contract v0.

### New modules
- **`canvas-types.ts`** — `SlotEvent`, allowed slot/content types, agent identity colors
- **`canvas-slots.ts`** — `SlotManager` — tracks active slots, ownership, staleness, history
- **`canvas-multiplexer.ts`** — validates against contract, broadcasts via SSE

### API
- `POST /canvas/render` — agents push content (contract-validated)
- `GET /canvas/slots` — active non-stale slots
- `GET /canvas/stream` — SSE stream for canvas subscribers (snapshot + live events)
- `GET /canvas/history` — render history
- `GET /canvas/rejections` — contract violation log

### Contract enforcement
All 6 gates from Screen Contract v0:
1. Slot type validation (8 types + agent_lane)
2. Content type validation (11 types)
3. Decision signal required (kind + why_now)
4. Evidence required for claims
5. Actionability check for action signals
6. Rejection logging for tuning

### Tests
268 passing (21 new). Covers validation, slot management, multiplexer broadcast, and rejection logging.