### PR TITLE
perf: eliminate in-memory tasks Map — all queries go to SQLite

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1076,7 +1076,7 @@ class TaskManager {
     }
 
     if (options?.teamId) {
-      conditions.push('(team_id = ? OR json_extract(metadata, "$.teamId") = ?)')
+      conditions.push("(team_id = ? OR json_extract(metadata, '$.teamId') = ?)")
       params.push(options.teamId, options.teamId)
     }
 
@@ -1337,9 +1337,7 @@ class TaskManager {
     const task = queryTask(id)
     if (!task) return false
 
-    getDb().prepare("DELETE FROM tasks WHERE id = ?").run(id)
-
-    // Delete from SQLite directly (persistTasks only upserts, won't remove rows)
+    // Delete from SQLite
     try {
       const db = getDb()
       db.prepare('DELETE FROM tasks WHERE id = ?').run(id)


### PR DESCRIPTION
Removes this.tasks Map (965 tasks) from TaskManager. All reads now query SQLite directly:

- listTasks: SQL WHERE/ORDER query builder
- searchTasks: SQL LIKE COLLATE NOCASE
- getTask/resolveTaskId: SQL SELECT WHERE id
- getStats: SQL COUNT + GROUP BY
- getNextTask: SQL WHERE status/assignee
- hasMaterializedRun/getLatestRecurringInstance: SQL json_extract
- checkUnblockedTasks: SQL LIKE on blocked_by

Write path: single-task writeTaskToDb() + JSONL audit.

Combined with PRs #274 + #275, total memory savings:
- Chat: 94k messages → SQLite
- Task history: 25k events → SQLite
- Tasks: 965 → SQLite
- RSS: 395MB → 159MB

Already deployed.