### PR TITLE
tasks: allow non-code validating without qa_bundle

### DIFF
--- a/process/TASK-task-1771880421057-g9r3lgxvt-noncode-validating-qabundle-gate-fix-20260224.md
+++ b/process/TASK-task-1771880421057-g9r3lgxvt-noncode-validating-qabundle-gate-fix-20260224.md
@@ -1,0 +1,32 @@
+# [Insight] non-code tasks stuck before validating — fix
+
+- **Task:** task-1771880421057-g9r3lgxvt
+- **Owner:** sage
+- **Reviewer:** kai
+- **Date:** 2026-02-24
+
+## Evidence validated
+- Insight: `ins-1771880421052-j5dhr40ra`
+
+Symptom: Non-code strategic tasks could meet their done-criteria (artifact posted, reviewer ready), but were blocked from moving to `validating` because the API required a **code-shaped** `metadata.qa_bundle.review_packet` (PR URL + commit SHA + changed files).
+
+## Root cause
+The `PATCH /tasks/:id` transition to `status=validating` enforced **two gates**:
+1) `metadata.review_handoff` (supports doc_only/config_only/non_code)
+2) `metadata.qa_bundle` + `qa_bundle.review_packet` (PR/commit/files), even for non-code tasks
+
+The second gate made the system treat all validations as PR-backed, which is false for strategy/docs-only work.
+
+## Fix
+- `enforceQaBundleGateForValidating()` now **skips the qa_bundle requirement** when `metadata.review_handoff` marks the task as `doc_only`, `config_only`, or `non_code`.
+- Also aligns behavior with automated recurring tasks (qa bundle gate skipped).
+
+This makes **review_handoff the validating contract** for non-code work, while code-lane tasks still require a qa_bundle review packet.
+
+## Proof
+- PR: https://github.com/reflectt/reflectt-node/pull/293
+- Tests: `npm test` green
+- New regression test: non-code validating accepted with `review_handoff.non_code=true` and **no** `qa_bundle`.
+
+## Notes
+Docs updated: `docs/TASKS_API_QUICKSTART.md` now reflects that `review_handoff` is required for validating, and `qa_bundle` is optional for non-code/doc-only/config-only tasks.

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1058,6 +1058,50 @@ describe('Non-code validating contract (design/docs)', () => {
   })
 })
 
+describe('Non-code validating without qa_bundle', () => {
+  let taskId: string
+
+  beforeAll(async () => {
+    const { body } = await req('POST', '/tasks', {
+      title: 'TEST: non-code validating without qa_bundle',
+      createdBy: 'test-runner',
+      assignee: 'pixel',
+      reviewer: 'test-reviewer',
+      priority: 'P2',
+      done_criteria: ['Validating accepted with non_code review_handoff and no qa_bundle'],
+      eta: '1h',
+      metadata: {
+        lane: 'analysis',
+      },
+    })
+    taskId = body.task.id
+  })
+
+  afterAll(async () => {
+    await req('DELETE', `/tasks/${taskId}`)
+  })
+
+  it('accepts validating without qa_bundle when review_handoff.non_code=true', async () => {
+    const { status, body } = await req('PATCH', `/tasks/${taskId}`, {
+      status: 'validating',
+      metadata: {
+        artifact_path: 'process/TASK-non-code-no-qabundle.md',
+        review_handoff: {
+          task_id: taskId,
+          artifact_path: 'process/TASK-non-code-no-qabundle.md',
+          test_proof: 'Strategic/non-code proof (manual checklist) complete.',
+          known_caveats: 'No PR/commit for this task type.',
+          non_code: true,
+        },
+      },
+    })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.task.status).toBe('validating')
+  })
+})
+
 describe('Backlog', () => {
   let taskId: string
 


### PR DESCRIPTION
Task: task-1771880421057-g9r3lgxvt

Fixes an insight: non-code strategic tasks could satisfy done-criteria but were blocked from entering validating because qa_bundle.review_packet required PR/commit.

Change:
- If review_handoff marks doc_only/config_only/non_code, skip qa_bundle gate for validating
- Adds regression test
- Updates TASKS_API_QUICKSTART validating contract

Artifact: process/TASK-task-1771880421057-g9r3lgxvt-noncode-validating-qabundle-gate-fix-20260224.md