### PR TITLE
feat: GET /tasks/active + inbox compact mode

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -125,7 +125,8 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | POST | `/tasks` | Create task. Required: `title`, `createdBy`, `assignee`, `reviewer`, `done_criteria` (string[]), `eta`. Optional: `description`, `priority` (P0-P3), `status`, `tags`, `metadata`. **Reflection-origin invariant:** `metadata.source_reflection` or `metadata.source_insight` required (or `metadata.reflection_exempt=true` with `reflection_exempt_reason`). Status contract: `validating` also requires `metadata.artifact_path` under `process/`. |
 | PATCH | `/tasks/:id` | Update task (partial). Any task field, plus optional `actor` for history attribution. Status contract: `doing` requires reviewer + `metadata.eta`; `validating` requires `metadata.artifact_path` under `process/` (workspace-agnostic). |
 | DELETE | `/tasks/:id` | Delete task |
-| GET | `/tasks/next` | Pull-based assignment. Query: `agent` |
+| GET | `/tasks/next` | Pull-based assignment. Query: `agent`, `compact` |
+| GET | `/tasks/active` | Get active (doing) task for agent. Query: `agent`, `compact`. Returns null if no doing tasks. |
 | GET | `/me/:agent` | Agent "My Now" cockpit payload: assigned tasks, pending reviews, blockers, failing-check signals, since-last-seen changelog, and next action |
 | GET | `/tasks/intake-schema` | Task intake schema discovery — returns required/optional fields and per-type templates |
 | GET | `/tasks/templates/:type` | Get task creation template for a specific type (e.g. `feature`, `bug`, `chore`) |
