### PR TITLE
feat: enforce next-task-before-close pipeline rule

### DIFF
--- a/incidents/watchdog-incidents.jsonl
+++ b/incidents/watchdog-incidents.jsonl
@@ -99,3 +99,5 @@
 {"type":"trio_general_silence","at":1771373456171,"thresholdMs":3600000,"lastUpdateAt":1771360759399}
 {"type":"trio_general_silence","at":1771621078538,"thresholdMs":3600000,"lastUpdateAt":1771617452299}
 {"type":"trio_general_silence","at":1771622878628,"thresholdMs":3600000,"lastUpdateAt":1771617452299}
+{"type":"stale_working","at":1771714086080,"agent":"link","taskId":"task-1771692505229-q114ozo7l","thresholdMs":2700000,"lastUpdateAt":null,"workingSinceAt":1771702230934}
+{"type":"stale_working","at":1771715886190,"agent":"link","taskId":"task-1771692505229-q114ozo7l","thresholdMs":2700000,"lastUpdateAt":null,"workingSinceAt":1771702230934}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -82,6 +82,7 @@ export interface PolicyConfig {
     escalateAfterMin: number   // idle+empty-queue → escalation timer
     cooldownMin: number        // don't re-alert within this window
     channel: string            // where to post warnings
+    enforceBlock?: boolean     // if true (default), block validating/done transitions when queue drops below floor
   }
 
   /** Escalation channels for different severity levels */


### PR DESCRIPTION
## What

Upgrades the ready-queue floor check from warning to blocking gate. When an agent tries to move a task to validating/done and their queue would drop below the floor (default ≥2), the transition is rejected.

## Changes
- `taskPrecheck.ts`: ready-queue floor severity escalated from `warning` → `error` when `enforceBlock` is true (default)
- `policy.ts`: added `enforceBlock?` field to readyQueueFloor config
- Override escape: set `metadata.readyQueueOverride=true` on individual tasks

## Already Active (no changes needed)
- Ready-queue floor monitoring via boardHealthWorker
- Idle >60m escalation via boardHealthWorker  
- Per-agent compliance via `GET /health/backlog`
- Policy config: `readyQueueFloor.enabled=true, minReady=2, agents=["link"], escalateAfterMin=60`

## Compliance Report
Engineering lane: healthy (8 ready tasks for @link, above floor of 2)

Task: task-1771427266778-kiw3dc52f | Reviewer: @sage