### PR TITLE
feat: chat-approval-detector — bridge chat approvals to formal review decisions

### DIFF
--- a/src/chat-approval-detector.ts
+++ b/src/chat-approval-detector.ts
@@ -1,0 +1,246 @@
+/**
+ * Chat Approval Detector
+ *
+ * Bridges chat-based reviewer approvals to formal task review decisions.
+ *
+ * Problem: When a reviewer says "LGTM" or "approved" in chat, the task stays
+ * stuck in "validating" because chat messages don't trigger the formal review
+ * endpoint (POST /tasks/:id/review). This module detects approval signals in
+ * chat messages and auto-submits the formal review decision.
+ *
+ * Resolution logic:
+ *   1. If the message explicitly references a task ID → target that task
+ *   2. If the reviewer has exactly one task in "validating" → target that
+ *   3. If ambiguous (multiple validating tasks, no reference) → skip + log
+ *
+ * Safety:
+ *   - Only triggers for the assigned reviewer (reviewer identity gate)
+ *   - Only fires once per task (idempotent — checks reviewer_approved first)
+ *   - Adds audit comment documenting the auto-detection
+ *   - Never auto-rejects (approval signals only)
+ */
+
+import { taskManager } from './tasks.js'
+import type { Task } from './types.js'
+
+// ── Approval signal patterns ──
+
+const APPROVAL_PATTERNS: RegExp[] = [
+  /\blgtm\b/i,
+  /\bapproved?\b/i,
+  /\bship\s*it\b/i,
+  /\blooks\s+good\s+to\s+me\b/i,
+  /\blooks\s+great\b/i,
+  /\b(?:good\s+to\s+(?:go|merge|ship))\b/i,
+  /\b(?:all\s+good|looks\s+solid|nice\s+work|well\s+done)\b/i,
+  /\b(?:✅|👍)\s*(?:approved?|lgtm|merge|ship)?\b/i,
+  /(?:✅|👍)\s*$/,  // standalone emoji at end of message
+  /^\s*(?:✅|👍)\s*$/,  // standalone emoji as entire message
+]
+
+// Negative patterns — if these match, don't treat as approval
+const REJECTION_PATTERNS: RegExp[] = [
+  /\bnot\s+(?:approved?|lgtm|ready)\b/i,
+  /\bdon'?t\s+(?:approve|ship|merge)\b/i,
+  /\bneeds?\s+(?:work|changes?|fixes?|rework)\b/i,
+  /\breject(?:ed|ing)?\b/i,
+  /\bblock(?:ed|ing|er)?\b/i,
+  /\bnit(?:s|pick)?\b/i,   // nit alone is not rejection but…
+  /\bfix\s+before\s+merge\b/i,
+  /\brequested?\s+changes?\b/i,
+]
+
+// ── Task ID extraction ──
+
+const TASK_ID_PATTERN = /\b(task-\d{13,}-[a-z0-9]+)\b/gi
+
+function extractTaskIds(content: string): string[] {
+  const matches = content.match(TASK_ID_PATTERN)
+  return matches ? [...new Set(matches.map(m => m.toLowerCase()))] : []
+}
+
+// ── Core detection ──
+
+export interface ApprovalSignal {
+  taskId: string
+  reviewer: string
+  source: 'explicit_reference' | 'sole_validating'
+  matchedPattern: string
+  comment: string
+}
+
+export interface DetectionResult {
+  detected: boolean
+  signal?: ApprovalSignal
+  skipped?: {
+    reason: 'no_approval_signal' | 'rejection_signal' | 'not_a_reviewer' |
+            'already_approved' | 'ambiguous_tasks' | 'no_validating_tasks' |
+            'task_not_validating' | 'reviewer_mismatch'
+    details?: string
+  }
+}
+
+/**
+ * Check if a chat message contains an approval signal from a reviewer.
+ */
+export function detectApproval(
+  from: string,
+  content: string,
+): DetectionResult {
+  // Step 1: Check for approval signal in content
+  const approvalMatch = APPROVAL_PATTERNS.find(p => p.test(content))
+  if (!approvalMatch) {
+    return { detected: false, skipped: { reason: 'no_approval_signal' } }
+  }
+
+  // Step 2: Check for rejection/negation signals (override approval)
+  const hasRejection = REJECTION_PATTERNS.some(p => p.test(content))
+  if (hasRejection) {
+    return { detected: false, skipped: { reason: 'rejection_signal' } }
+  }
+
+  const matchedPattern = approvalMatch.source
+
+  // Step 3: Find tasks where `from` is the assigned reviewer + status is validating
+  const validatingTasks = taskManager.listTasks({ status: 'validating' })
+    .filter(t =>
+      t.reviewer &&
+      t.reviewer.toLowerCase() === from.toLowerCase() &&
+      !isAlreadyApproved(t),
+    )
+
+  if (validatingTasks.length === 0) {
+    return { detected: false, skipped: { reason: 'no_validating_tasks' } }
+  }
+
+  // Step 4: Try to resolve target task
+  const referencedIds = extractTaskIds(content)
+
+  // 4a: Explicit task reference
+  if (referencedIds.length === 1) {
+    const targetTask = validatingTasks.find(t =>
+      t.id.toLowerCase() === referencedIds[0],
+    )
+    if (targetTask) {
+      return {
+        detected: true,
+        signal: {
+          taskId: targetTask.id,
+          reviewer: from,
+          source: 'explicit_reference',
+          matchedPattern,
+          comment: content,
+        },
+      }
+    }
+    // Referenced task exists but isn't in reviewer's validating queue
+    const anyTask = taskManager.listTasks({}).find(t =>
+      t.id.toLowerCase() === referencedIds[0],
+    )
+    if (anyTask) {
+      if (anyTask.status !== 'validating') {
+        return { detected: false, skipped: { reason: 'task_not_validating', details: `${anyTask.id} is ${anyTask.status}` } }
+      }
+      if (anyTask.reviewer?.toLowerCase() !== from.toLowerCase()) {
+        return { detected: false, skipped: { reason: 'reviewer_mismatch', details: `reviewer is ${anyTask.reviewer}, not ${from}` } }
+      }
+      if (isAlreadyApproved(anyTask)) {
+        return { detected: false, skipped: { reason: 'already_approved', details: anyTask.id } }
+      }
+    }
+    // Referenced task not found — fall through to sole-validating logic
+  }
+
+  if (referencedIds.length > 1) {
+    // Multiple task references — too ambiguous
+    return {
+      detected: false,
+      skipped: {
+        reason: 'ambiguous_tasks',
+        details: `Multiple task IDs referenced: ${referencedIds.join(', ')}`,
+      },
+    }
+  }
+
+  // 4b: Sole validating task
+  if (validatingTasks.length === 1) {
+    return {
+      detected: true,
+      signal: {
+        taskId: validatingTasks[0].id,
+        reviewer: from,
+        source: 'sole_validating',
+        matchedPattern,
+        comment: content,
+      },
+    }
+  }
+
+  // 4c: Multiple validating tasks, no explicit reference
+  return {
+    detected: false,
+    skipped: {
+      reason: 'ambiguous_tasks',
+      details: `${validatingTasks.length} validating tasks for reviewer ${from}: ${validatingTasks.map(t => t.id).join(', ')}`,
+    },
+  }
+}
+
+/**
+ * Apply an approval signal by updating the task metadata.
+ * Returns the updated task or null if the update failed.
+ */
+export async function applyApproval(
+  signal: ApprovalSignal,
+): Promise<Task | undefined> {
+  const now = Date.now()
+  const task = taskManager.getTask(signal.taskId)
+  if (!task) return undefined
+
+  // Double-check guard: don't approve twice
+  if (isAlreadyApproved(task)) return task
+
+  const updated = await taskManager.updateTask(signal.taskId, {
+    metadata: {
+      ...(task.metadata || {}),
+      reviewer_approved: true,
+      reviewer_decision: {
+        decision: 'approved',
+        reviewer: signal.reviewer,
+        comment: `[auto-detected from chat] ${signal.comment}`,
+        decidedAt: now,
+        source: 'chat-approval-detector',
+        resolution: signal.source,
+      },
+      reviewer_notes: signal.comment,
+      actor: signal.reviewer,
+      review_state: 'approved',
+      review_last_activity_at: now,
+    },
+  })
+
+  if (updated) {
+    const sourceLabel = signal.source === 'explicit_reference'
+      ? `(referenced ${signal.taskId} in message)`
+      : `(sole validating task for ${signal.reviewer})`
+
+    await taskManager.addTaskComment(
+      signal.taskId,
+      'system',
+      `[review] auto-approved: Detected approval signal from @${signal.reviewer} in chat ${sourceLabel}. Pattern: \`${signal.matchedPattern}\`. Original message: "${truncate(signal.comment, 200)}"`,
+    )
+  }
+
+  return updated
+}
+
+// ── Helpers ──
+
+function isAlreadyApproved(task: Task): boolean {
+  const meta = task.metadata as Record<string, unknown> | undefined
+  return meta?.reviewer_approved === true
+}
+
+function truncate(str: string, max: number): string {
+  return str.length <= max ? str : str.slice(0, max) + '…'
+}

