### PR TITLE
feat: enhanced chat dedup — 30m system window, persistent suppression ledger

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -217,6 +217,8 @@ Graceful degradation: if GitHub API is unavailable, the merge check is skipped (
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/chat/noise-budget` | Current budget snapshot: per-channel ratios, window stats, enforcement state |
+| GET | `/chat/suppression/stats` | Chat dedup suppression stats: total suppressed, by category (system/agent), active hash count, since timestamp. |
+| POST | `/chat/suppression/prune` | Prune expired entries from the suppression ledger. Returns `{ pruned }`. |
 | GET | `/chat/noise-budget/canary` | Canary rollback evaluation: ratio vs target, SLA miss delta, P95 response delta |
 | GET | `/chat/noise-budget/suppression-log` | Audit trail of suppressed/digested messages |
 | GET | `/chat/noise-budget/config` | Read current noise budget configuration |

--- a/src/suppression-ledger.ts
+++ b/src/suppression-ledger.ts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Persistent suppression ledger for system message deduplication
+//
+// Tracks dedup keys (category + channel + content hash) in SQLite.
+// Prevents duplicate system messages within a configurable window (default 30m).
+
+import { createHash } from 'crypto'
+import { getDb } from './db.js'
+
+export interface SuppressionEntry {
+  id: number
+  dedup_key: string
+  category: string
+  channel: string
+  from: string
+  content_preview: string | null
+  first_seen_at: number
+  last_seen_at: number
+  hit_count: number
+  suppressed: boolean
+  window_ms: number
+}
+
+export interface SuppressionCheckResult {
+  isDuplicate: boolean
+  dedup_key: string
+  existing?: SuppressionEntry
+}
+
+export interface SuppressionStats {
+  total_entries: number
+  total_suppressed: number
+  total_hits: number
+  by_category: Record<string, { entries: number; suppressed: number; hits: number }>
+  by_channel: Record<string, { entries: number; suppressed: number; hits: number }>
+  window_ms: number
+  active_entries: number
+}
+
+const DEFAULT_WINDOW_MS = 30 * 60 * 1000 // 30 minutes
+
+export class SuppressionLedger {
+  private windowMs: number
+
+  constructor(windowMs?: number) {
+    this.windowMs = windowMs ?? DEFAULT_WINDOW_MS
+  }
+
+  /**
+   * Compute a dedup key from category + channel + content.
+   * Content is normalized: timestamps, task IDs, and message IDs stripped.
+   */
+  computeDedupKey(category: string, channel: string, content: string): string {
+    const normalized = content
+      .trim()
+      .toLowerCase()
+      .replace(/\b(msg-|task-|tcomment-|ins-|ref-)\S+/g, '')
+      .replace(/\d{13,}/g, '')
+      .replace(/\s+/g, ' ')
+      .slice(0, 300)
+    const raw = `${category}:${channel}:${normalized}`
+    return createHash('sha256').update(raw).digest('hex').substring(0, 20)
+  }
+
+  /**
+   * Check if a message is a duplicate within the suppression window.
+   * If not a duplicate, records it in the ledger.
+   * If duplicate, increments the hit count and marks as suppressed.
+   */
+  check(opts: {
+    category: string
+    channel: string
+    from: string
+    content: string
+  }): SuppressionCheckResult {
+    const dedup_key = this.computeDedupKey(opts.category, opts.channel, opts.content)
+    const now = Date.now()
+    const db = getDb()
+
+    interface LedgerRow {
+      id: number
+      dedup_key: string
+      category: string
+      channel: string
+      from: string
+      content_preview: string | null
+      first_seen_at: number
+      last_seen_at: number
+      hit_count: number
+      suppressed: number // SQLite stores as 0/1
+      window_ms: number
+    }
+
+    const existing = db.prepare(
+      'SELECT * FROM suppression_ledger WHERE dedup_key = ?'
+    ).get(dedup_key) as LedgerRow | undefined
+
+    if (existing && (now - existing.last_seen_at) < this.windowMs) {
+      // Duplicate within window — update hit count
+      db.prepare(
+        'UPDATE suppression_ledger SET hit_count = hit_count + 1, last_seen_at = ?, suppressed = 1 WHERE dedup_key = ?'
+      ).run(now, dedup_key)
+
+      return {
+        isDuplicate: true,
+        dedup_key,
+        existing: {
+          ...existing,
+          suppressed: true,
+          hit_count: existing.hit_count + 1,
+          last_seen_at: now,
+        },
+      }
+    }
+
+    // Not a duplicate (or outside window) — upsert
+    db.prepare(`
+      INSERT INTO suppression_ledger (dedup_key, category, channel, "from", content_preview, first_seen_at, last_seen_at, hit_count, suppressed, window_ms)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1, 0, ?)
+      ON CONFLICT(dedup_key) DO UPDATE SET
+        last_seen_at = excluded.last_seen_at,
+        hit_count = 1,
+        suppressed = 0,
+        "from" = excluded."from",
+        content_preview = excluded.content_preview,
+        window_ms = excluded.window_ms
+    `).run(dedup_key, opts.category, opts.channel, opts.from, opts.content.slice(0, 200), now, now, this.windowMs)
+
+    return { isDuplicate: false, dedup_key }
+  }
+
+  /**
+   * Get suppression statistics.
+   */
+  getStats(): SuppressionStats {
+    const db = getDb()
+    const now = Date.now()
+    const activeCutoff = now - this.windowMs
+
+    const total = (db.prepare('SELECT COUNT(*) as c FROM suppression_ledger').get() as { c: number }).c
+    const totalSuppressed = (db.prepare('SELECT COUNT(*) as c FROM suppression_ledger WHERE suppressed = 1').get() as { c: number }).c
+    const totalHitsRow = db.prepare('SELECT COALESCE(SUM(hit_count), 0) as s FROM suppression_ledger').get() as { s: number }
+    const activeEntries = (db.prepare('SELECT COUNT(*) as c FROM suppression_ledger WHERE last_seen_at >= ?').get(activeCutoff) as { c: number }).c
+
+    const byCatRows = db.prepare(`
+      SELECT category,
+        COUNT(*) as entries,
+        SUM(CASE WHEN suppressed = 1 THEN 1 ELSE 0 END) as suppressed,
+        SUM(hit_count) as hits
+      FROM suppression_ledger GROUP BY category
+    `).all() as Array<{ category: string; entries: number; suppressed: number; hits: number }>
+
+    const byChannelRows = db.prepare(`
+      SELECT channel,
+        COUNT(*) as entries,
+        SUM(CASE WHEN suppressed = 1 THEN 1 ELSE 0 END) as suppressed,
+        SUM(hit_count) as hits
+      FROM suppression_ledger GROUP BY channel
+    `).all() as Array<{ channel: string; entries: number; suppressed: number; hits: number }>
+
+    return {
+      total_entries: total,
+      total_suppressed: totalSuppressed,
+      total_hits: totalHitsRow.s,
+      by_category: Object.fromEntries(byCatRows.map(r => [r.category, { entries: r.entries, suppressed: r.suppressed, hits: r.hits }])),
+      by_channel: Object.fromEntries(byChannelRows.map(r => [r.channel, { entries: r.entries, suppressed: r.suppressed, hits: r.hits }])),
+      window_ms: this.windowMs,
+      active_entries: activeEntries,
+    }
+  }
+
+  /**
+   * Prune old entries outside the window.
+   */
+  prune(): number {
+    const db = getDb()
+    const cutoff = Date.now() - this.windowMs * 10 // Keep 10x window for stats
+    const result = db.prepare('DELETE FROM suppression_ledger WHERE last_seen_at < ?').run(cutoff)
+    return result.changes
+  }
+
+  /**
+   * Get window in ms.
+   */
+  getWindowMs(): number {
+    return this.windowMs
+  }
+
+  /**
+   * Update window.
+   */
+  setWindowMs(ms: number): void {
+    this.windowMs = ms
+  }
+}
+
+export const suppressionLedger = new SuppressionLedger()

--- a/tests/chat-dedup.test.ts
+++ b/tests/chat-dedup.test.ts
@@ -1,0 +1,108 @@
+// Tests for chat message deduplication improvements
+import { describe, it, expect, beforeAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  process.env.REFLECTT_DATA_DIR = `/tmp/reflectt-test-dedup-${Date.now()}`
+  app = await createServer()
+  await app.ready()
+})
+
+async function sendMsg(from: string, content: string, channel = 'general', metadata?: Record<string, unknown>) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/chat/messages',
+    payload: { from, content, channel, ...(metadata ? { metadata } : {}) },
+  })
+  const body = JSON.parse(res.body)
+  return { statusCode: res.statusCode, body, id: body?.message?.id as string | undefined }
+}
+
+describe('Chat dedup suppression', () => {
+  it('suppresses duplicate system messages within 30m window', async () => {
+    const content = '⚠️ Ready-queue floor: @link has 0/2 unblocked todo tasks (need 2 more). @sage @pixel — please spec.'
+
+    const first = await sendMsg('system', content)
+    expect(first.statusCode).toBe(200)
+    expect(first.id).toBeDefined()
+    expect(first.id).not.toContain('suppressed')
+
+    const second = await sendMsg('system', content)
+    expect(second.statusCode).toBe(200)
+    expect(second.id).toContain('suppressed')
+  })
+
+  it('suppresses system messages with different task IDs but same pattern', async () => {
+    const ts = Date.now()
+    const content1 = `⚠️ SLA breach: "Fix bug" (task-${ts}-abc) in validating 3h. @kai — review needed.`
+    const content2 = `⚠️ SLA breach: "Fix bug" (task-${ts}-xyz) in validating 3h. @kai — review needed.`
+
+    const first = await sendMsg('system', content1)
+    expect(first.statusCode).toBe(200)
+    expect(first.id).not.toContain('suppressed')
+
+    const second = await sendMsg('system', content2)
+    expect(second.statusCode).toBe(200)
+    expect(second.id).toContain('suppressed')
+  })
+
+  it('supports explicit dedup_key in metadata', async () => {
+    const key = `test-dedup-key-${Date.now()}`
+
+    const first = await sendMsg('system', 'Alert: event A at ' + Date.now(), 'general', { dedup_key: key })
+    expect(first.statusCode).toBe(200)
+    expect(first.id).not.toContain('suppressed')
+
+    // Same dedup_key, different content — should still be suppressed
+    const second = await sendMsg('system', 'Alert: event B at ' + Date.now(), 'general', { dedup_key: key })
+    expect(second.statusCode).toBe(200)
+    expect(second.id).toContain('suppressed')
+  })
+
+  it('does not suppress messages from different channels', async () => {
+    const content = 'Unique cross-channel test ' + Date.now()
+
+    const first = await sendMsg('system', content, 'general')
+    expect(first.statusCode).toBe(200)
+    expect(first.id).not.toContain('suppressed')
+
+    // Same content, different channel — should NOT be suppressed
+    const second = await sendMsg('system', content, 'shipping')
+    expect(second.statusCode).toBe(200)
+    expect(second.id).toBeDefined()
+    expect(second.id).not.toContain('suppressed')
+  })
+})
+
+describe('GET /chat/suppression/stats', () => {
+  it('returns suppression statistics', async () => {
+    const res = await app.inject({ method: 'GET', url: '/chat/suppression/stats' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.inline_dedup).toBeDefined()
+    expect(body.inline_dedup.total).toBeGreaterThanOrEqual(0)
+    expect(body.inline_dedup.byCategory).toBeDefined()
+    expect(body.inline_dedup.since).toBeGreaterThan(0)
+    expect(typeof body.inline_dedup.activeHashes).toBe('number')
+    expect(body.ledger).toBeDefined()
+  })
+
+  it('tracks suppressed count after dedup', async () => {
+    // Get baseline
+    const before = await app.inject({ method: 'GET', url: '/chat/suppression/stats' })
+    const baselineTotal = JSON.parse(before.body).inline_dedup.total
+
+    // Send + suppress a message
+    const content = 'Stats tracking test ' + Date.now()
+    await sendMsg('system', content)
+    await sendMsg('system', content)
+
+    const after = await app.inject({ method: 'GET', url: '/chat/suppression/stats' })
+    const afterTotal = JSON.parse(after.body).inline_dedup.total
+    expect(afterTotal).toBeGreaterThan(baselineTotal)
+  })
+})

--- a/tests/suppression-ledger.test.ts
+++ b/tests/suppression-ledger.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SuppressionLedger } from '../src/suppression-ledger.js'
+import { getDb } from '../src/db.js'
+
+describe('Suppression Ledger', () => {
+  let ledger: SuppressionLedger
+
+  beforeEach(() => {
+    // Clear ledger between tests
+    const db = getDb()
+    db.prepare('DELETE FROM suppression_ledger').run()
+    ledger = new SuppressionLedger(30 * 60 * 1000) // 30m window
+  })
+
+  it('allows first message and returns dedup_key', () => {
+    const result = ledger.check({
+      category: 'watchdog-alert',
+      channel: 'ops',
+      from: 'system',
+      content: '⚠️ Agent link idle for 45 minutes',
+    })
+    expect(result.isDuplicate).toBe(false)
+    expect(result.dedup_key).toBeTruthy()
+    expect(result.dedup_key.length).toBe(20)
+  })
+
+  it('detects duplicate within window', () => {
+    const opts = {
+      category: 'watchdog-alert',
+      channel: 'ops',
+      from: 'system',
+      content: '⚠️ Agent link idle for 45 minutes',
+    }
+
+    const first = ledger.check(opts)
+    expect(first.isDuplicate).toBe(false)
+
+    const second = ledger.check(opts)
+    expect(second.isDuplicate).toBe(true)
+    expect(second.dedup_key).toBe(first.dedup_key)
+    expect(second.existing).toBeDefined()
+    expect(second.existing!.hit_count).toBe(2)
+  })
+
+  it('allows same content after window expires', () => {
+    // Use a very short window for testing
+    const shortLedger = new SuppressionLedger(1) // 1ms window
+
+    const opts = {
+      category: 'status-update',
+      channel: 'general',
+      from: 'system',
+      content: 'Status: all systems operational',
+    }
+
+    shortLedger.check(opts)
+
+    // Force the ledger entry to be old by directly updating DB
+    const db = getDb()
+    db.prepare('UPDATE suppression_ledger SET last_seen_at = last_seen_at - 10000').run()
+
+    const result = shortLedger.check(opts)
+    expect(result.isDuplicate).toBe(false)
+  })
+
+  it('generates different keys for different categories', () => {
+    const base = {
+      channel: 'ops',
+      from: 'system',
+      content: 'Same content here',
+    }
+
+    const key1 = ledger.computeDedupKey('watchdog-alert', base.channel, base.content)
+    const key2 = ledger.computeDedupKey('status-update', base.channel, base.content)
+    expect(key1).not.toBe(key2)
+  })
+
+  it('generates different keys for different channels', () => {
+    const key1 = ledger.computeDedupKey('alert', 'ops', 'Same content')
+    const key2 = ledger.computeDedupKey('alert', 'general', 'Same content')
+    expect(key1).not.toBe(key2)
+  })
+
+  it('normalizes timestamps and task IDs in content', () => {
+    const key1 = ledger.computeDedupKey('alert', 'ops', 'Task task-1772037188030-abc is overdue at 1772037188030')
+    const key2 = ledger.computeDedupKey('alert', 'ops', 'Task task-9999999999999-xyz is overdue at 9999999999999')
+    expect(key1).toBe(key2)
+  })
+
+  it('getStats returns correct counts', () => {
+    const opts1 = { category: 'watchdog-alert', channel: 'ops', from: 'system', content: 'Alert 1' }
+    const opts2 = { category: 'status-update', channel: 'general', from: 'system', content: 'Status 1' }
+
+    ledger.check(opts1)
+    ledger.check(opts1) // duplicate
+    ledger.check(opts2)
+
+    const stats = ledger.getStats()
+    expect(stats.total_entries).toBe(2) // 2 unique
+    expect(stats.total_suppressed).toBe(1) // 1 duplicate hit
+    expect(stats.total_hits).toBe(3) // 1+2=3 total hits
+    expect(stats.by_category['watchdog-alert']).toBeDefined()
+    expect(stats.by_category['watchdog-alert'].hits).toBe(2)
+    expect(stats.by_channel['ops']).toBeDefined()
+    expect(stats.by_channel['general']).toBeDefined()
+  })
+
+  it('prune removes old entries', () => {
+    ledger.check({ category: 'alert', channel: 'ops', from: 'system', content: 'Old alert' })
+
+    // Make entry very old
+    const db = getDb()
+    db.prepare('UPDATE suppression_ledger SET last_seen_at = 1000').run()
+
+    const pruned = ledger.prune()
+    expect(pruned).toBe(1)
+
+    const stats = ledger.getStats()
+    expect(stats.total_entries).toBe(0)
+  })
+
+  it('persists across ledger instances', () => {
+    const opts = { category: 'alert', channel: 'ops', from: 'system', content: 'Persistent check' }
+
+    const ledger1 = new SuppressionLedger(30 * 60 * 1000)
+    ledger1.check(opts)
+
+    // New instance should see the entry
+    const ledger2 = new SuppressionLedger(30 * 60 * 1000)
+    const result = ledger2.check(opts)
+    expect(result.isDuplicate).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

System messages (ready-queue warnings, SLA alerts, SHIP notices) were slipping through the 5-minute dedup window because they fire every few minutes. This extends the system message dedup to 30 minutes and adds a persistent SQLite-backed suppression ledger.

## Changes

- **chat.ts**: System messages use 30m dedup window (non-system stays 5m), better normalization (strip @mentions, counts, task IDs), explicit `dedup_key` support in metadata, suppression stats tracking
- **suppression-ledger.ts**: Persistent SQLite-backed dedup ledger with hit counting, window configuration, and pruning
- **db.ts**: Migration v14 — `suppression_ledger` table + `dedup_key` column on `chat_messages`
- **server.ts**: `GET /chat/suppression/stats` (inline dedup + ledger stats) + `POST /chat/suppression/prune`
- **docs.md**: Both endpoints documented
- **15 new tests** (6 chat-dedup + 9 suppression-ledger), 1278 total passing

## Impact

This directly addresses the token/context usage problem: duplicate system messages were burning agent context tokens on repeated ready-queue warnings, SLA alerts, and SHIP notices. The 30m window means agents see each alert once instead of every 5 minutes.

Task: task-1772057670075-fvynz2nxp
Reviewer: @ryan