### PR TITLE
fix: sweeper drift dedup — stop pr_drift alert spam

### DIFF
--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -274,11 +274,13 @@ export function sweepValidatingQueue(): SweepResult {
   }
 
   // Clean up escalation tracking for tasks no longer validating
-  for (const [taskId] of escalated) {
-    const lookup = taskManager.resolveTaskId(taskId)
-    if (!lookup.task || lookup.task.status !== 'validating') {
-      escalated.delete(taskId)
-      logDryRun('escalation_cleared', `${taskId} — no longer validating`)
+  for (const [key] of escalated) {
+    // drift: prefix holds the real task ID — strip before resolving
+    const realTaskId = key.startsWith("drift:") ? key.slice(6) : key
+    const lookup = taskManager.resolveTaskId(realTaskId)
+    if (!lookup.task || lookup.task.status !== "validating") {
+      escalated.delete(key)
+      logDryRun("escalation_cleared", `${key} — no longer validating`)
     }
   }
 


### PR DESCRIPTION
## Problem

The execution sweeper fires `pr_drift` alerts every 5 minutes for the same task, generating 50+ identical messages.

## Root Cause

When tracking `pr_drift` escalations, the sweeper uses a `drift:task-xxx` key in the escalation map. The cleanup loop passes this key directly to `resolveTaskId("drift:task-xxx")`, which returns null (not a valid task ID). This causes the tracking entry to be deleted every cycle, so the next sweep sees no prior escalation and fires the alert again.

## Fix

Strip the `drift:` prefix before resolving the task ID in the cleanup loop. One-line change, zero behavior change for non-drift escalations.

## Evidence

- task-1771606758469-sunv5wmu6 generated 50+ identical sweeper alerts
- Inbox flooded for link, sage, and other subscribers
- Reviewers (sage, kai) were failing due to rate limits, unable to respond

## Testing

- Build passes (`npm run build`)
- Existing test suite has pre-existing sqlite3 binary version mismatch (unrelated to this change)
- Logic verified by code review

Fixes task-1772016933688-9khkbqw7w