--- a/tests/chat-approval-detector.test.ts
+++ b/tests/chat-approval-detector.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { detectApproval, applyApproval, type ApprovalSignal, type DetectionResult } from '../src/chat-approval-detector.js'
+import { taskManager } from '../src/tasks.js'
+import type { Task } from '../src/types.js'
+
+// ── Test helpers ──
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    title: 'Test task',
+    description: 'Test description',
+    status: 'validating',
+    assignee: 'echo',
+    reviewer: 'sage',
+    done_criteria: [],
+    createdBy: 'system',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    priority: 'P1',
+    metadata: {},
+    tags: [],
+    ...overrides,
+  } as Task
+}
+
+// ── Tests ──
+
+describe('Chat Approval Detector', () => {
+  let listTasksSpy: ReturnType<typeof vi.spyOn>
+  let getTaskSpy: ReturnType<typeof vi.spyOn>
+  let updateTaskSpy: ReturnType<typeof vi.spyOn>
+  let addCommentSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    listTasksSpy = vi.spyOn(taskManager, 'listTasks')
+    getTaskSpy = vi.spyOn(taskManager, 'getTask')
+    updateTaskSpy = vi.spyOn(taskManager, 'updateTask')
+    addCommentSpy = vi.spyOn(taskManager, 'addTaskComment')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('detectApproval', () => {
+    describe('approval signal patterns', () => {
+      const validatingTask = makeTask({ reviewer: 'sage', status: 'validating' })
+
+      const approvalMessages = [
+        'LGTM',
+        'lgtm!',
+        'Approved',
+        'This is approved.',
+        'Ship it',
+        'ship it!',
+        'Looks good to me',
+        'looks great',
+        'Good to go',
+        'Good to merge',
+        'All good',
+        'Looks solid',
+        'Nice work',
+        '✅',
+        '👍',
+        '✅ approved',
+        '👍 lgtm',
+      ]
+
+      for (const msg of approvalMessages) {
+        it(`detects approval in "${msg}"`, () => {
+          listTasksSpy.mockReturnValue([validatingTask])
+          const result = detectApproval('sage', msg)
+          expect(result.detected).toBe(true)
+        })
+      }
+    })
+
+    describe('rejection signal overrides', () => {
+      const validatingTask = makeTask({ reviewer: 'sage', status: 'validating' })
+
+      // Messages that contain approval patterns BUT also rejection patterns → rejection_signal
+      const approvalWithRejection = [
+        'Not approved — needs changes',
+        'LGTM but needs work on X',
+        'Approved but fix before merge',
+      ]
+
+      for (const msg of approvalWithRejection) {
+        it(`detects rejection override in "${msg}"`, () => {
+          listTasksSpy.mockReturnValue([validatingTask])
+          const result = detectApproval('sage', msg)
+          expect(result.detected).toBe(false)
+          expect(result.skipped?.reason).toBe('rejection_signal')
+        })
+      }
+
+      // Messages that don't even match approval patterns → no_approval_signal
+      const noApprovalSignal = [
+        'Rejected',
+        'Blocking on test coverage',
+        'Requested changes',
+        'Don\'t ship this yet',
+        'Looks good but needs fixes',
+      ]
+
+      for (const msg of noApprovalSignal) {
+        it(`does NOT detect approval in "${msg}"`, () => {
+          listTasksSpy.mockReturnValue([validatingTask])
+          const result = detectApproval('sage', msg)
+          expect(result.detected).toBe(false)
+        })
+      }
+    })
+
+    describe('no approval signal', () => {
+      it('returns no_approval_signal for regular messages', () => {
+        const result = detectApproval('sage', 'Hey, how is the task going?')
+        expect(result.detected).toBe(false)
+        expect(result.skipped?.reason).toBe('no_approval_signal')
+      })
+
+      it('returns no_approval_signal for empty content', () => {
+        const result = detectApproval('sage', '')
+        expect(result.detected).toBe(false)
+        expect(result.skipped?.reason).toBe('no_approval_signal')
+      })
+    })
+
+    describe('reviewer matching', () => {
+      it('only detects for the assigned reviewer', () => {
+        const task = makeTask({ reviewer: 'sage', status: 'validating' })
+        listTasksSpy.mockReturnValue([task])
+
+        const result = detectApproval('echo', 'LGTM')
+        expect(result.detected).toBe(false)
+        expect(result.skipped?.reason).toBe('no_validating_tasks')
+      })
+
+      it('matches reviewer case-insensitively', () => {
+        const task = makeTask({ reviewer: 'Sage', status: 'validating' })
+        listTasksSpy.mockReturnValue([task])
+
+        const result = detectApproval('sage', 'LGTM')
+        expect(result.detected).toBe(true)
+      })
+    })
+
+    describe('task resolution', () => {
+      it('targets explicitly referenced task ID', () => {
+        const task1 = makeTask({ id: 'task-1111111111111-aaaa', reviewer: 'sage', status: 'validating' })
+        const task2 = makeTask({ id: 'task-2222222222222-bbbb', reviewer: 'sage', status: 'validating' })
+        listTasksSpy.mockReturnValue([task1, task2])
+
+        const result = detectApproval('sage', 'LGTM on task-1111111111111-aaaa')
+        expect(result.detected).toBe(true)
+        expect(result.signal?.taskId).toBe('task-1111111111111-aaaa')
+        expect(result.signal?.source).toBe('explicit_reference')
+      })
+
+      it('resolves sole validating task when no task referenced', () => {
+        const task = makeTask({ id: 'task-3333333333333-cccc', reviewer: 'sage', status: 'validating' })
+        listTasksSpy.mockReturnValue([task])
+
+        const result = detectApproval('sage', 'LGTM')
+        expect(result.detected).toBe(true)
+        expect(result.signal?.taskId).toBe('task-3333333333333-cccc')
+        expect(result.signal?.source).toBe('sole_validating')
+      })
+
+      it('skips when multiple validating tasks and no reference', () => {
+        const task1 = makeTask({ id: 'task-4444444444444-dddd', reviewer: 'sage', status: 'validating' })
+        const task2 = makeTask({ id: 'task-5555555555555-eeee', reviewer: 'sage', status: 'validating' })
+        listTasksSpy.mockReturnValue([task1, task2])
+
+        const result = detectApproval('sage', 'LGTM')
+        expect(result.detected).toBe(false)
+        expect(result.skipped?.reason).toBe('ambiguous_tasks')
+      })
+
+      it('skips when referenced task is not in validating', () => {
+        const doingTask = makeTask({ id: 'task-6666666666666-ffff', reviewer: 'sage', status: 'doing' })
+        listTasksSpy.mockReturnValue([]) // no validating tasks for reviewer
+        // Mock the general listTasks for the fallback check
+        listTasksSpy.mockImplementation((opts: any) => {
+          if (opts?.status === 'validating') return []
+          return [doingTask]
+        })
+
+        const result = detectApproval('sage', 'LGTM on task-6666666666666-ffff')
+        expect(result.detected).toBe(false)
+      })
+
+      it('skips when referenced task has different reviewer', () => {
+        const task = makeTask({ id: 'task-7777777777777-gggg', reviewer: 'kai', status: 'validating' })
+        // listTasks for reviewer 'sage' returns nothing, general returns the task
+        listTasksSpy.mockImplementation((opts: any) => {
+          if (opts?.status === 'validating') return []
+          return [task]
+        })
+
+        const result = detectApproval('sage', 'LGTM on task-7777777777777-gggg')
+        expect(result.detected).toBe(false)
+      })
+
+      it('skips already-approved tasks', () => {
+        const task = makeTask({
+          reviewer: 'sage',
+          status: 'validating',
+          metadata: { reviewer_approved: true },
+        })
+        listTasksSpy.mockReturnValue([]) // already approved is filtered out
+
+        const result = detectApproval('sage', 'LGTM')
+        expect(result.detected).toBe(false)
+        expect(result.skipped?.reason).toBe('no_validating_tasks')
+      })
+
+      it('skips when multiple task IDs are referenced', () => {
+        const task1 = makeTask({ id: 'task-8888888888888-hhhh', reviewer: 'sage', status: 'validating' })
+        const task2 = makeTask({ id: 'task-9999999999999-iiii', reviewer: 'sage', status: 'validating' })
+        listTasksSpy.mockReturnValue([task1, task2])
+
+        const result = detectApproval('sage', 'LGTM on task-8888888888888-hhhh and task-9999999999999-iiii')
+        expect(result.detected).toBe(false)
+        expect(result.skipped?.reason).toBe('ambiguous_tasks')
+      })
+    })
+  })
+
+  describe('applyApproval', () => {
+    it('updates task metadata with reviewer_approved', async () => {
+      const task = makeTask({
+        id: 'task-1234567890123-test',
+        reviewer: 'sage',
+        status: 'validating',
+        metadata: {},
+      })
+
+      getTaskSpy.mockReturnValue(task)
+      updateTaskSpy.mockResolvedValue({ ...task, metadata: { reviewer_approved: true } })
+      addCommentSpy.mockResolvedValue(undefined)
+
+      const signal: ApprovalSignal = {
+        taskId: task.id,
+        reviewer: 'sage',
+        source: 'sole_validating',
+        matchedPattern: '\\blgtm\\b',
+        comment: 'LGTM',
+      }
+
+      const result = await applyApproval(signal)
+      expect(result).toBeDefined()
+
+      expect(updateTaskSpy).toHaveBeenCalledWith(
+        task.id,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            reviewer_approved: true,
+            review_state: 'approved',
+            actor: 'sage',
+          }),
+        }),
+      )
+    })
+
+    it('adds audit comment documenting the detection', async () => {
+      const task = makeTask({
+        id: 'task-1234567890123-audit',
+        reviewer: 'sage',
+        status: 'validating',
+        metadata: {},
+      })
+
+      getTaskSpy.mockReturnValue(task)
+      updateTaskSpy.mockResolvedValue({ ...task, metadata: { reviewer_approved: true } })
+      addCommentSpy.mockResolvedValue(undefined)
+
+      const signal: ApprovalSignal = {
+        taskId: task.id,
+        reviewer: 'sage',
+        source: 'explicit_reference',
+        matchedPattern: '\\bapproved?\\b',
+        comment: `Approved ${task.id}`,
+      }
+
+      await applyApproval(signal)
+
+      expect(addCommentSpy).toHaveBeenCalledWith(
+        task.id,
+        'system',
+        expect.stringContaining('[review] auto-approved'),
+      )
+    })
+
+    it('is idempotent — does not double-approve', async () => {
+      const task = makeTask({
+        id: 'task-1234567890123-idem',
+        reviewer: 'sage',
+        status: 'validating',
+        metadata: { reviewer_approved: true },
+      })
+
+      getTaskSpy.mockReturnValue(task)
+
+      const signal: ApprovalSignal = {
+        taskId: task.id,
+        reviewer: 'sage',
+        source: 'sole_validating',
+        matchedPattern: '\\blgtm\\b',
+        comment: 'LGTM',
+      }
+
+      const result = await applyApproval(signal)
+      expect(result).toBe(task) // returns existing, no update
+      expect(updateTaskSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns undefined for missing task', async () => {
+      getTaskSpy.mockReturnValue(undefined)
+
+      const signal: ApprovalSignal = {
+        taskId: 'task-nonexistent-xxx',
+        reviewer: 'sage',
+        source: 'sole_validating',
+        matchedPattern: '\\blgtm\\b',
+        comment: 'LGTM',
+      }
+
+      const result = await applyApproval(signal)
+      expect(result).toBeUndefined()
+    })
+
+    it('includes chat-approval-detector source in reviewer_decision', async () => {
+      const task = makeTask({
+        id: 'task-1234567890123-src',
+        reviewer: 'sage',
+        status: 'validating',
+        metadata: {},
+      })
+
+      getTaskSpy.mockReturnValue(task)
+      updateTaskSpy.mockResolvedValue({ ...task, metadata: { reviewer_approved: true } })
+      addCommentSpy.mockResolvedValue(undefined)
+
+      const signal: ApprovalSignal = {
+        taskId: task.id,
+        reviewer: 'sage',
+        source: 'sole_validating',
+        matchedPattern: '\\blgtm\\b',
+        comment: 'LGTM',
+      }
+
+      await applyApproval(signal)
+
+      const updateCall = updateTaskSpy.mock.calls[0]
+      const meta = updateCall[1].metadata
+      expect(meta.reviewer_decision.source).toBe('chat-approval-detector')
+      expect(meta.reviewer_decision.resolution).toBe('sole_validating')
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Tasks get stuck in `validating` when a reviewer says "LGTM" or "approved" in chat, because chat messages don't trigger the formal review endpoint (`POST /tasks/:id/review`). Evidence: task-1771895729141-3s5zly0jv sat in validating ~64m until manual intervention.

## Solution

New module `src/chat-approval-detector.ts` hooks into `POST /chat/messages` and detects approval signals from assigned reviewers:

### Resolution Logic
1. **Explicit reference** — message contains a task ID → target that task
2. **Sole validating** — reviewer has exactly one validating task → target that
3. **Ambiguous** — multiple validating tasks, no reference → skip (logged, no false positive)

### Safety
- Only triggers for the assigned reviewer (reviewer identity gate)
- Idempotent — checks `reviewer_approved` before updating
- Rejection/negation patterns override approval signals ("needs work", "fix before merge", etc.)
- Audit comment documents auto-detection + matched pattern + original message
- Never auto-rejects (approval signals only)

### Testing
- 41 new tests covering signal detection, rejection overrides, reviewer matching, task resolution, idempotency, audit trail
- `tsc --noEmit` clean
- Existing test suites pass

Fixes: task-1771941650209-aj1yzzys7
Reviewer: @sage