### PR TITLE
docs: mention-rescue delay default is 3m (align with policy)

### DIFF
--- a/docs/WATCHDOG_BEHAVIOR_EXPLAINER.md
+++ b/docs/WATCHDOG_BEHAVIOR_EXPLAINER.md
@@ -33,7 +33,8 @@ Signal inputs typically include:
 
 Config:
 - `MENTION_RESCUE_ENABLED` (default: enabled)
-- `MENTION_RESCUE_DELAY_MIN` (default: **5**; values `<3` are clamped to **3**)
+- `MENTION_RESCUE_DELAY_MIN` (default: **3** via policy; values `<3` are clamped to **3**)
+  - Note: when unset, runtime uses the policy default; env overrides are clamped at runtime.
 - `MENTION_RESCUE_COOLDOWN_MIN` (default: 10)
 - `MENTION_RESCUE_GLOBAL_COOLDOWN_MIN` (default: 5)
 


### PR DESCRIPTION
Fixes docs drift after PR #322.

- Update WATCHDOG_BEHAVIOR_EXPLAINER mention-rescue config: delay default is **3m** (policy default), clamped >=3.
- Add one-line clarifier: env unset uses policy default; env overrides clamped at runtime.

No code changes.