### PR TITLE
fix(tasks): stamp actor + review queue state on /tasks/:id/review

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2982,10 +2982,13 @@ export async function createServer(): Promise<FastifyInstance> {
     }
 
     const decidedAt = Date.now()
-    const decisionLabel = body.decision === 'approve' ? 'approved' : 'rejected'
+    const isApprove = body.decision === 'approve'
+    const decisionLabel = isApprove ? 'approved' : 'rejected'
     const mergedMetadata = {
       ...(task.metadata || {}),
-      reviewer_approved: body.decision === 'approve',
+
+      // Reviewer decision (single canonical place)
+      reviewer_approved: isApprove,
       reviewer_decision: {
         decision: decisionLabel,
         reviewer: body.reviewer,
@@ -2993,6 +2996,13 @@ export async function createServer(): Promise<FastifyInstance> {
         decidedAt,
       },
       reviewer_notes: body.comment,
+
+      // Stamp actor so downstream gates can assert reviewer identity.
+      actor: body.reviewer,
+
+      // Keep review queue state coherent even when approving via /tasks/:id/review
+      review_state: isApprove ? 'approved' : 'needs_author',
+      review_last_activity_at: decidedAt,
     }
 
     const updated = await taskManager.updateTask(task.id, {
@@ -3702,7 +3712,7 @@ export async function createServer(): Promise<FastifyInstance> {
               success: false,
               error: `Task-close gate: reviewer sign-off required from "${existing.reviewer}"`,
               gate: 'reviewer_signoff',
-              hint: `Reviewer "${existing.reviewer}" must approve via: PATCH with metadata.reviewer_approved: true`,
+              hint: `Reviewer "${existing.reviewer}" must approve via: POST /tasks/:id/review (decision=approve) (or PATCH as reviewer with actor set).`, 
             }
           }
         }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1400,6 +1400,11 @@ describe('Task review endpoint', () => {
     expect(body.task.metadata.reviewer_approved).toBe(true)
     expect(body.task.metadata.reviewer_decision.reviewer).toBe('assigned-reviewer')
     expect(body.task.metadata.reviewer_decision.comment).toBe('Ship it')
+
+    // reviewer actions should stamp actor + keep queue state coherent
+    expect(body.task.metadata.actor).toBe('assigned-reviewer')
+    expect(body.task.metadata.review_state).toBe('approved')
+    expect(body.task.metadata.review_last_activity_at).toBeTruthy()
   })
 
   it('POST /tasks/:id/review supports reject and flips reviewer_approved false', async () => {
@@ -1414,6 +1419,10 @@ describe('Task review endpoint', () => {
     expect(body.decision.decision).toBe('rejected')
     expect(body.task.metadata.reviewer_approved).toBe(false)
     expect(body.task.metadata.reviewer_decision.comment).toBe('Missing validation evidence')
+
+    expect(body.task.metadata.actor).toBe('assigned-reviewer')
+    expect(body.task.metadata.review_state).toBe('needs_author')
+    expect(body.task.metadata.review_last_activity_at).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
Fixes /tasks/:id/review to stamp metadata.actor, review_state, review_last_activity_at; updates tests.