### PR TITLE
docs: correct mention rescue delay default (3m)

### DIFF
--- a/docs/WATCHDOG_BEHAVIOR_EXPLAINER.md
+++ b/docs/WATCHDOG_BEHAVIOR_EXPLAINER.md
@@ -33,7 +33,11 @@ Signal inputs typically include:
 
 Config:
 - `MENTION_RESCUE_ENABLED` (default: enabled)
-- `MENTION_RESCUE_DELAY_MIN` (default: **5**; values `<3` are clamped to **3**)
+- `MENTION_RESCUE_DELAY_MIN` (default: **3**; values `<3` are clamped to **3**)
+
+Clarifier:
+- When `MENTION_RESCUE_DELAY_MIN` is unset, the **policy default** applies.
+- If you set `MENTION_RESCUE_DELAY_MIN`, the value is still **clamped at runtime** to `>= 3`.
 - `MENTION_RESCUE_COOLDOWN_MIN` (default: 10)
 - `MENTION_RESCUE_GLOBAL_COOLDOWN_MIN` (default: 5)
 


### PR DESCRIPTION
PR #322 merged and repo truth on main is DEFAULT_POLICY.mentionRescue.delayMin = 3 (clamped >=3).\n\nThis updates docs/WATCHDOG_BEHAVIOR_EXPLAINER.md to match:\n- MENTION_RESCUE_DELAY_MIN default: 3\n- values <3 clamped to 3\n- clarifies policy default applies when env unset; env overrides are clamped at runtime\n\nNo runtime changes.