### PR TITLE
fix: normalize artifact paths on validating + GitHub blob fallback

### DIFF
--- a/src/artifact-resolver.ts
+++ b/src/artifact-resolver.ts
@@ -1,0 +1,197 @@
+/**
+ * Artifact path normalization + GitHub blob fallback.
+ *
+ * Solves: reviewers can't access artifacts because paths are workspace-dependent
+ * (absolute, or prefixed with workspace-<agent>/).
+ *
+ * Strategy:
+ * 1) Normalize: strip workspace prefixes → repo-relative process/...
+ * 2) Reject: absolute paths that don't contain a recognizable workspace/repo pattern
+ * 3) GitHub fallback: if local file missing but PR is known, build GitHub blob URL
+ */
+
+import { isAbsolute, basename, relative, resolve } from 'node:path'
+
+// ── Known workspace prefix patterns ──────────────────────────────────
+
+const WORKSPACE_PATTERNS = [
+  // OpenClaw workspace paths
+  /^.*?\/\.openclaw\/workspace[^/]*\//,
+  // Reflectt home paths
+  /^.*?\/\.reflectt\//,
+  // Generic Users/*/projects/reflectt-node/ pattern
+  /^.*?\/projects\/reflectt-node\//,
+  // Generic Users/*/reflectt-node/ pattern
+  /^.*?\/reflectt-node\//,
+]
+
+/**
+ * Normalize an artifact path to repo-relative.
+ * Returns { normalized, wasAbsolute, wasNormalized }.
+ *
+ * Examples:
+ *   "/Users/ryan/.openclaw/workspace-link/process/QA.md" → "process/QA.md"
+ *   "workspace-shared/process/QA.md" → "process/QA.md"
+ *   "process/QA.md" → "process/QA.md" (unchanged)
+ *   "/etc/passwd" → null (rejected)
+ */
+export function normalizeArtifactPath(raw: string): {
+  normalized: string | null
+  wasAbsolute: boolean
+  wasNormalized: boolean
+  rejected: boolean
+  rejectReason?: string
+} {
+  if (!raw || typeof raw !== 'string') {
+    return { normalized: null, wasAbsolute: false, wasNormalized: false, rejected: true, rejectReason: 'Empty path' }
+  }
+
+  const trimmed = raw.trim()
+
+  // Reject null bytes
+  if (trimmed.includes('\0')) {
+    return { normalized: null, wasAbsolute: false, wasNormalized: false, rejected: true, rejectReason: 'Null byte in path' }
+  }
+
+  // URLs pass through unchanged
+  if (/^https?:\/\//i.test(trimmed)) {
+    return { normalized: trimmed, wasAbsolute: false, wasNormalized: false, rejected: false }
+  }
+
+  const wasAbsolute = isAbsolute(trimmed)
+
+  // If absolute, try to strip known workspace prefixes
+  if (wasAbsolute) {
+    for (const pattern of WORKSPACE_PATTERNS) {
+      const match = trimmed.match(pattern)
+      if (match) {
+        const stripped = trimmed.slice(match[0].length)
+        if (stripped && !stripped.includes('..') && !isAbsolute(stripped)) {
+          return { normalized: stripped, wasAbsolute: true, wasNormalized: true, rejected: false }
+        }
+      }
+    }
+    // Absolute path with no recognizable prefix → reject
+    return {
+      normalized: null,
+      wasAbsolute: true,
+      wasNormalized: false,
+      rejected: true,
+      rejectReason: `Absolute path does not match any known workspace pattern: ${trimmed.slice(0, 80)}...`,
+    }
+  }
+
+  // Strip common relative workspace prefixes
+  let result = trimmed
+  const RELATIVE_PREFIXES = ['workspace-shared/', 'workspace-link/', 'workspace-echo/', 'workspace-kai/', 'workspace-sage/', 'workspace-pixel/', 'workspace-spark/', 'workspace-harmony/', 'workspace-scout/', 'workspace-rhythm/', 'shared/']
+  for (const prefix of RELATIVE_PREFIXES) {
+    if (result.startsWith(prefix)) {
+      result = result.slice(prefix.length)
+      break
+    }
+  }
+
+  // Reject traversal
+  if (result.includes('..')) {
+    return { normalized: null, wasAbsolute: false, wasNormalized: false, rejected: true, rejectReason: 'Path contains ..' }
+  }
+
+  const wasNormalized = result !== trimmed
+  return { normalized: result, wasAbsolute, wasNormalized, rejected: false }
+}
+
+/**
+ * Normalize all artifact paths in task metadata.
+ * Returns { patches, warnings } where patches is a metadata merge object
+ * and warnings lists any normalization events.
+ */
+export function normalizeTaskArtifactPaths(metadata: Record<string, unknown>): {
+  patches: Record<string, unknown>
+  warnings: string[]
+  rejected: string[]
+} {
+  const patches: Record<string, unknown> = {}
+  const warnings: string[] = []
+  const rejected: string[] = []
+
+  // Normalize metadata.artifact_path
+  if (typeof metadata.artifact_path === 'string') {
+    const result = normalizeArtifactPath(metadata.artifact_path)
+    if (result.rejected) {
+      rejected.push(`artifact_path: ${result.rejectReason}`)
+    } else if (result.wasNormalized && result.normalized) {
+      patches.artifact_path = result.normalized
+      warnings.push(`artifact_path normalized: "${metadata.artifact_path}" → "${result.normalized}"`)
+    }
+  }
+
+  // Normalize qa_bundle.review_packet.artifact_path
+  const qaBundle = metadata.qa_bundle as Record<string, unknown> | undefined
+  const reviewPacket = qaBundle?.review_packet as Record<string, unknown> | undefined
+  if (typeof reviewPacket?.artifact_path === 'string') {
+    const result = normalizeArtifactPath(reviewPacket.artifact_path)
+    if (result.rejected) {
+      rejected.push(`qa_bundle.review_packet.artifact_path: ${result.rejectReason}`)
+    } else if (result.wasNormalized && result.normalized) {
+      // Deep merge
+      patches.qa_bundle = {
+        ...(patches.qa_bundle as Record<string, unknown> || {}),
+        ...qaBundle,
+        review_packet: { ...reviewPacket, artifact_path: result.normalized },
+      }
+      warnings.push(`qa_bundle.review_packet.artifact_path normalized: "${reviewPacket.artifact_path}" → "${result.normalized}"`)
+    }
+  }
+
+  // Normalize review_handoff.artifact_path
+  const reviewHandoff = metadata.review_handoff as Record<string, unknown> | undefined
+  if (typeof reviewHandoff?.artifact_path === 'string') {
+    const result = normalizeArtifactPath(reviewHandoff.artifact_path)
+    if (result.rejected) {
+      rejected.push(`review_handoff.artifact_path: ${result.rejectReason}`)
+    } else if (result.wasNormalized && result.normalized) {
+      patches.review_handoff = { ...reviewHandoff, artifact_path: result.normalized }
+      warnings.push(`review_handoff.artifact_path normalized: "${reviewHandoff.artifact_path}" → "${result.normalized}"`)
+    }
+  }
+
+  return { patches, warnings, rejected }
+}
+
+/**
+ * Build a GitHub blob URL for an artifact when the local file is missing.
+ * Uses the PR's repo + head SHA + file path.
+ */
+export function buildGitHubBlobUrl(
+  prUrl: string,
+  commitSha: string,
+  filePath: string,
+): string | null {
+  // Extract owner/repo from PR URL
+  const prMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/)
+  if (!prMatch) return null
+
+  const ownerRepo = prMatch[1]
+  const sha = commitSha.length >= 7 ? commitSha : null
+  if (!sha) return null
+
+  return `https://github.com/${ownerRepo}/blob/${sha}/${filePath}`
+}
+
+/**
+ * Build a GitHub raw URL for downloading artifact content.
+ */
+export function buildGitHubRawUrl(
+  prUrl: string,
+  commitSha: string,
+  filePath: string,
+): string | null {
+  const prMatch = prUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/)
+  if (!prMatch) return null
+
+  const ownerRepo = prMatch[1]
+  const sha = commitSha.length >= 7 ? commitSha : null
+  if (!sha) return null
+
+  return `https://raw.githubusercontent.com/${ownerRepo}/${sha}/${filePath}`
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import { startSweeper, getSweeperStatus, sweepValidatingQueue, flagPrDrift, gene
 import { autoPopulateCloseGate, tryAutoCloseTask, getMergeAttemptLog } from './prAutoMerge.js'
 import { recordReviewMutation, diffReviewFields, getAuditEntries, loadAuditLedger } from './auditLedger.js'
 import { listSharedFiles, readSharedFile, resolveTaskArtifact, validatePath, ALLOWED_EXTENSIONS } from './shared-workspace-api.js'
+import { normalizeArtifactPath, normalizeTaskArtifactPaths, buildGitHubBlobUrl, buildGitHubRawUrl } from './artifact-resolver.js'
 import {
   emitActivationEvent,
   getUserFunnelState,
@@ -639,6 +640,25 @@ function applyReviewStateMetadata(
       metadata.review_state = 'queued'
     }
     metadata.review_last_activity_at = now
+
+    // ── Artifact path normalization on validating transition ──
+    // Normalize workspace-prefixed paths to repo-relative.
+    // This prevents reviewers from hitting "file not found" due to workspace-dependent paths.
+    const normResult = normalizeTaskArtifactPaths(metadata)
+    if (normResult.rejected.length > 0) {
+      // Log but don't block — auto-normalize what we can
+      console.warn(`[ArtifactNormalize] task ${existing.id}: rejected paths:`, normResult.rejected)
+    }
+    if (Object.keys(normResult.patches).length > 0) {
+      Object.assign(metadata, normResult.patches)
+      metadata.artifact_normalization = {
+        normalized: true,
+        warnings: normResult.warnings,
+        rejected: normResult.rejected,
+        normalizedAt: new Date().toISOString(),
+      }
+      console.log(`[ArtifactNormalize] task ${existing.id}: normalized`, normResult.warnings)
+    }
   }
 
   if (previousStatus === 'validating' && nextStatus === 'doing' && !incomingReviewState) {
@@ -3304,7 +3324,25 @@ export async function createServer(): Promise<FastifyInstance> {
           }
           return result
         }
-        return { ...ref, type: 'file' as const, accessible: false, error: 'File not found (checked workspace + shared-workspace)' }
+        // GitHub blob fallback: if local file missing but PR is known, build a GitHub URL
+        const prUrl = meta.pr_url || meta.qa_bundle?.review_packet?.pr_url || meta.review_handoff?.pr_url
+        const commitSha = meta.commit_sha || meta.commit || meta.qa_bundle?.review_packet?.commit || meta.review_handoff?.commit_sha
+        if (typeof prUrl === 'string' && typeof commitSha === 'string' && ref.path.startsWith('process/')) {
+          const blobUrl = buildGitHubBlobUrl(prUrl, commitSha, ref.path)
+          const rawUrl = buildGitHubRawUrl(prUrl, commitSha, ref.path)
+          if (blobUrl) {
+            return {
+              ...ref,
+              type: 'file' as const,
+              accessible: true,
+              source: 'github-fallback',
+              resolvedPath: blobUrl,
+              rawUrl,
+              note: 'Local file not found; resolved via GitHub blob URL from PR metadata.',
+            }
+          }
+        }
+        return { ...ref, type: 'file' as const, accessible: false, error: 'File not found (checked workspace + shared-workspace + GitHub fallback)' }
       })
     )
 

