### PR TITLE
docs: unblock CI by documenting /health/backlog

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -68,6 +68,7 @@ Operationally:
 | GET | `/health/team/summary` | Compact team health summary |
 | GET | `/health/team/history` | Historical team health data |
 | GET | `/health/workflow` | Unified per-agent workflow state: doing-task age, last shipped timestamp, blocker flag, artifact path, and linked PR state |
+| GET | `/health/backlog` | Backlog readiness snapshot by lane/agent with ready-floor breach detection and stale-validating summary. |
 | GET | `/health/mention-ack` | Mention-ack lifecycle metrics (pending, timeout, latency counters) |
 | GET | `/health/mention-ack/recent` | Recent mention-ack entries for debugging. Query: `limit` (max 100) |
 | GET | `/health/mention-ack/:agent` | Pending mention-ack entries for one agent |


### PR DESCRIPTION
## Why
CI is red on route/docs contract for open PRs because `GET /health/backlog` exists in `src/server.ts` but was missing from `public/docs.md`.

## What
- Add `GET /health/backlog` to health endpoints table in `public/docs.md`.

## Verification
- `npm run check:route-docs-contract` passes locally (221 server routes / 221 docs routes).

## Impact
Unblocks PRs currently failing only on docs contract gate (including #205 and #206).
