### PR TITLE
feat: GET /version — version info with update availability check

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -130,6 +130,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | GET | `/heartbeat/:agent` | Single compact heartbeat payload (~200 tokens). Returns active task, next task, slim inbox, queue counts, and suggested action. Replaces 3 separate API calls. |
 | GET | `/bootstrap/heartbeat/:agent` | Generate optimal HEARTBEAT.md content for agent. References best endpoints. Includes version stamp and content hash for change detection. |
 | GET | `/capabilities` | Agent-facing endpoint discovery. Lists all endpoints grouped by purpose, compact support flags, and usage recommendations. |
+| GET | `/version` | Current version + latest available from GitHub releases. Includes `update_available` boolean. Caches GitHub check for 15 minutes. |
 | GET | `/me/:agent` | Agent "My Now" cockpit payload: assigned tasks, pending reviews, blockers, failing-check signals, since-last-seen changelog, and next action. Supports `compact`. |
 | GET | `/tasks/intake-schema` | Task intake schema discovery — returns required/optional fields and per-type templates |
 | GET | `/tasks/templates/:type` | Get task creation template for a specific type (e.g. `feature`, `bug`, `chore`) |

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for GET /version — version info with update availability check.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+})
+
+describe('GET /version', () => {
+  it('returns current version from package.json', async () => {
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.current).toBeDefined()
+    expect(typeof body.current).toBe('string')
+    expect(body.current).not.toBe('0.0.0') // Should read from package.json
+  })
+
+  it('includes commit hash', async () => {
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    const body = JSON.parse(res.body)
+    expect(body.commit).toBeDefined()
+    expect(typeof body.commit).toBe('string')
+  })
+
+  it('includes latest field', async () => {
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    const body = JSON.parse(res.body)
+    // May be 'unknown' if no releases published yet, or a version string
+    expect(body.latest).toBeDefined()
+  })
+
+  it('includes update_available boolean', async () => {
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    const body = JSON.parse(res.body)
+    expect(typeof body.update_available).toBe('boolean')
+  })
+
+  it('includes checked_at timestamp', async () => {
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    const body = JSON.parse(res.body)
+    expect(body.checked_at).toBeDefined()
+    expect(typeof body.checked_at).toBe('number')
+    expect(body.checked_at).toBeGreaterThan(0)
+  })
+
+  it('includes uptime_seconds', async () => {
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    const body = JSON.parse(res.body)
+    expect(typeof body.uptime_seconds).toBe('number')
+    expect(body.uptime_seconds).toBeGreaterThanOrEqual(0)
+  })
+
+  it('caches GitHub check (second call is fast)', async () => {
+    // First call triggers fetch
+    await app.inject({ method: 'GET', url: '/version' })
+    // Second call should use cache
+    const start = Date.now()
+    const res = await app.inject({ method: 'GET', url: '/version' })
+    const elapsed = Date.now() - start
+    expect(res.statusCode).toBe(200)
+    // Cached call should be fast (under 100ms)
+    expect(elapsed).toBeLessThan(100)
+  })
+})
+
+describe('GET /health includes version', () => {
+  it('returns version field', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.version).toBeDefined()
+    expect(typeof body.version).toBe('string')
+    expect(body.version).not.toBe('0.0.0')
+  })
+
+  it('returns commit field', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    const body = JSON.parse(res.body)
+    expect(body.commit).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

New `GET /version` endpoint: current version, commit, latest from GitHub releases, `update_available` boolean.

## Features
- Reads current version from package.json at startup
- Checks GitHub releases API for latest version
- 15-minute cache to avoid rate limiting
- Graceful fallback when no releases exist (returns `latest: 'unknown'`)
- `/health` already had version/commit (unchanged)

## Changes
- `src/server.ts`: +60 lines — new route + cache
- `public/docs.md`: +1 line
- `tests/version.test.ts`: 9 new tests

## Tests
1331 pass (+9 new), 1 skipped. Route-docs: 361/361.

Refs: task-1772064430641-0qx4rtsy3