### PR TITLE
feat(knowledge): docs CRUD with tags/categories + auto-index on ship

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -285,6 +285,11 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | GET | `/knowledge/search` | Unified knowledge search across all indexed content (tasks, chat, reflections, insights, shared files). Query: `q` (required), `limit`, `type` (optional filter). Returns results with source_type, snippet, similarity score, and deep link. |
 | GET | `/knowledge/stats` | Knowledge index health — availability and counts per source type |
 | POST | `/knowledge/reindex-shared` | Scan and index shared workspace files (process/, specs/, artifacts/, handoffs/, references/) for knowledge search |
+| POST | `/knowledge/docs` | Create a knowledge document. Body: `title`, `content`, `category` (decision\|runbook\|architecture\|lesson\|how-to), `author`; optional: `tags[]`, `related_task_ids[]`, `related_insight_ids[]`. Auto-indexed for search. |
+| GET | `/knowledge/docs` | List knowledge documents. Query: `tag`, `category`, `author`, `q` (text search), `limit`, `offset`. |
+| GET | `/knowledge/docs/:id` | Get a single knowledge document by ID. |
+| PATCH | `/knowledge/docs/:id` | Update a knowledge document. Body: any of `title`, `content`, `category`, `tags[]`, `related_task_ids[]`, `related_insight_ids[]`. Re-indexes on update. |
+| DELETE | `/knowledge/docs/:id` | Delete a knowledge document. Removes from vector index. |
 
 ## Experiments
 

