### PR TITLE
feat(insights): add /insights/top API for top pain clusters + task linkage

### DIFF
--- a/process/TASK-task-1771955349046-ikbcp9zov-insights-top-api-20260225.md
+++ b/process/TASK-task-1771955349046-ikbcp9zov-insights-top-api-20260225.md
@@ -1,0 +1,64 @@
+# Task Artifact: /insights/top API
+
+**Task:** task-1771955349046-ikbcp9zov
+**Title:** Add /insights/top API to surface weekly top pain clusters + task linkage
+**Author:** link
+**Date:** 2026-02-25
+
+## What Was Done
+
+Added `GET /insights/top` endpoint that aggregates insights by `cluster_key` within a configurable time window and returns the top pain clusters ranked by frequency.
+
+### Endpoint
+
+`GET /insights/top?window=7d&limit=10`
+
+### Parameters
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | `7d` | Time window: `Nh`, `Nd`, `Nw` (hours/days/weeks) |
+| `limit` | `10` | Max clusters to return (1-50) |
+
+### Response Shape
+
+```json
+{
+  "clusters": [
+    {
+      "cluster_key": "runtime::crash::api-server",
+      "count": 5,
+      "avg_score": 7.6,
+      "last_seen_at": 1771987260456,
+      "linked_task_ids": ["task-abc", "task-def"]
+    }
+  ],
+  "window": "7d",
+  "since": 1771382460456,
+  "limit": 10
+}
+```
+
+### Implementation
+
+- SQL aggregation: `GROUP BY cluster_key` with `COUNT(*)`, `AVG(score)`, `MAX(created_at)`, `GROUP_CONCAT(task_id)`
+- Task IDs are deduplicated via `Set`
+- Null/empty task_ids excluded from aggregation
+- Window parsing supports `h`, `d`, `w` units; defaults to 7d on invalid input
+- Limit clamped to [1, 50]
+
+## Files Changed
+
+- `src/server.ts` — New `GET /insights/top` route
+- `tests/insights-top.test.ts` — 7 focused regression tests
+- `public/docs.md` — Endpoint documentation with example curl + response
+
+## Test Proof
+
+- 1021 passed, 1 skipped (0 failures)
+- 7 new tests: shape validation, window parsing (24h, 30d), limit, task_id dedup, ordering, defaults
+
+## Caveats
+
+- Aggregation is post-SQL dedup (GROUP_CONCAT then Set in JS) — fine for typical cluster counts
+- Only `created_at` is used for window filtering (not `updated_at`)

--- a/public/docs.md
+++ b/public/docs.md
@@ -459,6 +459,30 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | GET | `/insights/:id/audit` | Promotion audit trail for an insight. |
 | GET | `/insights/promotions` | List all promotion audit entries. Query: `limit`. |
 | GET | `/insights/recurring/candidates` | List recurring task candidates from insights with persistent patterns. Auto-suggests owner/lane per failure family. Template-first (no auto task spam). |
+| GET | `/insights/top` | Top pain clusters by frequency within a time window. Query: `window` (e.g. `7d`, `24h`, `2w`; default `7d`), `limit` (1-50, default 10). Returns `{ clusters: [{ cluster_key, count, avg_score, last_seen_at, linked_task_ids }], window, since, limit }`. |
+
+### Example: `/insights/top`
+
+```bash
+curl "http://localhost:4445/insights/top?window=7d&limit=10"
+```
+
+```json
+{
+  "clusters": [
+    {
+      "cluster_key": "runtime::crash::api-server",
+      "count": 5,
+      "avg_score": 7.6,
+      "last_seen_at": 1771987260456,
+      "linked_task_ids": ["task-abc123", "task-def456"]
+    }
+  ],
+  "window": "7d",
+  "since": 1771382460456,
+  "limit": 10
+}
+```
 
 ## Scoring Engine Configuration
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6489,6 +6489,60 @@ export async function createServer(): Promise<FastifyInstance> {
     return { success: true, config: getBridgeConfig() }
   })
 