@@ -252,7 +253,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/inbox/:agent` | Get inbox. Query: `limit`, `since` (epoch ms), `channel` |
+| GET | `/inbox/:agent` | Get inbox. Query: `limit`, `since` (epoch ms), `channel`, `compact` (strips id/reactions/replyCount) |
 | POST | `/inbox/:agent/ack` | Acknowledge messages. Body: `{ "upTo": epochMs }` |
 | POST | `/inbox/:agent/subscribe` | Replace channel subscriptions. Body: `{ "channels": ["reviews", "blockers"] }` |
 | GET | `/inbox/:agent/subscriptions` | List subscriptions |

--- a/src/server.ts
+++ b/src/server.ts
@@ -2930,6 +2930,18 @@ export async function createServer(): Promise<FastifyInstance> {
     
     // Auto-update presence when agent checks inbox
     presenceManager.updatePresence(request.params.agent, 'working')
+
+    const rawQuery = request.query as Record<string, string>
+    if (isCompact(rawQuery)) {
+      const slim = inbox.map(m => ({
+        from: m.from,
+        content: m.content,
+        ts: m.timestamp,
+        ch: m.channel,
+        ...(m.priority ? { priority: m.priority } : {}),
+      }))
+      return { messages: slim, count: slim.length }
+    }
     
     return { messages: inbox, count: inbox.length }
   })
@@ -7580,6 +7592,22 @@ export async function createServer(): Promise<FastifyInstance> {
     const task = taskManager.getNextTask(agent, { includeTest })
     if (!task) {
       return { task: null, message: 'No available tasks' }
+    }
+    const enriched = enrichTaskWithComments(task)
+    return { task: isCompact(query) ? compactTask(enriched) : enriched }
+  })
+
+  // Get active (doing) task for an agent
+  app.get('/tasks/active', async (request) => {
+    const query = request.query as Record<string, string>
+    const agent = query.agent
+    if (!agent) {
+      return { task: null, message: 'agent query param required' }
+    }
+    const doingTasks = taskManager.listTasks({ status: 'doing', assignee: agent })
+    const task = doingTasks[0] || null
+    if (!task) {
+      return { task: null, message: 'No active tasks' }
     }
     const enriched = enrichTaskWithComments(task)
     return { task: isCompact(query) ? compactTask(enriched) : enriched }

--- a/tests/tasks-active-inbox-compact.test.ts
+++ b/tests/tasks-active-inbox-compact.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for GET /tasks/active and inbox compact mode.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+const AGENT = `active-test-${Date.now()}`
+let taskId: string
+
+beforeAll(async () => {
+  process.env.REFLECTT_DATA_DIR = `/tmp/reflectt-test-active-${Date.now()}`
+  app = await createServer()
+  await app.ready()
+
+  // Create and move a task to doing
+  const createRes = await app.inject({
+    method: 'POST', url: '/tasks',
+    payload: {
+      title: 'Active task test',
+      description: 'Description for testing',
+      assignee: AGENT,
+      reviewer: 'ryan',
+      priority: 'P2',
+      createdBy: AGENT,
+      eta: '~1h',
+      done_criteria: ['test passes'],
+      metadata: { lane: 'test', wip_override: true },
+    },
+  })
+  taskId = JSON.parse(createRes.body).task.id
+
+  await app.inject({
+    method: 'PATCH', url: `/tasks/${taskId}`,
+    payload: { status: 'doing' },
+  })
+
+  // Seed an inbox message
+  await app.inject({
+    method: 'POST', url: '/chat/messages',
+    payload: { from: 'kai', content: `@${AGENT} heads up on task-123`, channel: 'general' },
+  })
+})
+
+describe('GET /tasks/active', () => {
+  it('returns active task for agent', async () => {
+    const res = await app.inject({ method: 'GET', url: `/tasks/active?agent=${AGENT}` })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.task).toBeDefined()
+    expect(body.task.id).toBe(taskId)
+    expect(body.task.status).toBe('doing')
+  })
+
+  it('returns null when no active tasks', async () => {
+    const res = await app.inject({ method: 'GET', url: '/tasks/active?agent=nobody-agent' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.task).toBeNull()
+  })
+
+  it('supports compact mode', async () => {
+    const full = await app.inject({ method: 'GET', url: `/tasks/active?agent=${AGENT}` })
+    const compact = await app.inject({ method: 'GET', url: `/tasks/active?agent=${AGENT}&compact=true` })
+    const fullBody = JSON.parse(full.body)
+    const compactBody = JSON.parse(compact.body)
+
+    expect(fullBody.task.metadata).toBeDefined()
+    expect(fullBody.task.description).toBeDefined()
+    expect(compactBody.task.metadata).toBeUndefined()
+    expect(compactBody.task.description).toBeUndefined()
+    expect(compactBody.task.id).toBe(taskId)
+  })
+
+  it('requires agent param', async () => {
+    const res = await app.inject({ method: 'GET', url: '/tasks/active' })
+    const body = JSON.parse(res.body)
+    expect(body.task).toBeNull()
+  })
+})
+
+describe('GET /inbox/:agent compact mode', () => {
+  it('returns full messages by default', async () => {
+    const res = await app.inject({ method: 'GET', url: `/inbox/${AGENT}` })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    if (body.messages.length > 0) {
+      expect(body.messages[0].id).toBeDefined()
+      expect(body.messages[0].reactions).toBeDefined()
+    }
+  })
+
+  it('returns slim messages with compact=true', async () => {
+    const res = await app.inject({ method: 'GET', url: `/inbox/${AGENT}?compact=true` })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    if (body.messages.length > 0) {
+      const msg = body.messages[0]
+      expect(msg.from).toBeDefined()
+      expect(msg.content).toBeDefined()
+      expect(msg.ts).toBeDefined()
+      expect(msg.ch).toBeDefined()
+      // Stripped fields
+      expect(msg.id).toBeUndefined()
+      expect(msg.reactions).toBeUndefined()
+      expect(msg.replyCount).toBeUndefined()
+    }
+  })
+
+  it('compact is smaller than full', async () => {
+    const full = await app.inject({ method: 'GET', url: `/inbox/${AGENT}` })
+    const compact = await app.inject({ method: 'GET', url: `/inbox/${AGENT}?compact=true` })
+    expect(compact.body.length).toBeLessThanOrEqual(full.body.length)
+  })
+})


### PR DESCRIPTION
## What

Two fixes for agent heartbeat efficiency:

### 1. GET /tasks/active?agent=X (NEW)
Agents' HEARTBEAT.md instructs them to call `/tasks/active?agent=link` — but that endpoint didn't exist! Every heartbeat got a 404. Now returns the agent's `doing` task (or null). Supports `?compact=true`.

### 2. GET /inbox/:agent?compact=true
Inbox messages now support compact mode — strips id/reactions/replyCount, returns slim format (`from/content/ts/ch/priority`).

## Changes
- **server.ts**: New `GET /tasks/active` endpoint + inbox compact mode
- **docs.md**: Both documented
- **7 new tests**, 1299 total passing, route-docs 356/356

Reviewer: @ryan