### PR TITLE
fix(tests): add afterAll cleanup + is_test metadata to live-server tests

### DIFF
--- a/tests/reflection-origin-gate.test.ts
+++ b/tests/reflection-origin-gate.test.ts
@@ -1,8 +1,10 @@
 // Tests for reflection-origin invariant enforcement on task creation
-import { describe, it, expect, beforeAll } from 'vitest'
+// These tests hit the LIVE server — created tasks are cleaned up in afterAll
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 
 const BASE = 'http://127.0.0.1:4445'
 let serverUp = false
+const createdTaskIds: string[] = []
 
 beforeAll(async () => {
   try {
@@ -13,7 +15,20 @@ beforeAll(async () => {
   }
 })
 
+afterAll(async () => {
+  // Clean up all tasks created during this test run
+  for (const id of createdTaskIds) {
+    try {
+      await fetch(`${BASE}/tasks/${id}`, { method: 'DELETE' })
+    } catch { /* best-effort */ }
+  }
+})
+
 function taskBody(overrides: Record<string, any> = {}) {
+  const meta = {
+    is_test: true,
+    ...(overrides.metadata || {}),
+  }
   return {
     title: `Enforce reflection-origin invariant on task creation pipeline ${Date.now()}`,
     createdBy: 'link',
@@ -23,18 +38,27 @@ function taskBody(overrides: Record<string, any> = {}) {
     eta: '~30m',
     priority: 'P2',
     ...overrides,
+    metadata: meta,
   }
+}
+
+/** POST a task and track its ID for cleanup */
+async function postTask(body: Record<string, any>): Promise<any> {
+  const res = await fetch(`${BASE}/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json() as any
+  const id = data.task?.id || data.id
+  if (id) createdTaskIds.push(id)
+  return data
 }
 
 describe('Reflection-origin gate', () => {
   it('rejects task without source_reflection or source_insight', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const res = await fetch(`${BASE}/tasks`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(taskBody({ metadata: {} })),
-    })
-    const data = await res.json() as any
+    const data = await postTask(taskBody({ metadata: { is_test: true } }))
     expect(data.success).toBe(false)
     expect(data.code).toBe('DEFINITION_OF_READY')
     expect(data.problems?.some((p: string) => p.includes('Reflection-origin required'))).toBe(true)
@@ -42,72 +66,48 @@ describe('Reflection-origin gate', () => {
 
   it('accepts task with source_reflection', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const res = await fetch(`${BASE}/tasks`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(taskBody({
-        metadata: { source_reflection: 'ref-test-123' },
-      })),
-    })
-    const data = await res.json() as any
+    const data = await postTask(taskBody({
+      metadata: { source_reflection: 'ref-test-123', is_test: true },
+    }))
     expect(data.success).toBe(true)
   })
 
   it('accepts task with source_insight', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const res = await fetch(`${BASE}/tasks`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(taskBody({
-        title: `Accept task with source insight in metadata for pipeline validation ${Date.now()}`,
-        metadata: { source_insight: 'ins-test-456' },
-      })),
-    })
-    const data = await res.json() as any
+    const data = await postTask(taskBody({
+      title: `Accept task with source insight in metadata for pipeline validation ${Date.now()}`,
+      metadata: { source_insight: 'ins-test-456', is_test: true },
+    }))
     expect(data.success).toBe(true)
   })
 
   it('accepts task with source=reflection_pipeline', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const res = await fetch(`${BASE}/tasks`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(taskBody({
-        title: `Accept task from reflection pipeline source with full metadata ${Date.now()}`,
-        metadata: { source: 'reflection_pipeline' },
-      })),
-    })
-    const data = await res.json() as any
+    const data = await postTask(taskBody({
+      title: `Accept task from reflection pipeline source with full metadata ${Date.now()}`,
+      metadata: { source: 'reflection_pipeline', is_test: true },
+    }))
     expect(data.success).toBe(true)
   })
 
   it('accepts exempt task with reason', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const res = await fetch(`${BASE}/tasks`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(taskBody({
-        title: `System maintenance task exempt from reflection origin requirement ${Date.now()}`,
-        metadata: {
-          reflection_exempt: true,
-          reflection_exempt_reason: 'Recurring system maintenance task',
-        },
-      })),
-    })
-    const data = await res.json() as any
+    const data = await postTask(taskBody({
+      title: `System maintenance task exempt from reflection origin requirement ${Date.now()}`,
+      metadata: {
+        reflection_exempt: true,
+        reflection_exempt_reason: 'Recurring system maintenance task',
+        is_test: true,
+      },
+    }))
     expect(data.success).toBe(true)
   })
 
   it('rejects exempt task without reason', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const res = await fetch(`${BASE}/tasks`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(taskBody({
-        metadata: { reflection_exempt: true },
-      })),
-    })
-    const data = await res.json() as any
+    const data = await postTask(taskBody({
+      metadata: { reflection_exempt: true, is_test: true },
+    }))
     expect(data.success).toBe(false)
     expect(data.problems?.some((p: string) => p.includes('reflection_exempt_reason'))).toBe(true)
   })


### PR DESCRIPTION
## Problem

Three test files create tasks against the live server (`localhost:4445`) with **no cleanup**:
- `artifact-visibility.test.ts` — creates ~7 tasks per run
- `reflection-origin-gate.test.ts` — creates ~4 tasks per run  
- `pipeline-health-merge.test.ts` — creates reflections that auto-promote to tasks

This caused **455+ junk tasks** to accumulate (board showed 468 todo, 224 assigned to link).

## Root Cause

These integration tests hit the live running server, not the in-process test server. The temp `REFLECTT_HOME` from `tests/setup.ts` only isolates tests using `app.inject()` — it has no effect on HTTP requests to localhost:4445.

## Fix

- Track all created task IDs in each test file
- `afterAll` hook DELETEs every tracked task (best-effort)
- All task metadata includes `is_test: true` as defense-in-depth (caught by harness filter from #336)
- Pipeline test tracks auto-promoted task IDs from reflection submissions

## Verification

- All 13 live-server tests pass (not skipped)
- Board stays clean after test run (3 real tasks, 0 new junk)
- Full suite: 992 passed, 1 skipped

Fixes task-1771959182464-9syvaps01