### PR TITLE
fix(sweeper): persistent escalation, cooldown, batching, realistic SLAs

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -985,6 +985,20 @@ class TaskManager {
     }
   }
 
+  /**
+   * Lightweight metadata-only patch that bypasses lifecycle gates.
+   * Used by internal subsystems (sweeper, auto-close) to persist bookkeeping
+   * fields without triggering full validation or history events.
+   */
+  patchTaskMetadata(id: string, metadataUpdates: Record<string, unknown>): boolean {
+    const task = queryTask(id)
+    if (!task) return false
+    const merged = { ...(task.metadata || {}), ...metadataUpdates }
+    const updated: Task = { ...task, metadata: merged, updatedAt: Date.now() }
+    this.writeTaskToDb(updated)
+    return true
+  }
+
   getTaskHistory(id: string): TaskHistoryEvent[] {
     const db = getDb()
     const rows = db.prepare(


### PR DESCRIPTION
## Problem

The sweeper bot was firing CRITICAL alerts every 5 minutes for all tasks stuck in validating, generating 8+ identical alerts per task in 30-minute windows. All 6+ validating tasks triggered simultaneously. Reviewers had no active subscriptions, so the alerts were pure noise going nowhere.

**Root causes:**
1. Escalation tracking was in-memory only — server restarts cleared the Map, causing all tasks to re-fire from scratch
2. SLA thresholds were 30m warning / 60m critical — way too aggressive for async AI reviewer workflows that routinely take hours
3. Each violation generated its own message — 6 tasks x 2 levels = 12 individual CRITICAL messages
4. No re-escalation cooldown — once tracking was cleared, immediate re-fire
5. No escalation cap — tasks could generate unlimited alerts forever

## Changes

- Persist escalation state in task metadata - survives server restarts
- 4-hour re-escalation cooldown
- Max 3 escalations per task before permanent silencing
- Realistic SLA thresholds: 2h warning, 8h critical (was 30m/60m)
- Batched digest messages instead of N individual alerts
- patchTaskMetadata() for lightweight sweeper bookkeeping
- 3 new tests, 1017 total passing

Fixes task-1772016933688-9khkbqw7w | Insight: ins-1772016933664-e6k9xsa5m