### PR TITLE
fix: filter test-harness noise from /tasks/next (clean cherry-pick)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6471,7 +6471,8 @@ export async function createServer(): Promise<FastifyInstance> {
   app.get('/tasks/next', async (request) => {
     const query = request.query as Record<string, string>
     const agent = query.agent
-    const task = taskManager.getNextTask(agent)
+    const includeTest = query.include_test === '1' || query.include_test === 'true'
+    const task = taskManager.getNextTask(agent, { includeTest })
     if (!task) {
       return { task: null, message: 'No available tasks' }
     }


### PR DESCRIPTION
## Surgical cherry-pick of containment fix (replaces PR #311)

Clean cherry-pick of commit cbb2033 onto latest main. **Only 3 files changed** — no unrelated changes.

## Problem
Test harness emits fake tasks into the production queue. 6+ instances triaged manually, burning ~30 min of team review time.

## Fix
`isTestHarnessTask()` filter in `getNextTask()` excludes tasks matching:
- `metadata.is_test === true`
- `metadata.source_reflection` starts with `ref-test-`
- `metadata.source_insight` starts with `ins-test-`
- title matches `/test run \d{13}/`

Override: `?include_test=1` on `/tasks/next`.

## Changed files (exactly 3)
- `src/tasks.ts` — `getNextTask()` filter + opts param
- `src/server.ts` — pass `include_test` query param
- `tests/api.test.ts` — 4 new integration tests

## Tests
187 passing.