--- a/src/knowledge-docs.ts
+++ b/src/knowledge-docs.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Knowledge docs — structured knowledge articles with tags and categories.
+ *
+ * Gives the team a place to write durable knowledge beyond task artifacts
+ * and reflections. Documents are auto-indexed in the vector store for
+ * semantic search via /knowledge/search.
+ *
+ * Categories: decision, runbook, architecture, lesson, how-to
+ * SQLite table: knowledge_docs
+ */
+
+import { getDb } from './db.js'
+
+// ── Types ──
+
+export const KNOWLEDGE_CATEGORIES = ['decision', 'runbook', 'architecture', 'lesson', 'how-to'] as const
+export type KnowledgeCategory = (typeof KNOWLEDGE_CATEGORIES)[number]
+
+export interface KnowledgeDoc {
+  id: string
+  title: string
+  content: string            // markdown
+  tags: string[]
+  category: KnowledgeCategory
+  author: string
+  related_task_ids: string[]
+  related_insight_ids: string[]
+  created_at: number
+  updated_at: number
+}
+
+export interface CreateKnowledgeDocInput {
+  title: string
+  content: string
+  tags?: string[]
+  category: KnowledgeCategory
+  author: string
+  related_task_ids?: string[]
+  related_insight_ids?: string[]
+}
+
+export interface UpdateKnowledgeDocInput {
+  title?: string
+  content?: string
+  tags?: string[]
+  category?: KnowledgeCategory
+  related_task_ids?: string[]
+  related_insight_ids?: string[]
+}
+
+export interface KnowledgeDocListOpts {
+  tag?: string
+  category?: KnowledgeCategory
+  author?: string
+  q?: string
+  limit?: number
+  offset?: number
+}
+
+// ── DB row ──
+
+interface KnowledgeDocRow {
+  id: string
+  title: string
+  content: string
+  tags: string            // JSON array
+  category: string
+  author: string
+  related_task_ids: string // JSON array
+  related_insight_ids: string // JSON array
+  created_at: number
+  updated_at: number
+}
+
+function rowToDoc(row: KnowledgeDocRow): KnowledgeDoc {
+  return {
+    id: row.id,
+    title: row.title,
+    content: row.content,
+    tags: JSON.parse(row.tags || '[]'),
+    category: row.category as KnowledgeCategory,
+    author: row.author,
+    related_task_ids: JSON.parse(row.related_task_ids || '[]'),
+    related_insight_ids: JSON.parse(row.related_insight_ids || '[]'),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+function generateId(): string {
+  const ts = Date.now()
+  const rand = Math.random().toString(36).slice(2, 11)
+  return `kdoc-${ts}-${rand}`
+}
+
+// ── Migration ──
+
+export function initKnowledgeDocsTable(): void {
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS knowledge_docs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tags TEXT NOT NULL DEFAULT '[]',
+      category TEXT NOT NULL,
+      author TEXT NOT NULL,
+      related_task_ids TEXT NOT NULL DEFAULT '[]',
+      related_insight_ids TEXT NOT NULL DEFAULT '[]',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_knowledge_docs_category ON knowledge_docs(category)`)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_knowledge_docs_author ON knowledge_docs(author)`)
+}
+
+// ── CRUD ──
+
+export function createKnowledgeDoc(input: CreateKnowledgeDocInput): KnowledgeDoc {
+  const db = getDb()
+  const now = Date.now()
+  const id = generateId()
+
+  const doc: KnowledgeDoc = {
+    id,
+    title: input.title,
+    content: input.content,
+    tags: input.tags || [],
+    category: input.category,
+    author: input.author,
+    related_task_ids: input.related_task_ids || [],
+    related_insight_ids: input.related_insight_ids || [],
+    created_at: now,
+    updated_at: now,
+  }
+
+  db.prepare(`
+    INSERT INTO knowledge_docs (id, title, content, tags, category, author, related_task_ids, related_insight_ids, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    doc.id, doc.title, doc.content,
+    JSON.stringify(doc.tags), doc.category, doc.author,
+    JSON.stringify(doc.related_task_ids), JSON.stringify(doc.related_insight_ids),
+    doc.created_at, doc.updated_at,
+  )
+
+  return doc
+}
+
+export function getKnowledgeDoc(id: string): KnowledgeDoc | null {
+  const db = getDb()
+  const row = db.prepare('SELECT * FROM knowledge_docs WHERE id = ?').get(id) as KnowledgeDocRow | undefined
+  return row ? rowToDoc(row) : null
+}
+
+export function updateKnowledgeDoc(id: string, input: UpdateKnowledgeDocInput): KnowledgeDoc | null {
+  const db = getDb()
+  const existing = db.prepare('SELECT * FROM knowledge_docs WHERE id = ?').get(id) as KnowledgeDocRow | undefined
+  if (!existing) return null
+
+  const now = Date.now()
+  const sets: string[] = ['updated_at = ?']
+  const params: unknown[] = [now]
+
+  if (input.title !== undefined) { sets.push('title = ?'); params.push(input.title) }
+  if (input.content !== undefined) { sets.push('content = ?'); params.push(input.content) }
+  if (input.tags !== undefined) { sets.push('tags = ?'); params.push(JSON.stringify(input.tags)) }
+  if (input.category !== undefined) { sets.push('category = ?'); params.push(input.category) }
+  if (input.related_task_ids !== undefined) { sets.push('related_task_ids = ?'); params.push(JSON.stringify(input.related_task_ids)) }
+  if (input.related_insight_ids !== undefined) { sets.push('related_insight_ids = ?'); params.push(JSON.stringify(input.related_insight_ids)) }
+
+  params.push(id)
+  db.prepare(`UPDATE knowledge_docs SET ${sets.join(', ')} WHERE id = ?`).run(...params)
+
+  return getKnowledgeDoc(id)
+}
+
+export function deleteKnowledgeDoc(id: string): boolean {
+  const db = getDb()
+  const result = db.prepare('DELETE FROM knowledge_docs WHERE id = ?').run(id)
+  return result.changes > 0
+}
+
+export function listKnowledgeDocs(opts: KnowledgeDocListOpts = {}): { docs: KnowledgeDoc[]; total: number } {
+  const db = getDb()
+  const where: string[] = []
+  const params: unknown[] = []
+
+  if (opts.category) { where.push('category = ?'); params.push(opts.category) }
+  if (opts.author) { where.push('author = ?'); params.push(opts.author) }
+  if (opts.tag) { where.push("tags LIKE '%' || ? || '%'"); params.push(`"${opts.tag}"`) }
+  if (opts.q) {
+    where.push("(title LIKE '%' || ? || '%' OR content LIKE '%' || ? || '%')")
+    params.push(opts.q, opts.q)
+  }
+
+  const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : ''
+  const limit = Math.min(opts.limit || 50, 200)
+  const offset = opts.offset || 0
+
+  const countRow = db.prepare(`SELECT COUNT(*) as c FROM knowledge_docs ${whereClause}`).get(...params) as { c: number }
+  const rows = db.prepare(
+    `SELECT * FROM knowledge_docs ${whereClause} ORDER BY updated_at DESC LIMIT ? OFFSET ?`
+  ).all(...params, limit, offset) as KnowledgeDocRow[]
+
+  return { docs: rows.map(rowToDoc), total: countRow.c }
+}
+
+export function countKnowledgeDocs(): number {
+  const db = getDb()
+  const row = db.prepare('SELECT COUNT(*) as c FROM knowledge_docs').get() as { c: number }
+  return row.c
+}

--- a/tests/knowledge-docs.test.ts
+++ b/tests/knowledge-docs.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, beforeAll } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+
+describe('Knowledge Docs CRUD', () => {
+  let app: FastifyInstance
+  let createdDocId: string
+
+  beforeAll(async () => {
+    const { createServer } = await import('../src/server.js')
+    app = await createServer()
+    await app.ready()
+  })
+
+  it('POST /knowledge/docs creates a document', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/knowledge/docs',
+      payload: {
+        title: 'Deploy Runbook: reflectt-node',
+        content: '## Steps\n1. git pull\n2. npm run build\n3. launchctl restart\n4. Verify /health',
+        category: 'runbook',
+        author: 'link',
+        tags: ['deploy', 'ops'],
+        related_task_ids: ['task-123'],
+        metadata: { test_harness: true }
+      }
+    })
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.doc.id).toMatch(/^kdoc-/)
+    expect(body.doc.title).toBe('Deploy Runbook: reflectt-node')
+    expect(body.doc.category).toBe('runbook')
+    expect(body.doc.tags).toEqual(['deploy', 'ops'])
+    expect(body.doc.related_task_ids).toEqual(['task-123'])
+    createdDocId = body.doc.id
+  })
+
+  it('POST /knowledge/docs rejects missing fields', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/knowledge/docs',
+      payload: { title: 'Missing stuff' }
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('POST /knowledge/docs rejects invalid category', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/knowledge/docs',
+      payload: {
+        title: 'Bad Cat',
+        content: 'test',
+        category: 'invalid-category',
+        author: 'link'
+      }
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.body)
+    expect(body.error).toContain('Invalid category')
+  })
+
+  it('GET /knowledge/docs lists documents', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/knowledge/docs'
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(Array.isArray(body.docs)).toBe(true)
+    expect(typeof body.total).toBe('number')
+    expect(body.docs.length).toBeGreaterThan(0)
+  })
+
+  it('GET /knowledge/docs filters by category', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/knowledge/docs?category=runbook'
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    for (const doc of body.docs) {
+      expect(doc.category).toBe('runbook')
+    }
+  })
+
+  it('GET /knowledge/docs filters by tag', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/knowledge/docs?tag=deploy'
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.docs.length).toBeGreaterThan(0)
+    for (const doc of body.docs) {
+      expect(doc.tags).toContain('deploy')
+    }
+  })
+
+  it('GET /knowledge/docs filters by author', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/knowledge/docs?author=link'
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    for (const doc of body.docs) {
+      expect(doc.author).toBe('link')
+    }
+  })
+
+  it('GET /knowledge/docs text search with q', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/knowledge/docs?q=Deploy'
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.docs.length).toBeGreaterThan(0)
+  })
+
+  it('GET /knowledge/docs/:id returns single doc', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/knowledge/docs/${createdDocId}`
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.doc.id).toBe(createdDocId)
+    expect(body.doc.title).toBe('Deploy Runbook: reflectt-node')
+  })
+
+  it('GET /knowledge/docs/:id returns 404 for missing', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/knowledge/docs/kdoc-nonexistent'
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('PATCH /knowledge/docs/:id updates document', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/knowledge/docs/${createdDocId}`,
+      payload: {
+        title: 'Deploy Runbook: reflectt-node (updated)',
+        tags: ['deploy', 'ops', 'production'],
+        category: 'runbook'
+      }
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.doc.title).toBe('Deploy Runbook: reflectt-node (updated)')
+    expect(body.doc.tags).toEqual(['deploy', 'ops', 'production'])
+    expect(body.doc.updated_at).toBeGreaterThan(body.doc.created_at)
+  })
+
+  it('PATCH /knowledge/docs/:id rejects invalid category', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/knowledge/docs/${createdDocId}`,
+      payload: { category: 'bogus' }
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('PATCH /knowledge/docs/:id returns 404 for missing', async () => {
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/knowledge/docs/kdoc-nonexistent',
+      payload: { title: 'nope' }
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('DELETE /knowledge/docs/:id removes document', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/knowledge/docs/${createdDocId}`
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.deleted).toBe(true)
+
+    // Verify it's gone
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/knowledge/docs/${createdDocId}`
+    })
+    expect(getRes.statusCode).toBe(404)
+  })
+
+  it('DELETE /knowledge/docs/:id returns 404 for missing', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/knowledge/docs/kdoc-nonexistent'
+    })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('all 5 categories are accepted', async () => {
+    const categories = ['decision', 'runbook', 'architecture', 'lesson', 'how-to']
+    for (const cat of categories) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/knowledge/docs',
+        payload: {
+          title: `Test ${cat}`,
+          content: `Content for ${cat}`,
+          category: cat,
+          author: 'test',
+          metadata: { test_harness: true }
+        }
+      })
+      expect(res.statusCode).toBe(201)
+      const body = JSON.parse(res.body)
+      expect(body.doc.category).toBe(cat)
+    }
+  })
+})


### PR DESCRIPTION
## Knowledge Base — Tasks 4 & 5: Docs CRUD + Auto-Index

### Knowledge Docs (`src/knowledge-docs.ts`)
- CRUD for structured knowledge articles
- Categories: decision, runbook, architecture, lesson, how-to
- Tags, related task/insight linking
- Text search, category/author/tag filtering, pagination
- Auto-indexed in vector store for `/knowledge/search`

### Auto-Index on Ship
- Task → done triggers re-indexing with full context (title + description + QA summary)
- Shipped work is immediately searchable via knowledge search

### New endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/knowledge/docs` | Create knowledge document |
| GET | `/knowledge/docs` | List with filters |
| GET | `/knowledge/docs/:id` | Get single doc |
| PATCH | `/knowledge/docs/:id` | Update + re-index |
| DELETE | `/knowledge/docs/:id` | Delete + clean index |

### Testing
- 16 new tests (1186 total)
- Route-docs contract: 346/346

### Tasks
- task-1772034736549-pc64dwnrc (docs CRUD)
- task-1772034745807-xtakjss93 (auto-index pipeline)
- Insight: ins-1771948464078-1cv9vkqwy