### PR TITLE
fix(working-contract): reconcile stale reflection tracking on claim gate

### DIFF
--- a/process/TASK-task-1771971304787-3gs8t57n0-reflection-gate-reclaim-fix-20260224.md
+++ b/process/TASK-task-1771971304787-3gs8t57n0-reflection-gate-reclaim-fix-20260224.md
@@ -1,0 +1,58 @@
+# task-1771971304787-3gs8t57n0 — Reflection gate reclaim unblock (stale tracking reconciliation)
+
+**Insight:** ins-1771971304740-jd60sjjy1  
+**Owner:** link  
+**Reviewer:** sage  
+**Date:** 2026-02-24
+
+## Problem
+
+Agents can be blocked by the **working-contract reflection gate** (422 `reflection_overdue`) while they have submitted recent reflections.
+
+Observed evidence (from insight):
+- `PATCH /tasks/:id` → 422 `reflection_overdue` even though reflections exist (e.g., `ref-1771952448811-wu85xbqb0`, `ref-1771952172649-ue4vvnfmt`).
+- Gate reason references `tasks_done_since_reflection`, suggesting the `reflection_tracking` row is stale and not being reset.
+
+## Root cause
+
+`checkClaimGate()` relied exclusively on the `reflection_tracking` table:
+- `last_reflection_at`
+- `tasks_done_since_reflection`
+
+If a reflection is ingested through any path that writes into `reflections` **without** calling `onReflectionSubmitted()` (e.g., sync/integration paths), the `reflection_tracking` row can remain stale:
+- `tasks_done_since_reflection` stays high
+- `last_reflection_at` stays old
+
+Result: the agent can be *permanently* blocked from re-claiming work even after reflecting.
+
+## Fix
+
+When the gate would block (`tasksDone >= 2 && hoursSinceReflection > 4`), `checkClaimGate()` now performs a **reconciliation** step:
+
+1. Read latest reflection for `author=agent` via `listReflections({ author, limit: 1 })`.
+2. If that reflection is newer than `reflection_tracking.last_reflection_at`, treat it as a missed tracking reset:
+   - Upsert `reflection_tracking` with `last_reflection_at = latest.created_at`
+   - Reset `tasks_done_since_reflection = 0`
+   - Allow the claim.
+
+This restores **signal over noise**: the hard gate enforces the real reflection stream, not a stale counter.
+
+## Tests / proof
+
+- Added regression test: `checkClaimGate reconciles stale tracking when a newer reflection exists`
+  - Inserts a stale `reflection_tracking` row
+  - Creates a reflection directly via `createReflection()` (simulating non-HTTP ingestion)
+  - Verifies gate allows and tracking row is repaired (tasks_done_since_reflection=0)
+
+Full suite:
+- `npm test --silent` → **991 passed**, 1 skipped
+
+## Files changed
+
+- `src/working-contract.ts`
+- `tests/working-contract.test.ts`
+
+## Notes / follow-ups
+
+- This is intentionally **defensive**: it keeps enforcement intact while preventing lockouts caused by stale tracking.
+- Optional follow-up: add logging/telemetry when reconciliation occurs (rate-limited) to identify ingestion paths missing `onReflectionSubmitted()`.


### PR DESCRIPTION
## Problem

The reflection gate in `checkClaimGate()` permanently blocks agents from claiming tasks when `reflection_tracking` rows become stale. This happens when reflections are ingested via paths that skip `onReflectionSubmitted()` (e.g., case mismatch in agent name, alternate ingestion paths), so the tracking row's `tasks_done_since_reflection` never resets.

**Root cause**: Echo's SLA showed `tasksDoneSinceLastReflection: 5` despite having a recent `lastReflectionAt` — the tracking table was out of sync with the actual `reflections` table.

## Fix

Added reconciliation logic in `checkClaimGate()`: when about to block an agent, queries `listReflections({ author, limit: 1 })` to check if a newer reflection exists in the `reflections` table. If so, syncs the tracking row (resets `tasks_done_since_reflection=0`, updates `last_reflection_at`) and returns `{ allowed: true }`.

This acts as a safety net regardless of how reflections enter the system.

## Changes

- `src/working-contract.ts`: Import `listReflections`, add reconciliation block in `checkClaimGate()` before returning `allowed: false`
- `tests/working-contract.test.ts`: Regression test — creates stale tracking row, inserts reflection via `createReflection()` (bypassing `onReflectionSubmitted`), verifies gate allows and tracking is repaired
- Process artifact documenting the fix

## Testing

- 991 tests passing (1 skipped), CI green
- New regression test covers the exact stale-row scenario

## Task

`task-1771971304787-3gs8t57n0` (P0) — originated from insight `ins-1771971304740-jd60sjjy1` (echo)

Reviewer: @sage