### PR TITLE
fix: auto-close guard blocks closing when reviewer rejected/changes_requested

### DIFF
--- a/src/prAutoMerge.ts
+++ b/src/prAutoMerge.ts
@@ -334,6 +334,18 @@ export function tryAutoCloseTask(taskId: string): AutoCloseResult {
     failedGates.push('reviewer_approved')
   }
 
+  // Gate: review_state must not be rejected/changes_requested
+  // This prevents auto-close when a reviewer has explicitly rejected,
+  // even if reviewer_approved was set from a prior approval cycle.
+  const reviewState = meta.review_state as string | undefined
+  const reviewerDecision = meta.reviewer_decision as { decision?: string } | undefined
+  if (reviewState === 'changes_requested' || reviewState === 'rejected') {
+    failedGates.push(`review_state_blocked:${reviewState}`)
+  }
+  if (reviewerDecision?.decision === 'rejected') {
+    failedGates.push('reviewer_decision_rejected')
+  }
+
   // Gate: artifact_path must exist
   if (!meta.artifact_path) {
     failedGates.push('artifact_path')


### PR DESCRIPTION
## Auto-Close Guard

**Task:** task-1771910196867-sxoi7m2td | **Reviewer:** @kai

### Bug
`task-1771398805268-5l724kpz2` auto-closed to done even after reviewer rejected. `tryAutoCloseTask` checked `reviewer_approved` but not `review_state` or `reviewer_decision`, so stale approvals from prior cycles bypassed active rejections.

### Fix
- Gate: `review_state` must not be `changes_requested` or `rejected`
- Gate: `reviewer_decision.decision` must not be `rejected`
- Explicit failedGates entries for audit trail

### Tests
4 new regression tests, 844 total passing, 0 failed