### PR TITLE
Insights: avoid unknown cluster collisions

### DIFF
--- a/tests/insights.test.ts
+++ b/tests/insights.test.ts
@@ -66,7 +66,19 @@ describe('extractClusterKey', () => {
     expect(key.failure_family).toBe('uncategorized')
   })
 
-  it('uses team_id as impacted_unit fallback', () => {
+  it('uses first non-reserved tag as impacted_unit fallback (prevents unknown clustering)', () => {
+    const ref = makeReflection({ tags: ['stage:build', 'chat', 'performance'] })
+    const key = extractClusterKey(ref)
+    expect(key.impacted_unit).toBe('chat')
+  })
+
+  it('derives a topic signature from pain when unit is missing', () => {
+    const ref = makeReflection({ tags: [], team_id: undefined })
+    const key = extractClusterKey(ref)
+    expect(key.impacted_unit).toBe('topic-chat-messages-truncated')
+  })
+
+  it('uses team_id as impacted_unit fallback when no unit/tag hint exists', () => {
     const ref = makeReflection({ tags: ['stage:build'], team_id: 'team-alpha' })
     const key = extractClusterKey(ref)
     expect(key.impacted_unit).toBe('team-alpha')


### PR DESCRIPTION
Problem: reflections missing stage/unit tags were collapsing into cluster_key unknown::family::unknown, causing unrelated reflections to dedupe and inflate priority.

Fix:
- extractClusterKey now infers impacted_unit from first non-reserved tag (e.g. chat, status-discipline)
- if still missing, derive a short topic signature from pain text (topic-*) to prevent broad collisions
- sanitize cluster parts to avoid :: delimiter issues

Tests:
- updated + added extractClusterKey unit/topic fallback tests
- vitest run