### PR TITLE
idle-nudge: prompt queue-clear agents to pull /tasks/next

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1823,6 +1823,23 @@ describe('Idle Nudge lane-state transitions', () => {
     expect(decision.lane.selectedTaskId).toBeNull()
   })
 
+  it('nudges queue-clear agents to pull /tasks/next after warn threshold', async () => {
+    const agent = 'lane-queue-clear-nudge'
+    await cleanupAgentTasks(agent)
+    await req('POST', `/presence/${agent}`, { status: 'working' })
+
+    const tickNowMs = Date.now() + (50 * 60_000) // > warnMin (45m)
+    const { status, body } = await req('POST', `/health/idle-nudge/tick?dryRun=true&force=true&nowMs=${tickNowMs}`)
+    expect(status).toBe(200)
+
+    const decision = (body.decisions || []).find((d: any) => d.agent === agent)
+    expect(decision).toBeDefined()
+    expect(decision.lane.laneReason).toBe('no-active-lane')
+    expect(decision.decision).toBe('warn')
+    expect(decision.reason).toBe('queue-clear')
+    expect(String(decision.renderedMessage || '')).toContain('/tasks/next')
+  })
+
   it('shows ambiguous-lane when agent has multiple fresh doing tasks', async () => {
     const agent = 'lane-ambiguous'
     await cleanupAgentTasks(agent)


### PR DESCRIPTION
Fixes nudge-loop engagement gap: when an agent has no active doing lane (queue-clear/no-active-lane) and is idle past warn threshold, emit a nudge instructing them to pull /tasks/next and claim work.\n\n- Adds queue-clear engagement nudge path (no active task)\n- Adds regression test: "nudges queue-clear agents to pull /tasks/next after warn threshold"\n\nTask: task-1771800692928-llqpnqu0t\n