### PR TITLE
feat: auto-notify @link on design→implementation handoff

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1355,6 +1355,60 @@ describe('Task close follow-on linkage gate', () => {
   })
 })
 
+describe('Design handoff auto-notification', () => {
+  let taskId: string
+
+  beforeAll(async () => {
+    const { body } = await req('POST', '/tasks', {
+      title: 'TEST: design handoff source task',
+      description: 'Design-ready task should auto-notify implementation handoff to @link',
+      createdBy: 'test-runner',
+      assignee: 'pixel',
+      reviewer: 'test-reviewer',
+      priority: 'P1',
+      done_criteria: ['implement chat page polish', 'verify with design QA'],
+      eta: '1h',
+      metadata: {
+        lane: 'design',
+      },
+    })
+    taskId = body.task.id
+  })
+
+  afterAll(async () => {
+    await req('DELETE', `/tasks/${taskId}`)
+  })
+
+  it('posts a @link review-channel handoff message when design task becomes ready', async () => {
+    const done = await req('PATCH', `/tasks/${taskId}`, {
+      status: 'done',
+      metadata: {
+        lane: 'design',
+        artifact_path: 'process/TASK-design-ready-proof.md',
+        artifacts: ['process/TASK-design-ready-proof.md'],
+        reviewer_approved: true,
+      },
+    })
+
+    expect(done.status).toBe(200)
+    expect(done.body.success).toBe(true)
+
+    const { status, body } = await req('GET', '/chat/messages?channel=reviews&limit=200')
+    expect(status).toBe(200)
+    expect(Array.isArray(body.messages)).toBe(true)
+
+    const handoff = body.messages.find((m: any) => {
+      const content = String(m.content || '')
+      return content.includes(taskId)
+        && content.includes('@link')
+        && content.includes('process/TASK-design-ready-proof.md')
+        && content.includes('Acceptance criteria')
+    })
+
+    expect(handoff).toBeDefined()
+  })
+})
+
 describe('Task review endpoint', () => {
   let taskId: string
 


### PR DESCRIPTION
## What

When a design-lane task transitions to `validating` or `done` with an artifact path, automatically post a handoff message to #reviews with the task ID, artifact path, and acceptance criteria.

## Changes

- `getDesignHandoffArtifactPath()` helper extracts artifact path from task metadata
- Design handoff detection in `PATCH /tasks/:id`: checks lane/title for design context, detects readiness transitions
- Duplicate prevention via `design_handoff.notifiedAt` marker in task metadata
- Auto-posts to `reviews` channel with structured handoff message
- Integration test covering the full flow

## Testing

- New test: `Design handoff auto-notification` → creates design task, transitions to done, verifies #reviews message
- Full suite: 287 passed, 1 skipped

## Task

task-1771345240342-6u3syt3el

## Attribution

Original implementation by sage. Cherry-picked and adapted to current main.

Co-authored-by: sage <sage@reflectt.ai>