### PR TITLE
fix(tasks): include hasMore in paginated /tasks response

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -87,7 +87,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/tasks` | List tasks. Query: `status`, `assignee`, `agent`, `priority`, `limit`, `offset`, `q` (text search), `updatedSince`. Returns `{ tasks, total, offset, limit }`. |
+| GET | `/tasks` | List tasks. Query: `status`, `assignee`, `agent`, `priority`, `limit`, `offset`, `q` (text search), `updatedSince`. Returns `{ tasks, total, offset, limit, hasMore }`. |
 | GET | `/tasks/:id` | Get task by ID. Also accepts unambiguous ID prefixes. Ambiguous prefix returns `400` with full-ID suggestions. |
 | GET | `/tasks/:id/history` | Status changelog for task lifecycle transitions. Returns `history[]` entries shaped as `{ status, changedBy, changedAt, metadata }` for each status transition. |
 | GET | `/tasks/:id/comments` | List task discussion comments. Returns `{ comments, count }` |

--- a/src/server.ts
+++ b/src/server.ts
@@ -2440,8 +2440,9 @@ export async function createServer(): Promise<FastifyInstance> {
     const total = tasks.length
     const offset = parsePositiveInt(query.offset) || 0
     tasks = tasks.slice(offset, offset + limit)
+    const hasMore = offset + tasks.length < total
 
-    const payload = { tasks: tasks.map(enrichTaskWithComments), total, offset, limit }
+    const payload = { tasks: tasks.map(enrichTaskWithComments), total, offset, limit, hasMore }
     const lastModified = tasks.length > 0 ? Math.max(...tasks.map(t => t.updatedAt || 0)) : undefined
     if (applyConditionalCaching(request, reply, payload, lastModified)) {
       return


### PR DESCRIPTION
## Summary
Follow-up for task search/pagination review packet issues.

- Adds `hasMore` to `GET /tasks` paginated response
- Keeps server-side `q=` text search across title/description/assignee/id
- Updates docs contract for `/tasks`

## Why
Reviewer flagged previous proof packet as invalid (`/pull/0` placeholder and unverifiable evidence). This PR provides canonical merged-review path + explicit endpoint contract output.

## Validation
- `npm test` (410 passed, 1 skipped)
- Manual check: `GET /tasks?q=heartbeat&limit=3&offset=0` returns filtered results with pagination envelope

Task: task-1771392782428-yd1yd6wae
Reviewer: @kai
