### PR TITLE
feat: add version/commit/uptime to /health + fix event type labels

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -21,6 +21,8 @@ export type EventType =
   | 'task_updated'
   | 'memory_written'
   | 'presence_updated'
+  | 'reflection_created'
+  | 'insight_created'
 
 export const VALID_EVENT_TYPES = new Set<EventType>([
   'message_posted',
@@ -29,6 +31,8 @@ export const VALID_EVENT_TYPES = new Set<EventType>([
   'task_updated',
   'memory_written',
   'presence_updated',
+  'reflection_created',
+  'insight_created',
 ])
 
 export interface Event {

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -523,14 +523,14 @@ function createInsight(key: InsightClusterKey, clusterKeyStr: string, reflection
   if (shouldPromote) {
     eventBus.emit({
       id: `evt-insight-promoted-${id}`,
-      type: 'task_created' as const,
+      type: 'insight_created' as const,
       timestamp: Date.now(),
       data: { kind: 'insight:promoted', insightId: id, priority, score },
     })
   } else {
     eventBus.emit({
       id: `evt-insight-created-${id}`,
-      type: 'task_created' as const,
+      type: 'insight_created' as const,
       timestamp: Date.now(),
       data: { kind: 'insight:created', insightId: id },
     })
@@ -604,7 +604,7 @@ function addReflectionToInsight(existing: Insight, reflection: Reflection): Insi
   if (shouldPromote && wasCandidate) {
     eventBus.emit({
       id: `evt-insight-promoted-${existing.id}`,
-      type: 'task_created' as const,
+      type: 'insight_created' as const,
       timestamp: Date.now(),
       data: { kind: 'insight:promoted', insightId: existing.id, priority, score },
     })

--- a/src/reflections.ts
+++ b/src/reflections.ts
@@ -226,7 +226,7 @@ export function createReflection(input: ReflectionInput): Reflection {
 
   eventBus.emit({
     id: `evt-reflection-${id}`,
-    type: 'task_created' as const,
+    type: 'reflection_created' as const,
     timestamp: Date.now(),
     data: { kind: 'reflection:created', reflectionId: id, author: reflection.author },
   })


### PR DESCRIPTION
## What

Two small fixes from today's deploy experience:

### 1. Version info in /health
`/health` now returns:
```json
{
  "version": "0.1.0",
  "commit": "17149c8",
  "uptime_seconds": 42,
  ...
}
```
Read once at startup (no per-request overhead). Lets customers confirm which version is running after a deploy.

### 2. Event type labeling fix
Reflections and insights were emitting `task_created` events, which made the activity feed confusing (Ryan spotted this — "I see task created event twice but nothing on the board"). Now they emit `reflection_created` and `insight_created` respectively.

## Changed files
- `src/server.ts` — BUILD_VERSION, BUILD_COMMIT, BUILD_STARTED_AT constants + /health response
- `src/events.ts` — added `reflection_created` and `insight_created` to EventType + VALID_EVENT_TYPES
- `src/reflections.ts` — emit `reflection_created` instead of `task_created`
- `src/insights.ts` — emit `insight_created` instead of `task_created`

## Testing
- Built clean (tsc, zero errors)
- Deployed to live instance, verified /health returns correct version + commit
- 29 insertions, 5 deletions