### PR TITLE
Docs: Core Truths + session continuity mitigation (v1)

### DIFF
--- a/docs/continuity/CORE_TRUTHS_RYAN_v1.md
+++ b/docs/continuity/CORE_TRUTHS_RYAN_v1.md
@@ -1,0 +1,23 @@
+# CORE_TRUTHS_RYAN_v1 (canonical)
+
+**Owner:** @ryan (content) · @pixel (editor/maintainer)
+
+**Purpose:** One always-on card that prevents “surprise loop” rehashing and keeps work tied to revenue + current constraints.
+
+**Hard limits**
+- **Max bullets:** 8 (keep it skimmable)
+- Each bullet must be a **constraint or decision**, not an aspiration.
+
+## Core truths (v1)
+
+1) We need to become **profitable**; shipping volume without value is a failure mode.
+2) Prioritize **making what exists work** over net-new pages/features.
+3) **Design serves revenue**: improvements must map to conversion, retention, or paid usage.
+4) **Accessibility is non-negotiable** (WCAG 2.1 AA minimum).
+5) **LLM burn is real**; default to cheaper/faster unless the task explicitly requires premium reasoning.
+6) Focus on **reflectt-node first** (internal team needs + hardening) as the likely first product.
+7) Every task must have **clear done-criteria** and an artifact that unblocks execution.
+8) If a change increases risk/complexity, it must include an **owner + rollback plan**.
+
+## Change log
+- 2026-02-24: v1 created

--- a/docs/continuity/task-1771878460281-session-continuity-mitigation-v1.md
+++ b/docs/continuity/task-1771878460281-session-continuity-mitigation-v1.md
@@ -1,0 +1,21 @@
+# Session continuity mitigation v1 (repeat-conversation / surprise loop)
+
+**Task:** task-1771878460281-to8bcspiy  
+**Owner:** pixel  
+**Reviewer:** spark  
+**Date:** 2026-02-24
+
+This doc is a **repo copy** of the canonical task artifact:
+- `process/TASK-task-1771878460281-to8bcspiy-session-continuity-mitigation-v1-20260224.md`
+
+(also mirrored for local access at `workspace-shared/process/...`).
+
+## Evidence
+- Ryan explicitly reports the same “business focus / reflectt loop” conversation repeats multiple times per day with surprise each time.
+
+## Fix (minimal, enforceable)
+- **Core Truths canonical:** `process/CORE_TRUTHS_RYAN_v1.md`
+- **Ack definition:** task comment (or reflection tied to task) containing literal `ACK CORE_TRUTHS_RYAN_v1`.
+
+## Follow-up (product)
+- Optional server-side preflight to warn/block sending to `@ryan` if `core_truths_ack_at` is stale.


### PR DESCRIPTION
Adds lightweight docs artifacts to support task task-1771878460281-to8bcspiy (session continuity / surprise-loop mitigation).

- docs/continuity/CORE_TRUTHS_RYAN_v1.md
- docs/continuity/task-1771878460281-session-continuity-mitigation-v1.md

Canonical execution artifacts remain under workspace process/ and workspace-shared/process; this PR is to provide a GitHub PR URL + commit for validating gates + long-term reference.

Task: task-1771878460281-to8bcspiy
Reviewer: @spark