+  // ── Insights Top Clusters ─────────────────────────────────────────────
+
+  app.get('/insights/top', async (request) => {
+    const query = request.query as Record<string, string>
+    const limit = Math.min(Math.max(Number(query.limit) || 10, 1), 50)
+
+    // Parse window: e.g. "7d", "30d", "24h", "2w"
+    let windowMs = 7 * 24 * 60 * 60 * 1000 // default 7d
+    const windowStr = (query.window || '7d').trim().toLowerCase()
+    const windowMatch = windowStr.match(/^(\d+)(h|d|w)$/)
+    if (windowMatch) {
+      const n = Number(windowMatch[1])
+      const unit = windowMatch[2]
+      if (unit === 'h') windowMs = n * 60 * 60 * 1000
+      else if (unit === 'd') windowMs = n * 24 * 60 * 60 * 1000
+      else if (unit === 'w') windowMs = n * 7 * 24 * 60 * 60 * 1000
+    }
+
+    const since = Date.now() - windowMs
+    const db = getDb()
+
+    const rows = db.prepare(`
+      SELECT
+        cluster_key,
+        COUNT(*) as count,
+        AVG(score) as avg_score,
+        MAX(created_at) as last_seen_at,
+        GROUP_CONCAT(CASE WHEN task_id IS NOT NULL AND task_id != '' THEN task_id ELSE NULL END) as task_ids_csv
+      FROM insights
+      WHERE created_at >= ?
+      GROUP BY cluster_key
+      ORDER BY count DESC, avg_score DESC
+      LIMIT ?
+    `).all(since, limit) as Array<{
+      cluster_key: string
+      count: number
+      avg_score: number
+      last_seen_at: number
+      task_ids_csv: string | null
+    }>
+
+    const clusters = rows.map(r => ({
+      cluster_key: r.cluster_key,
+      count: r.count,
+      avg_score: Math.round(r.avg_score * 100) / 100,
+      last_seen_at: r.last_seen_at,
+      linked_task_ids: r.task_ids_csv
+        ? [...new Set(r.task_ids_csv.split(',').filter(Boolean))]
+        : [],
+    }))
+
+    return { clusters, window: windowStr, since, limit }
+  })
+
   // ── Continuity Loop ──────────────────────────────────────────────────
 
   app.get('/continuity/stats', async () => {

--- a/tests/insights-top.test.ts
+++ b/tests/insights-top.test.ts
@@ -1,0 +1,151 @@
+// Tests for GET /insights/top — top pain clusters with task linkage
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { createServer } from '../src/server.js'
+import { getDb } from '../src/db.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+function insertInsight(overrides: Record<string, unknown> = {}) {
+  const db = getDb()
+  const id = `ins-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO insights (
+      id, cluster_key, workflow_stage, failure_family, impacted_unit,
+      title, status, score, priority, reflection_ids, independent_count,
+      evidence_refs, authors, promotion_readiness, recurring_candidate,
+      task_id, metadata, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    overrides.id ?? id,
+    overrides.cluster_key ?? 'testing::unit::default',
+    overrides.workflow_stage ?? 'testing',
+    overrides.failure_family ?? 'unit',
+    overrides.impacted_unit ?? 'default',
+    overrides.title ?? 'Test insight',
+    overrides.status ?? 'candidate',
+    overrides.score ?? 5,
+    overrides.priority ?? 'P2',
+    overrides.reflection_ids ?? '[]',
+    overrides.independent_count ?? 1,
+    overrides.evidence_refs ?? '[]',
+    overrides.authors ?? '["test"]',
+    overrides.promotion_readiness ?? 'not_ready',
+    overrides.recurring_candidate ?? 0,
+    overrides.task_id ?? null,
+    overrides.metadata ?? null,
+    overrides.created_at ?? now,
+    overrides.updated_at ?? now,
+  )
+  return id
+}
+
+describe('GET /insights/top', () => {
+  const uniqueTag = Date.now().toString(36)
+
+  it('returns clusters grouped by cluster_key with correct shape', async () => {
+    const ck = `top-test::shape::${uniqueTag}`
+    insertInsight({ cluster_key: ck, score: 8 })
+    insertInsight({ cluster_key: ck, score: 6 })
+
+    const res = await app.inject({ method: 'GET', url: '/insights/top' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+
+    expect(body).toHaveProperty('clusters')
+    expect(body).toHaveProperty('window')
+    expect(body).toHaveProperty('since')
+    expect(body).toHaveProperty('limit')
+
+    const cluster = body.clusters.find((c: any) => c.cluster_key === ck)
+    expect(cluster).toBeDefined()
+    expect(cluster.count).toBe(2)
+    expect(cluster.avg_score).toBe(7)
+    expect(cluster.linked_task_ids).toBeInstanceOf(Array)
+    expect(typeof cluster.last_seen_at).toBe('number')
+  })
+
+  it('parses window parameter correctly (24h)', async () => {
+    const ck = `top-test::window::${uniqueTag}`
+    // Insert one insight now and one 48h ago
+    insertInsight({ cluster_key: ck, score: 5 })
+    const oldTs = Date.now() - 48 * 60 * 60 * 1000
+    insertInsight({ cluster_key: ck, score: 5, created_at: oldTs, updated_at: oldTs })
+
+    const res = await app.inject({ method: 'GET', url: '/insights/top?window=24h' })
+    const body = JSON.parse(res.body)
+
+    const cluster = body.clusters.find((c: any) => c.cluster_key === ck)
+    // Only the recent one should be included
+    expect(cluster?.count ?? 0).toBe(1)
+  })
+
+  it('parses window=30d', async () => {
+    const ck = `top-test::30d::${uniqueTag}`
+    insertInsight({ cluster_key: ck, score: 7 })
+
+    const res = await app.inject({ method: 'GET', url: '/insights/top?window=30d' })
+    const body = JSON.parse(res.body)
+    expect(body.window).toBe('30d')
+    const cluster = body.clusters.find((c: any) => c.cluster_key === ck)
+    expect(cluster).toBeDefined()
+  })
+
+  it('respects limit parameter', async () => {
+    // Insert insights for 3 different clusters
+    for (let i = 0; i < 3; i++) {
+      insertInsight({ cluster_key: `top-test::limit${i}::${uniqueTag}`, score: 5 + i })
+    }
+
+    const res = await app.inject({ method: 'GET', url: '/insights/top?limit=2' })
+    const body = JSON.parse(res.body)
+    expect(body.clusters.length).toBeLessThanOrEqual(2)
+    expect(body.limit).toBe(2)
+  })
+
+  it('includes linked_task_ids and deduplicates', async () => {
+    const ck = `top-test::tasks::${uniqueTag}`
+    insertInsight({ cluster_key: ck, task_id: 'task-aaa', score: 6 })
+    insertInsight({ cluster_key: ck, task_id: 'task-aaa', score: 7 }) // duplicate
+    insertInsight({ cluster_key: ck, task_id: 'task-bbb', score: 8 })
+    insertInsight({ cluster_key: ck, task_id: null, score: 4 }) // no task
+
+    const res = await app.inject({ method: 'GET', url: '/insights/top' })
+    const body = JSON.parse(res.body)
+    const cluster = body.clusters.find((c: any) => c.cluster_key === ck)
+    expect(cluster).toBeDefined()
+    expect(cluster.count).toBe(4)
+    expect(cluster.linked_task_ids).toContain('task-aaa')
+    expect(cluster.linked_task_ids).toContain('task-bbb')
+    expect(cluster.linked_task_ids.length).toBe(2) // deduplicated
+  })
+
+  it('orders by count desc then avg_score desc', async () => {
+    const ckMany = `top-test::order-many::${uniqueTag}`
+    const ckFew = `top-test::order-few::${uniqueTag}`
+    insertInsight({ cluster_key: ckMany, score: 3 })
+    insertInsight({ cluster_key: ckMany, score: 3 })
+    insertInsight({ cluster_key: ckMany, score: 3 })
+    insertInsight({ cluster_key: ckFew, score: 10 })
+
+    const res = await app.inject({ method: 'GET', url: '/insights/top?limit=50' })
+    const body = JSON.parse(res.body)
+    const manyIdx = body.clusters.findIndex((c: any) => c.cluster_key === ckMany)
+    const fewIdx = body.clusters.findIndex((c: any) => c.cluster_key === ckFew)
+    // Many-count cluster should come before few-count
+    expect(manyIdx).toBeLessThan(fewIdx)
+  })
+
+  it('defaults to window=7d and limit=10', async () => {
+    const res = await app.inject({ method: 'GET', url: '/insights/top' })
+    const body = JSON.parse(res.body)
+    expect(body.window).toBe('7d')
+    expect(body.limit).toBe(10)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `GET /insights/top` to surface the most frequent pain clusters within a configurable time window, with linked task IDs for traceability.

## Endpoint

`GET /insights/top?window=7d&limit=10`

**Parameters:**
- `window` — Time window: `Nh`, `Nd`, `Nw` (default: `7d`)
- `limit` — Max clusters (1-50, default: 10)

**Response:**
```json
{
  "clusters": [
    {
      "cluster_key": "runtime::crash::api-server",
      "count": 5,
      "avg_score": 7.6,
      "last_seen_at": 1771987260456,
      "linked_task_ids": ["task-abc123", "task-def456"]
    }
  ],
  "window": "7d",
  "since": 1771382460456,
  "limit": 10
}
```

## Implementation

- SQL aggregation: `GROUP BY cluster_key` with `COUNT(*)`, `AVG(score)`, `MAX(created_at)`, `GROUP_CONCAT(task_id)`
- Task IDs deduplicated via `Set`, null/empty excluded
- Window parsing: `h`/`d`/`w` units, defaults to 7d on invalid input
- Limit clamped to [1, 50]

## Done Criteria

- [x] `GET /insights/top?window=7d&limit=10` returns clusters with count, avg_score, last_seen_at, and linked_task_ids
- [x] Focused regression test covering window parsing and correct cluster aggregation (7 tests)
- [x] `public/docs.md` documents the new endpoint with example curl and sample response

## Testing

1021 tests passing, 1 skipped, 0 failures.
7 new tests in `tests/insights-top.test.ts`: shape validation, window parsing (24h, 30d), limit, task_id dedup, ordering, defaults.

## Task

`task-1771955349046-ikbcp9zov` (P1)

Reviewer: @sage