### PR TITLE
fix(compliance): portable paths + owner/ETA in breach output

### DIFF
--- a/scripts/content-lane-compliance-report.mjs
+++ b/scripts/content-lane-compliance-report.mjs
@@ -82,6 +82,7 @@ async function main() {
 
   if (breach) {
     lines.push(`- Recovery: ${recoveryPlan({ wip, readyCount })}`)
+    lines.push(`- Owner: ${ASSIGNEE} | ETA: 30m`)
     lines.push(`- Escalation: @kai ${CONTROL_TASK_ID} breach during active hours; needs recovery within 30m`)
   }
 

--- a/scripts/content-lane-compliance-report.sh
+++ b/scripts/content-lane-compliance-report.sh
@@ -1,10 +1,13 @@
 #!/bin/zsh
 set -euo pipefail
 
+# Portable wrapper — resolves the .mjs script relative to this file's location.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 REFLECTT_NODE_URL="${REFLECTT_NODE_URL:-http://127.0.0.1:4445}"
 ASSIGNEE="${ASSIGNEE:-echo}"
 CONTROL_TASK_ID="${CONTROL_TASK_ID:-task-1771427184904-mu356v5md}"
 
 export REFLECTT_NODE_URL ASSIGNEE CONTROL_TASK_ID
 
-/opt/homebrew/bin/node "/Users/ryan/.openclaw/workspace-echo/scripts/content-lane-compliance-report.mjs"
+node "${SCRIPT_DIR}/content-lane-compliance-report.mjs"

--- a/scripts/launchd/ai.reflectt.echo.content-lane-compliance.plist
+++ b/scripts/launchd/ai.reflectt.echo.content-lane-compliance.plist
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Content lane compliance reporter — launchd template.
+
+  Before loading, replace these placeholders with your actual paths:
+    __REPO_ROOT__   → absolute path to your reflectt-node checkout
+                      e.g. /Users/you/.openclaw/workspace/projects/reflectt-node
+    __NODE_BIN__    → path to node binary (run `which node` to find yours)
+                      e.g. /opt/homebrew/bin/node  or  /usr/local/bin/node
+
+  Install:
+    cp scripts/launchd/ai.reflectt.echo.content-lane-compliance.plist ~/Library/LaunchAgents/
+    # edit the copy to fill in __REPO_ROOT__ and __NODE_BIN__
+    launchctl load ~/Library/LaunchAgents/ai.reflectt.echo.content-lane-compliance.plist
+-->
 <plist version="1.0">
 <dict>
   <key>Label</key>
@@ -8,11 +22,11 @@
   <key>ProgramArguments</key>
   <array>
     <string>/bin/zsh</string>
-    <string>/Users/ryan/.openclaw/workspace-echo/scripts/content-lane-compliance-report.sh</string>
+    <string>__REPO_ROOT__/scripts/content-lane-compliance-report.sh</string>
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/ryan/.openclaw/workspace-echo</string>
+  <string>__REPO_ROOT__</string>
 
   <key>EnvironmentVariables</key>
   <dict>
@@ -24,90 +38,22 @@
     <string>echo</string>
     <key>CONTROL_TASK_ID</key>
     <string>task-1771427184904-mu356v5md</string>
+    <key>PATH</key>
+    <string>__NODE_BIN__:/usr/local/bin:/usr/bin:/bin</string>
   </dict>
 
   <key>StartCalendarInterval</key>
   <array>
-    <dict>
-      <key>Weekday</key>
-      <integer>2</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>2</integer>
-      <key>Hour</key>
-      <integer>14</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>3</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>3</integer>
-      <key>Hour</key>
-      <integer>14</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>4</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>4</integer>
-      <key>Hour</key>
-      <integer>14</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>5</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>5</integer>
-      <key>Hour</key>
-      <integer>14</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>6</integer>
-      <key>Hour</key>
-      <integer>9</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
-    <dict>
-      <key>Weekday</key>
-      <integer>6</integer>
-      <key>Hour</key>
-      <integer>14</integer>
-      <key>Minute</key>
-      <integer>0</integer>
-    </dict>
+    <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>6</integer><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+    <dict><key>Weekday</key><integer>6</integer><key>Hour</key><integer>14</integer><key>Minute</key><integer>0</integer></dict>
   </array>
 
   <key>StandardOutPath</key>


### PR DESCRIPTION
Follow-up to PR #335. Fixes sage review feedback on task-1771427184904-mu356v5md:

## Changes
1. **Shell wrapper** — uses $(dirname $0) to resolve the .mjs script relative to itself (no hardcoded workspace paths)
2. **Launchd plist** — converted to template with __REPO_ROOT__ and __NODE_BIN__ placeholders + documented install steps  
3. **Breach output** — adds explicit `Owner: <agent> | ETA: 30m` line per done criteria

## Verification
- Ran reporter locally: snapshots visible via `GET /tasks/:id/comments` (SQLite-backed API)
- All 3 review blocking issues from sage addressed

Task: task-1771427184904-mu356v5md