--- a/tests/artifact-resolver.test.ts
+++ b/tests/artifact-resolver.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeArtifactPath,
+  normalizeTaskArtifactPaths,
+  buildGitHubBlobUrl,
+  buildGitHubRawUrl,
+} from '../src/artifact-resolver.js'
+
+describe('normalizeArtifactPath', () => {
+  it('passes through repo-relative paths unchanged', () => {
+    const result = normalizeArtifactPath('process/QA-bundle.md')
+    expect(result.normalized).toBe('process/QA-bundle.md')
+    expect(result.wasNormalized).toBe(false)
+    expect(result.rejected).toBe(false)
+  })
+
+  it('strips absolute OpenClaw workspace prefix', () => {
+    const result = normalizeArtifactPath('/Users/ryan/.openclaw/workspace-link/process/task-123-qa.md')
+    expect(result.normalized).toBe('process/task-123-qa.md')
+    expect(result.wasAbsolute).toBe(true)
+    expect(result.wasNormalized).toBe(true)
+    expect(result.rejected).toBe(false)
+  })
+
+  it('strips absolute reflectt home prefix', () => {
+    const result = normalizeArtifactPath('/Users/ryan/.reflectt/process/artifact.md')
+    expect(result.normalized).toBe('process/artifact.md')
+    expect(result.wasAbsolute).toBe(true)
+    expect(result.wasNormalized).toBe(true)
+  })
+
+  it('strips relative workspace-shared/ prefix', () => {
+    const result = normalizeArtifactPath('workspace-shared/process/QA.md')
+    expect(result.normalized).toBe('process/QA.md')
+    expect(result.wasNormalized).toBe(true)
+  })
+
+  it('strips shared/ prefix', () => {
+    const result = normalizeArtifactPath('shared/process/QA.md')
+    expect(result.normalized).toBe('process/QA.md')
+    expect(result.wasNormalized).toBe(true)
+  })
+
+  it('rejects unknown absolute paths', () => {
+    const result = normalizeArtifactPath('/etc/passwd')
+    expect(result.rejected).toBe(true)
+    expect(result.normalized).toBeNull()
+    expect(result.rejectReason).toContain('Absolute path')
+  })
+
+  it('rejects paths with ..', () => {
+    const result = normalizeArtifactPath('process/../../../etc/passwd')
+    expect(result.rejected).toBe(true)
+    expect(result.normalized).toBeNull()
+  })
+
+  it('rejects null bytes', () => {
+    const result = normalizeArtifactPath('process/file\0.md')
+    expect(result.rejected).toBe(true)
+  })
+
+  it('rejects empty string', () => {
+    const result = normalizeArtifactPath('')
+    expect(result.rejected).toBe(true)
+  })
+
+  it('passes through URLs unchanged', () => {
+    const url = 'https://github.com/reflectt/reflectt-node/pull/341'
+    const result = normalizeArtifactPath(url)
+    expect(result.normalized).toBe(url)
+    expect(result.rejected).toBe(false)
+    expect(result.wasNormalized).toBe(false)
+  })
+
+  it('strips reflectt-node project prefix', () => {
+    const result = normalizeArtifactPath('/Users/ryan/projects/reflectt-node/process/QA.md')
+    expect(result.normalized).toBe('process/QA.md')
+    expect(result.wasNormalized).toBe(true)
+  })
+})
+
+describe('normalizeTaskArtifactPaths', () => {
+  it('normalizes artifact_path in metadata', () => {
+    const result = normalizeTaskArtifactPaths({
+      artifact_path: '/Users/ryan/.openclaw/workspace-link/process/task-qa.md',
+    })
+    expect(result.patches.artifact_path).toBe('process/task-qa.md')
+    expect(result.warnings.length).toBeGreaterThan(0)
+    expect(result.rejected).toHaveLength(0)
+  })
+
+  it('normalizes nested qa_bundle.review_packet.artifact_path', () => {
+    const result = normalizeTaskArtifactPaths({
+      qa_bundle: {
+        review_packet: {
+          artifact_path: 'workspace-shared/process/QA.md',
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/1',
+        },
+      },
+    })
+    const patch = result.patches.qa_bundle as Record<string, unknown>
+    const rp = patch?.review_packet as Record<string, unknown>
+    expect(rp?.artifact_path).toBe('process/QA.md')
+  })
+
+  it('normalizes review_handoff.artifact_path', () => {
+    const result = normalizeTaskArtifactPaths({
+      review_handoff: {
+        artifact_path: 'shared/process/TASK-123.md',
+        pr_url: 'https://github.com/reflectt/reflectt-node/pull/1',
+      },
+    })
+    const patch = result.patches.review_handoff as Record<string, unknown>
+    expect(patch?.artifact_path).toBe('process/TASK-123.md')
+  })
+
+  it('does nothing for already-normalized paths', () => {
+    const result = normalizeTaskArtifactPaths({
+      artifact_path: 'process/clean-path.md',
+    })
+    expect(Object.keys(result.patches)).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  it('reports rejected paths', () => {
+    const result = normalizeTaskArtifactPaths({
+      artifact_path: '/etc/shadow',
+    })
+    expect(result.rejected.length).toBeGreaterThan(0)
+  })
+})
+
+describe('buildGitHubBlobUrl', () => {
+  it('builds correct blob URL from PR', () => {
+    const url = buildGitHubBlobUrl(
+      'https://github.com/reflectt/reflectt-node/pull/341',
+      'abc1234',
+      'process/task-qa.md',
+    )
+    expect(url).toBe('https://github.com/reflectt/reflectt-node/blob/abc1234/process/task-qa.md')
+  })
+
+  it('returns null for non-GitHub URLs', () => {
+    expect(buildGitHubBlobUrl('https://gitlab.com/foo/bar/pull/1', 'abc1234', 'file.md')).toBeNull()
+  })
+
+  it('returns null for short commit SHAs', () => {
+    expect(buildGitHubBlobUrl('https://github.com/o/r/pull/1', 'abc', 'file.md')).toBeNull()
+  })
+})
+
+describe('buildGitHubRawUrl', () => {
+  it('builds correct raw URL from PR', () => {
+    const url = buildGitHubRawUrl(
+      'https://github.com/reflectt/reflectt-node/pull/341',
+      'abc1234',
+      'process/task-qa.md',
+    )
+    expect(url).toBe('https://raw.githubusercontent.com/reflectt/reflectt-node/abc1234/process/task-qa.md')
+  })
+})


### PR DESCRIPTION
## Problem

Reviewers frequently can't access process/ artifacts because tasks store paths relative to the author's workspace or as absolute paths.

## Fix

### Path Normalization (on validating transition)
- Auto-strips workspace prefixes to repo-relative `process/...`
- Handles: `/Users/.../workspace-link/`, `.reflectt/`, `workspace-shared/`, `shared/`
- Rejects: unknown absolute paths, `..`, null bytes
- Stamps `metadata.artifact_normalization` with warnings/rejected

### GitHub Blob Fallback (on artifact access)
- When local file missing but PR URL + commit SHA known
- Returns GitHub blob URL with `source: 'github-fallback'`
- Includes raw URL for direct download

### Tests
- 20 new tests covering normalization + rejection + GitHub URL building
- 1034 total pass

Task: task-1771943949250-c8sbvsfm2