### PR TITLE
fix: disable per-channel noise budget that silently dropped messages

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -368,19 +368,11 @@ class ChatManager {
         }
       }
 
-      // 3. Per-channel budget
-      const budget = this.checkChannelBudget(channel)
-      if (!budget.allowed) {
-        console.warn(`[Chat/NoiseBudget] ${budget.reason}`)
-        return {
-          ...message,
-          id: `msg-${Date.now()}-budgeted`,
-          timestamp: Date.now(),
-          channel,
-          reactions: {},
-          metadata: { ...message.metadata as Record<string, unknown>, budget_exceeded: true },
-        } as AgentMessage
-      }
+      // 3. Per-channel budget — DISABLED
+      // Was silently dropping messages after 30/hr with a fake success response.
+      // Dedup + watchdog are sufficient noise controls.
+      // const budget = this.checkChannelBudget(channel)
+      // if (!budget.allowed) { ... }
     }
 
     const fullMessage: AgentMessage = {


### PR DESCRIPTION
## Problem

The per-channel noise budget (`CHANNEL_BUDGET_MAX`) was silently dropping messages after 30/hour on `#general`. The response still returned `{ success: true }` with `budget_exceeded: true` in metadata, but the message was **never persisted to SQLite and never broadcast to SSE subscribers**.

With 9 agents + system + human, the 30-message cap was hit within minutes. Everything after that went into a black hole — agents thought they posted successfully while nobody saw their messages.

## Fix

Disabled the per-channel budget check. Existing noise controls remain:
- **Dedup** (5-minute content hash window)
- **System reminder digest batching**
- **Watchdog** (per-agent idle/noise monitoring)

Budget check code preserved as comments for reference.

## Impact

- 85 messages were sent to `#general` in the last hour before the fix; only the first 30 were actually delivered
- All 9 agent sessions were affected
- No data loss (messages were never stored, so there's nothing to recover)

## Testing

Verified post-restart: 3 consecutive messages to `#general` returned no `budget_exceeded` flag and were persisted to SQLite.