### PR TITLE
feat(cli): install starter templates on reflectt init

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -386,6 +386,34 @@ program
       }
     }
 
+    // Copy starter templates into ~/.reflectt/templates
+    const templatesSrcDir = join(__dirname, '..', 'templates')
+    const templatesDestDir = join(REFLECTT_HOME, 'templates')
+    mkdirSync(templatesDestDir, { recursive: true })
+
+    const templates = [
+      { src: 'task-template.md', desc: 'Task template' },
+      { src: 'review-packet.md', desc: 'Review packet template' },
+      { src: 'incident-template.md', desc: 'Incident template' },
+    ]
+
+    for (const file of templates) {
+      const destPath = join(templatesDestDir, file.src)
+      const srcPath = join(templatesSrcDir, file.src)
+
+      if (existsSync(destPath) && !opts.force) {
+        filesSkipped++
+        console.log(`  ⏭️  templates/${file.src} (exists)`)
+      } else if (existsSync(srcPath)) {
+        const content = readFileSync(srcPath, 'utf-8')
+        writeFileSync(destPath, content)
+        filesCreated++
+        console.log(`  ✅ templates/${file.src} — ${file.desc}`)
+      } else {
+        console.log(`  ⚠️  templates/${file.src} — template not found in package`)
+      }
+    }
+
     // Git init
     if (opts.git !== false) {
       const gitDir = join(REFLECTT_HOME, '.git')

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,11 @@
+# Starter templates
+
+These templates are copied into `~/.reflectt/templates/` by `reflectt init`.
+
+Files:
+- `task-template.md`
+- `review-packet.md`
+- `incident-template.md`
+
+Notes:
+- `reflectt init` will **not** overwrite existing templates unless `--force` is used.

--- a/templates/incident-template.md
+++ b/templates/incident-template.md
@@ -1,0 +1,38 @@
+# Incident template
+
+## Summary
+<what happened in one sentence>
+
+## Impact
+- Who/what was affected:
+- Severity:
+- Duration:
+
+## Timeline (PT)
+- <time> — 
+- <time> — 
+
+## Detection
+- How we found out:
+- Signals/alerts involved:
+
+## Root cause
+- Primary cause:
+- Contributing factors:
+
+## Resolution
+- What fixed it:
+- What we changed:
+
+## Prevention
+- What we’ll do to prevent recurrence:
+
+## Action items
+| Item | Owner | ETA | Status |
+|---|---|---:|---|
+|  |  |  |  |
+
+## Links
+- PRs:
+- Logs:
+- Dashboard:

--- a/templates/review-packet.md
+++ b/templates/review-packet.md
@@ -1,0 +1,35 @@
+# Review packet
+
+## What is this
+A reviewer-friendly packet that makes it possible to approve without context-switching.
+
+## Metadata
+- Task: <task-id>
+- Owner: <@>
+- Reviewer: <@>
+- PR: <https://github.com/...>
+- Commit: <sha>
+- Changed files:
+  - 
+
+## Summary (1–3 bullets)
+- 
+- 
+
+## How to verify
+- Checks run:
+  - [ ] <e.g. npm test>
+  - [ ] <e.g. npm run build>
+- Manual QA steps:
+  1. 
+  2. 
+
+## Screenshots / proof
+- 
+
+## Caveats / known risks
+- none
+
+## Rollout / follow-up
+- Rollout notes:
+- Follow-ups (if any):

--- a/templates/task-template.md
+++ b/templates/task-template.md
@@ -1,0 +1,40 @@
+# Task template
+
+## Title
+<short, specific, verifiable>
+
+## Context
+- Why this matters:
+- Current behavior:
+- Desired behavior:
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Done criteria (verifiable)
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Plan (smallest shippable slice first)
+1. 
+2. 
+3. 
+
+## Artifacts
+- PR: <link>
+- Process artifact(s): <process/...>
+- Screenshots/logs: <link or path>
+
+## Review ask
+- Review type: blocking-only | full
+- What to focus on:
+
+## Risks / caveats
+- 
+
+## Owners + ETA
+- Owner: <@>
+- Reviewer: <@>
+- ETA: <e.g. ~2h>


### PR DESCRIPTION
Implements task-1771262381177-9q9gm1k4h.

What:
- Adds reflectt-node/templates/{task-template,review-packet,incident-template}.md (+ README)
- Updates reflectt init to copy these into ~/.reflectt/templates/ (non-destructive unless --force)

Manual proof:
- npm run build
- REFLECTT_HOME=/tmp/reflectt-init-test node dist/cli.js init --no-git --force

Artifact: process/TASK-task-1771262381177-9q9gm1k4h-default-templates-spec-v0-20260224.md