### PR TITLE
fix(tasks): treat comments as task activity (updatedAt touch)

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -511,6 +511,14 @@ class TaskManager {
       `)
       updateCount.run(comment.taskId, comment.taskId)
 
+      // Touch task updated_at so comment activity counts as task activity (autonomy, SLA, sorting)
+      const touchUpdatedAt = db.prepare(`
+        UPDATE tasks
+        SET updated_at = MAX(updated_at, ?)
+        WHERE id = ?
+      `)
+      touchUpdatedAt.run(comment.timestamp, comment.taskId)
+
       // Append to JSONL (audit log)
       await fs.mkdir(DATA_DIR, { recursive: true })
       await fs.appendFile(TASK_COMMENTS_FILE, `${JSON.stringify(comment)}\n`, 'utf-8')

--- a/tests/task-comment-activity-updatedAt.test.ts
+++ b/tests/task-comment-activity-updatedAt.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression: posting a task comment must advance task.updatedAt.
+ *
+ * This is required for autonomy enforcement and “activity signal” to treat
+ * comments as real work (not forcing metadata churn via PATCH).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+})
+
+async function req(method: string, url: string, body?: unknown) {
+  const res = await app.inject({
+    method: method as any,
+    url,
+    payload: body,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+  })
+  return {
+    status: res.statusCode,
+    body: JSON.parse(res.body),
+  }
+}
+
+describe('Task comment activity', () => {
+  it('POST /tasks/:id/comments advances task.updatedAt', async () => {
+    const created = await req('POST', '/tasks', {
+      title: 'TEST: comment updates updatedAt',
+      description: 'regression test',
+      status: 'todo',
+      createdBy: 'test-runner',
+      assignee: 'spark',
+      reviewer: 'sage',
+      priority: 'P2',
+      done_criteria: ['Verify updatedAt advances when a task comment is posted'],
+      eta: '1h',
+    })
+
+    expect(created.status).toBe(200)
+    const taskId = created.body.task.id as string
+
+    const before = await req('GET', `/tasks/${taskId}`)
+    expect(before.status).toBe(200)
+    const beforeUpdatedAt = before.body.task.updatedAt as number
+
+    const commentRes = await req('POST', `/tasks/${taskId}/comments`, {
+      author: 'spark',
+      content: 'hello',
+    })
+    expect(commentRes.status).toBe(200)
+    expect(commentRes.body.success).toBe(true)
+
+    const commentTs = commentRes.body.comment.timestamp as number
+
+    const after = await req('GET', `/tasks/${taskId}`)
+    expect(after.status).toBe(200)
+    const afterUpdatedAt = after.body.task.updatedAt as number
+
+    expect(afterUpdatedAt).toBeGreaterThanOrEqual(commentTs)
+    expect(afterUpdatedAt).toBeGreaterThanOrEqual(beforeUpdatedAt)
+
+    await req('DELETE', `/tasks/${taskId}`)
+  })
+})


### PR DESCRIPTION
Context
- Autonomy/activity signal relies on task.updatedAt.
- Posting /tasks/:id/comments previously updated comment_count but did NOT advance tasks.updated_at, so tasks looked idle unless agents PATCHed metadata/status.

Change
- On comment insert, touch tasks.updated_at in SQLite: `UPDATE tasks SET updated_at = MAX(updated_at, ?) WHERE id = ?`.
- Adds regression test: tests/task-comment-activity-updatedAt.test.ts

Verification
- New test passes.
- Manual repro: GET task.updatedAt -> POST comment -> GET shows updatedAt advanced to comment timestamp.

Task
- task-1771907507179-j0wr96svl