### PR TITLE
fix: add task_id to insights base schema + safe migration v9

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -327,6 +327,7 @@ function runMigrations(db: Database.Database): void {
           cooldown_until INTEGER,
           cooldown_reason TEXT,
           severity_max TEXT,
+          task_id TEXT,
           metadata TEXT,
           created_at INTEGER NOT NULL,
           updated_at INTEGER NOT NULL
@@ -339,9 +340,13 @@ function runMigrations(db: Database.Database): void {
     },
     {
       version: 9,
-      sql: `
-        ALTER TABLE insights ADD COLUMN task_id TEXT;
-      `,
+      // task_id now in base schema; ALTER handled via runFn for legacy DBs
+      runFn: (database) => {
+        const cols = database.pragma('table_info(insights)') as Array<{ name: string }>
+        if (!cols.some(c => c.name === 'task_id')) {
+          database.exec('ALTER TABLE insights ADD COLUMN task_id TEXT')
+        }
+      },
     },
     {
       version: 10,


### PR DESCRIPTION
## task-1771776818851-49tebyka1

Fixes `/insights/:id/triage` failure: `no such column: task_id`

### Root cause
The `insights` table CREATE TABLE in `db.ts` was missing the `task_id` column. Code in `insights.ts` and `server.ts` references `task_id` on the insights table (for triage approval, status updates). Migration v9 adds it via ALTER TABLE, but fresh DBs could hit ordering issues.

### Fix
1. Added `task_id TEXT` to the base `CREATE TABLE insights` schema
2. Made migration v9 safe: uses `pragma table_info` check before ALTER to avoid duplicate column errors on fresh DBs
3. Extended migration runner to support custom `run()` functions for complex migrations

### Testing
- `tsc --noEmit` clean
- Migration handles both fresh DB (column in base schema) and existing DB (v9 ALTER) paths