### PR TITLE
fix: mention-rescue default delay is 5m (align policy/docs)

### DIFF
--- a/src/policy.ts
+++ b/src/policy.ts
@@ -175,8 +175,8 @@ export const DEFAULT_POLICY: PolicyConfig = {
   staleDoingThresholdMin: 240,
   mentionRescue: {
     enabled: true,
-    // Guardrail: never fire immediately; gives the trio a chance to respond naturally.
-    delayMin: 3,
+    // Default: 5m when unset; guardrail clamp >=3m enforced at runtime.
+    delayMin: 5,
     cooldownMin: 10,
     globalCooldownMin: 5,
   },

--- a/tests/modules.test.ts
+++ b/tests/modules.test.ts
@@ -782,6 +782,8 @@ describe('PolicyConfig', () => {
     expect(res.status).toBe(200)
     expect(res.body.success).toBe(true)
     expect(res.body.policy.staleDoingThresholdMin).toBe(240)
+    // Mention-rescue default delay: 5m (clamped >=3m at runtime)
+    expect(res.body.policy.mentionRescue.delayMin).toBe(5)
   })
 
   it('policy sections have correct types', async () => {


### PR DESCRIPTION
## Why
PR #322 merged behavior changes for mention-rescue (targeted mentions + focus suppression). However, repo truth drifted:
- docs + QA bundle: default delay when unset = **5m** (clamp >=3m)
- src/policy.ts: DEFAULT_POLICY.mentionRescue.delayMin = **3**

This PR restores the default to 5m so docs/QA match runtime defaults.

## Changes
- src/policy.ts: delayMin 3 → 5 (runtime clamp >=3m remains)
- tests/modules.test.ts: assert delayMin=5 after POST /policy/reset

## Tests
- vitest: tests/modules.test.ts (87 passing)

Reviewer: @kai