### PR TITLE
fix: shift enforcement from leadership to product automation

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -1459,7 +1459,7 @@ class TeamHealthMonitor {
         continue
       }
 
-      const content = `@${agent} @kai @pixel system watchdog: status=working with no #general update for ${staleMin}m on ${task.id}. Post required status now: 1) shipped 2) blocker 3) next+ETA.`
+      const content = `@${agent} [Product Enforcement] status=working with no update for ${staleMin}m on ${task.id}. Post status now: 1) shipped 2) blocker 3) next+ETA. (Automated — working contract ${staleMin >= 45 ? 'requeue warning imminent' : 'monitoring'}.)`
       alerts.push(content)
 
       if (!dryRun) {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -210,8 +210,8 @@ export const DEFAULT_POLICY: PolicyConfig = {
   },
   workingContract: {
     enabled: true,
-    staleAutoRequeueMin: 90,
-    graceAfterWarningMin: 15,
+    staleAutoRequeueMin: 45,        // Warn at 45m (before any manual 60m check)
+    graceAfterWarningMin: 10,       // 10m grace → auto-requeue at 55m
     reflectionGateOnClaim: true,
     agents: [],
     channel: 'general',

--- a/src/working-contract.ts
+++ b/src/working-contract.ts
@@ -108,7 +108,7 @@ export async function tickWorkingContract(): Promise<TickResult> {
       if (!config.dryRun) {
         await routeMessage({
           from: 'system',
-          content: `⚠️ Working contract warning: @${agent}, task ${task.id} ("${task.title.slice(0, 60)}") has no status update in ${Math.floor(staleDurationMs / 60_000)}m. **Post a comment within ${config.graceAfterWarningMin}m or the task will auto-requeue to todo.**`,
+          content: `⚠️ [Product Enforcement] @${agent}, task ${task.id} ("${task.title.slice(0, 60)}") has no status update in ${Math.floor(staleDurationMs / 60_000)}m. **Post a status comment within ${config.graceAfterWarningMin}m or the task will auto-requeue to todo.** (This is automated — no leadership action needed.)`,
           category: 'watchdog-alert',
           severity: 'warning',
           forceChannel: config.channel,
@@ -149,12 +149,12 @@ export async function tickWorkingContract(): Promise<TickResult> {
           // Post enforcement comment
           const commentId = `tcomment-${now}-${Math.random().toString(36).slice(2, 9)}`
           db.prepare('INSERT INTO task_comments (id, task_id, author, content, timestamp) VALUES (?, ?, ?, ?, ?)')
-            .run(commentId, task.id, 'system', `🔄 Auto-requeued: no status update from @${agent} after warning. Task moved back to todo.`, now)
+            .run(commentId, task.id, 'system', `🔄 [Product Enforcement] Auto-requeued: no status update from @${agent} after warning. Task moved back to todo. (Automated — no leadership action needed.)`, now)
           db.prepare('UPDATE tasks SET comment_count = comment_count + 1 WHERE id = ?').run(task.id)
 
           await routeMessage({
             from: 'system',
-            content: `🔄 **Auto-requeued**: ${task.id} ("${task.title.slice(0, 60)}") moved from doing → todo. @${agent} did not respond to working contract warning within ${config.graceAfterWarningMin}m.`,
+            content: `🔄 **[Product Enforcement] Auto-requeued**: ${task.id} ("${task.title.slice(0, 60)}") moved from doing → todo. @${agent} did not respond within ${config.graceAfterWarningMin}m. (Automated enforcement — no leadership intervention required.)`,
             category: 'watchdog-alert',
             severity: 'warning',
             forceChannel: config.channel,


### PR DESCRIPTION
## Summary
Addresses insight that leadership (Kai) was still manually enforcing process rules that the product should automate.

### Root Cause
Working contract stale threshold (90m) was **higher** than Kai's manual check (60m), so the product never got to enforce first. Messages didn't signal automation, so Kai intervened.

### Changes
- **Stale threshold**: 90m → 45m (warn at 45m, auto-requeue at 55m — before any 60m manual check)
- **Grace period**: 15m → 10m (tighter feedback loop)
- **All enforcement messages**: Prefixed with `[Product Enforcement]` and `no leadership action needed`
- **Watchdog alerts**: No longer tag @kai — product handles it

### Done criteria
- [x] Root cause addressed (product enforces before leadership can)
- [x] Evidence validated (Kai's 60m manual checks now pre-empted by 45m product enforcement)
- [x] Follow-up reflection submitted (ref-1771825018410-gw7our7bm)

745 tests pass (zero regressions).

Task: task-1771800349310-938b6ebrn
Reviewer: @sage