### PR TITLE
task-1771345240342: auto-notify implementation handoff for design-ready tasks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -618,6 +618,21 @@ function extractArtifactPathsFromTask(task: Task): string[] {
   return Array.from(out)
 }
 
+function getDesignHandoffArtifactPath(metadata: Record<string, unknown>): string | undefined {
+  const artifactPath = metadata.artifact_path
+  if (typeof artifactPath === 'string' && artifactPath.trim().length > 0) {
+    return artifactPath.trim()
+  }
+
+  const artifacts = metadata.artifacts
+  if (Array.isArray(artifacts)) {
+    const firstPath = artifacts.find((item) => typeof item === 'string' && item.trim().length > 0)
+    if (typeof firstPath === 'string') return firstPath.trim()
+  }
+
+  return undefined
+}
+
 function parseGitHubPrUrl(prUrl: string): { owner: string; repo: string; pullNumber: number } | null {
   const match = prUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:$|[/?#])/i)
   if (!match) return null
@@ -2874,6 +2889,35 @@ export async function createServer(): Promise<FastifyInstance> {
         ...(actor ? { actor } : {}),
       }
 
+      const previousStatus = existing.status
+      const nextStatus = parsed.status ?? existing.status
+      const laneHint = String((mergedMeta.lane || mergedMeta.supports || '')).toLowerCase()
+      const titleHint = `${existing.title || ''} ${(existing.description || '')}`.toLowerCase()
+      const isDesignLaneTask = laneHint.includes('design') || /\bdesign\b/.test(titleHint)
+      const isReadyTransition =
+        (nextStatus === 'validating' && previousStatus !== 'validating')
+        || (nextStatus === 'done' && previousStatus !== 'done')
+      const designHandoffArtifactPath = getDesignHandoffArtifactPath(mergedMeta)
+      const existingHandoffMeta = ((existing.metadata as Record<string, unknown> | undefined)?.design_handoff || {}) as Record<string, unknown>
+      const hasPriorDesignHandoff = typeof existingHandoffMeta.notifiedAt === 'number'
+      const shouldSendDesignHandoff = Boolean(
+        isDesignLaneTask
+        && isReadyTransition
+        && designHandoffArtifactPath
+        && !hasPriorDesignHandoff,
+      )
+
+      if (shouldSendDesignHandoff) {
+        nextMetadata.design_handoff = {
+          ...existingHandoffMeta,
+          notifiedAt: Date.now(),
+          notifiedForStatus: nextStatus,
+          notifiedTo: 'link',
+          sourceTaskId: lookup.resolvedId,
+          artifactPath: designHandoffArtifactPath,
+        }
+      }
+
       if (parsed.status === 'done' && existing.status !== 'done') {
         const completedAt = Date.now()
         const outcomeMeta = ((nextMetadata.outcome_checkpoint as Record<string, unknown>) || {})
@@ -2893,6 +2937,28 @@ export async function createServer(): Promise<FastifyInstance> {
       if (!task) {
         reply.code(404)
         return { success: false, error: 'Task not found' }
+      }
+
+      if (shouldSendDesignHandoff && designHandoffArtifactPath) {
+        const acceptanceCriteria = (task.done_criteria || []).join(' | ')
+        const handoffMessage = [
+          `@link ${task.id} design-ready handoff from ${task.assignee || 'design-owner'}.`,
+          `Artifact: ${designHandoffArtifactPath}`,
+          `Acceptance criteria: ${acceptanceCriteria || 'Use task done_criteria from source task.'}`,
+          'Please claim implementation handoff and post execution plan.',
+        ].join(' ')
+
+        await chatManager.sendMessage({
+          from: 'system',
+          channel: 'reviews',
+          content: handoffMessage,
+          metadata: {
+            kind: 'design_implementation_handoff',
+            sourceTaskId: task.id,
+            artifactPath: designHandoffArtifactPath,
+            to: 'link',
+          },
+        }).catch(() => {})
       }
       
       // Auto-update presence on task activity


### PR DESCRIPTION
## Summary
- add design-handoff detection when a design-lane task transitions to validating/done with artifact metadata
- persist `metadata.design_handoff` marker to avoid duplicate notifications
- post an automatic `@link` handoff message in `#reviews` including task id, artifact path, and acceptance criteria
- add integration coverage for the new handoff notification behavior

## Validation
- npm test -- tests/api.test.ts -t "Design handoff auto-notification"

## Task
- task-1771345240342-6u3syt3el
