### PR TITLE
feat: compact mode for chat/messages, insights, and loop/summary

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -202,7 +202,7 @@ Graceful degradation: if GitHub API is unavailable, the merge check is skipped (
 | GET | `/chat/ws` | WebSocket — real-time chat |
 | GET | `/ws/stats` | WebSocket heartbeat stats (connections, ping/pong health, cleanup stats) |
 | POST | `/chat/messages` | Post message. Body: `from` (required), `content` (required), `channel`, `replyTo` |
-| GET | `/chat/messages` | Message history. Query: `channel`, `limit`, `before`, `after` |
+| GET | `/chat/messages` | Message history. Query: `channel`, `limit`, `before`, `after`, `compact` (slim: from/content/ts/ch only) |
 | GET | `/chat/context/:agent` | Compact, deduplicated chat context for agent injection. Prioritizes mentions, deduplicates system alerts, slim format. Query: `limit` (default 30), `channel`, `since` (epoch ms, default 4h). |
 | PATCH | `/chat/messages/:id` | Edit message (author-only). Body: `from`, `content` |
 | DELETE | `/chat/messages/:id` | Delete message (author-only). Body: `from` |
@@ -461,7 +461,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/insights/ingest` | Ingest a reflection into clustering. Body: `{ reflection_id }`. Cluster key auto-derived from reflection tags/content. Promotion gate: 2 independent reflections (distinct authors) OR severity high/critical. 24h cooldown after promotion. |
-| GET | `/insights` | List insights. Query: `status` (candidate\|promoted\|pending_triage\|task_created\|cooldown\|closed), `priority` (P0-P3), `workflow_stage`, `failure_family`, `impacted_unit`, `limit`, `offset`. Sorted by score desc. |
+| GET | `/insights` | List insights. Supports `compact=true` (slim: id/title/score/priority/status/task_id/independent_count). Query: `status` (candidate\|promoted\|pending_triage\|task_created\|cooldown\|closed), `priority` (P0-P3), `workflow_stage`, `failure_family`, `impacted_unit`, `limit`, `offset`. Sorted by score desc. |
 | GET | `/insights/bridge/stats` | Insight→Task bridge stats: auto-created count, triaged count, duplicates skipped, errors. |
 | GET | `/insights/bridge/config` | Current bridge config including ownership guardrail settings. |
 | PATCH | `/insights/bridge/config` | Update bridge config. Body: partial config object (e.g. `{ ownershipGuardrail: { enabled: false } }`). |
@@ -478,7 +478,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | GET | `/insights/promotions` | List all promotion audit entries. Query: `limit`. |
 | GET | `/insights/recurring/candidates` | List recurring task candidates from insights with persistent patterns. Auto-suggests owner/lane per failure family. Template-first (no auto task spam). |
 | GET | `/insights/top` | Top pain clusters by frequency within a time window. Query: `window` (e.g. `7d`, `24h`, `2w`; default `7d`), `limit` (1-50, default 10). Returns `{ clusters: [{ cluster_key, count, avg_score, last_seen_at, linked_task_ids }], window, since, limit }`. |
-| GET | `/loop/summary` | Top signals from the reflection→insight→task loop. Returns insights ranked by score, each with linked task details and evidence status. Query: `limit` (1-100, default 20), `min_score` (minimum score threshold, default 0), `exclude_addressed=1` (skip insights in cooldown/closed status or whose linked task is done/validating). Response: `{ success, entries[], total, filters }`. Each entry: `insight_id`, `title`, `score`, `priority`, `status`, `workflow_stage`, `failure_family`, `impacted_unit`, `independent_count`, `authors[]`, `evidence_count`, `evidence_refs[]`, `linked_task { id, title, status, assignee }`, `addressed`, `created_at`, `updated_at`. |
+| GET | `/loop/summary` | Supports `compact=true` (strips evidence_refs, slim linked_task). Top signals from the reflection→insight→task loop. Returns insights ranked by score, each with linked task details and evidence status. Query: `limit` (1-100, default 20), `min_score` (minimum score threshold, default 0), `exclude_addressed=1` (skip insights in cooldown/closed status or whose linked task is done/validating). Response: `{ success, entries[], total, filters }`. Each entry: `insight_id`, `title`, `score`, `priority`, `status`, `workflow_stage`, `failure_family`, `impacted_unit`, `independent_count`, `authors[]`, `evidence_count`, `evidence_refs[]`, `linked_task { id, title, status, assignee }`, `addressed`, `created_at`, `updated_at`. |
 
 ### Example: `/insights/top`
 

--- a/tests/compact-endpoints.test.ts
+++ b/tests/compact-endpoints.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for compact mode across chat messages, insights, and loop/summary.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  process.env.REFLECTT_DATA_DIR = `/tmp/reflectt-test-compact-ep-${Date.now()}`
+  app = await createServer()
+  await app.ready()
+
+  // Seed chat messages
+  await app.inject({
+    method: 'POST', url: '/chat/messages',
+    payload: { from: 'link', content: 'Testing compact endpoints', channel: 'general' },
+  })
+})
+
+describe('GET /chat/messages?compact=true', () => {
+  it('returns slim messages', async () => {
+    const res = await app.inject({ method: 'GET', url: '/chat/messages?channel=general&compact=true' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.messages.length).toBeGreaterThan(0)
+    const msg = body.messages[0]
+    expect(msg.from).toBeDefined()
+    expect(msg.content).toBeDefined()
+    expect(msg.ts).toBeDefined()
+    expect(msg.ch).toBeDefined()
+    expect(msg.id).toBeUndefined()
+    expect(msg.reactions).toBeUndefined()
+    expect(msg.replyCount).toBeUndefined()
+  })
+
+  it('returns full messages without compact', async () => {
+    const res = await app.inject({ method: 'GET', url: '/chat/messages?channel=general' })
+    const body = JSON.parse(res.body)
+    const msg = body.messages[0]
+    expect(msg.id).toBeDefined()
+    expect(msg.timestamp).toBeDefined()
+  })
+
+  it('compact is smaller', async () => {
+    const full = await app.inject({ method: 'GET', url: '/chat/messages?channel=general' })
+    const compact = await app.inject({ method: 'GET', url: '/chat/messages?channel=general&compact=true' })
+    expect(compact.body.length).toBeLessThan(full.body.length)
+  })
+})
+
+describe('GET /loop/summary?compact=true', () => {
+  it('returns slim entries without evidence_refs', async () => {
+    // Seed a reflection to generate an insight
+    await app.inject({
+      method: 'POST', url: '/reflections',
+      payload: {
+        pain: 'Tests are slow',
+        impact: 'high',
+        evidence: ['CI takes 10 minutes'],
+        went_well: 'Coverage is good',
+        suspected_why: 'Too many integration tests',
+        proposed_fix: 'Add unit test tier',
+        confidence: 7,
+        role_type: 'engineer',
+        author: 'link',
+      },
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/loop/summary?compact=true' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    if (body.entries.length > 0) {
+      const entry = body.entries[0]
+      expect(entry.insight_id).toBeDefined()
+      expect(entry.title).toBeDefined()
+      expect(entry.score).toBeDefined()
+      // Heavy fields stripped
+      expect(entry.evidence_refs).toBeUndefined()
+      expect(entry.authors).toBeUndefined()
+      expect(entry.workflow_stage).toBeUndefined()
+    }
+  })
+
+  it('full response has evidence_refs', async () => {
+    const res = await app.inject({ method: 'GET', url: '/loop/summary' })
+    const body = JSON.parse(res.body)
+    if (body.entries.length > 0) {
+      expect(body.entries[0].evidence_refs).toBeDefined()
+    }
+  })
+})
+
+describe('GET /insights?compact=true', () => {
+  it('returns slim insights', async () => {
+    const res = await app.inject({ method: 'GET', url: '/insights?compact=true' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    if (body.insights && body.insights.length > 0) {
+      const insight = body.insights[0]
+      expect(insight.id).toBeDefined()
+      expect(insight.title).toBeDefined()
+      expect(insight.score).toBeDefined()
+      // Heavy fields stripped
+      expect(insight.evidence_refs).toBeUndefined()
+      expect(insight.reflection_ids).toBeUndefined()
+      expect(insight.authors).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## What

Extends `?compact=true` to three more heavy endpoints:

| Endpoint | Full size | Compact size | Reduction |
|---|---|---|---|
| `/loop/summary` | 29K chars (7K tok) | ~7K chars (1.7K tok) | **75%** |
| `/chat/messages` | 18K chars (4.5K tok) | 14K chars (3.5K tok) | 22% |
| `/insights` | 7K chars (1.8K tok) | ~2K chars (0.5K tok) | ~70% |

The `/loop/summary` win is the biggest — `evidence_refs` alone is 17K of the 29K response.

## Changes
- **server.ts**: Add compact mode to `/chat/messages`, `/insights`, `/loop/summary`
- **docs.md**: All three documented
- **6 new tests**, 1311 total passing, route-docs 357/357

Reviewer: @ryan