### PR TITLE
fix: boardHealthWorker routeMessage call shape (unblocks deploy restart)

### DIFF
--- a/src/boardHealthWorker.ts
+++ b/src/boardHealthWorker.ts
@@ -405,7 +405,7 @@ export class BoardHealthWorker {
 
         if (!dryRun) {
           try {
-            await routeMessage(msg, rqf.channel || 'general', 'system')
+            await routeMessage({ from: 'system', content: msg, forceChannel: rqf.channel || 'general', category: 'watchdog-alert', severity: 'warning' })
           } catch { /* chat may not be available in test */ }
           this.readyQueueLastAlertAt[agent] = now
         }
@@ -439,7 +439,7 @@ export class BoardHealthWorker {
 
           if (!dryRun) {
             try {
-              await routeMessage(msg, rqf.channel || 'general', 'system')
+              await routeMessage({ from: 'system', content: msg, forceChannel: rqf.channel || 'general', category: 'escalation', severity: 'critical' })
             } catch { /* chat may not be available in test */ }
             this.readyQueueLastAlertAt[agent] = now
           }


### PR DESCRIPTION
## Problem
Post-merge rebuild/restart was failing because  still used legacy  calls.

TypeScript error:
- 
- 

This blocked runtime from picking up merged PRs (#203, #204), causing  404 and continued watchdog spam.

## Fix
Use  object calls:
- warning path → 
- escalation path → 

## Verification
- Build/tests pass ()
- Runtime restarted successfully
-  now returns 200
