### PR TITLE
feat: ownership guardrail for insight→task auto-assignment

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -387,6 +387,9 @@ Graceful degradation: if GitHub API is unavailable, the merge check is skipped (
 | POST | `/insights/ingest` | Ingest a reflection into clustering. Body: `{ reflection_id }`. Cluster key auto-derived from reflection tags/content. Promotion gate: 2 independent reflections (distinct authors) OR severity high/critical. 24h cooldown after promotion. |
 | GET | `/insights` | List insights. Query: `status` (candidate\|promoted\|pending_triage\|task_created\|cooldown\|closed), `priority` (P0-P3), `workflow_stage`, `failure_family`, `impacted_unit`, `limit`, `offset`. Sorted by score desc. |
 | GET | `/insights/bridge/stats` | Insight→Task bridge stats: auto-created count, triaged count, duplicates skipped, errors. |
+| GET | `/insights/bridge/config` | Current bridge config including ownership guardrail settings. |
+| PATCH | `/insights/bridge/config` | Update bridge config. Body: partial config object (e.g. `{ ownershipGuardrail: { enabled: false } }`). |
+| GET | `/insights/:id/assignment-preview` | Dry-run ownership guardrail for an insight. Returns `{ decision: { assignee, reviewer, reason, guardrailApplied, soleAuthorFallback, candidatesConsidered, insightAuthors } }`. Query: `team_id`. |
 | GET | `/insights/triage` | List insights in `pending_triage` status (medium/low severity awaiting review). Query: `limit`. |
 | POST | `/insights/:id/triage` | Triage a pending insight. Body: `{ action: "approve"\|"dismiss", assignee? (required for approve), reviewer?, rationale?, priority?, triaged_by? }`. Approve creates a linked task; dismiss closes the insight. Records audit decision with reviewer + rationale. |
 | GET | `/insights/triage/audit` | Triage decision audit trail (all insights). Returns timestamped decisions with reviewer, rationale, action, outcome. Query: `limit`. |


### PR DESCRIPTION
## Summary
Ownership guardrail for auto-created tasks from promoted insights. Replaces PR #233 (rebased cleanly on main).

### Changes
- **`resolveAssignment()`**: integrates with `suggestAssignee` scoring engine
  - Single-author: prefer non-author assignee
  - Sole-author fallback: assign author but require non-author reviewer  
  - Multi-author: normal scoring
- **Team config**: `ownershipGuardrail.teamOverrides` per-team disable
- **Audit trail**: `task.metadata.assignment_decision`
- **Endpoints**: GET/PATCH `/insights/bridge/config`, GET `/insights/:id/assignment-preview`
- 9 tests, 578 total passing

Task: task-1771729827061-h3ypsweq8