### PR TITLE
feat: markdown 404 responses with endpoint discovery

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1643,6 +1643,44 @@ export async function createServer(): Promise<FastifyInstance> {
     await healthMonitor.recordSnapshot().catch(() => {}) // Silent fail
   })
 
+  // ── Global 404: markdown-formatted endpoint discovery ────────────────
+  app.setNotFoundHandler(async (request, reply) => {
+    const method = request.method
+    const url = request.url.split('?')[0]
+
+    const md = [
+      `# 404 — \`${method} ${url}\` not found`,
+      '',
+      `reflectt-node v${BUILD_VERSION} does not have this endpoint.`,
+      '',
+      '## Quick Reference',
+      '',
+      '| Method | Endpoint | Description |',
+      '|--------|----------|-------------|',
+      '| GET | `/health` | System health + version + stats |',
+      '| GET | `/version` | Current version + update availability |',
+      '| GET | `/capabilities` | Full endpoint discovery with compact flags |',
+      '| GET | `/tasks?compact=true` | List tasks (slim) |',
+      '| GET | `/tasks/active?agent=NAME&compact=true` | Current doing task |',
+      '| GET | `/tasks/next?agent=NAME&compact=true` | Pull next task |',
+      '| GET | `/tasks/:id` | Task details |',
+      '| PATCH | `/tasks/:id` | Update task |',
+      '| POST | `/tasks/:id/comments` | Add comment |',
+      '| GET | `/inbox/:agent` | Agent inbox |',
+      '| GET | `/chat/messages` | Chat messages |',
+      '| GET | `/chat/context/:agent` | Compact chat context |',
+      '| GET | `/insights?compact=true` | Insights list |',
+      '| GET | `/loop/summary` | Top reflection signals |',
+      '| GET | `/bootstrap/heartbeat/:agent` | Generate HEARTBEAT.md |',
+      '| GET | `/me/:agent` | Agent dashboard |',
+      '',
+      '> Use `GET /capabilities` for the complete list with descriptions.',
+    ].join('\n')
+
+    reply.code(404).header('content-type', 'text/markdown; charset=utf-8')
+    return md
+  })
+
   // Load agent roles from YAML config (or fall back to built-in defaults)
   loadAgentRoles()
   startConfigWatch()

--- a/tests/markdown-404.test.ts
+++ b/tests/markdown-404.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for markdown 404 error responses with endpoint discovery.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+})
+
+describe('Markdown 404 responses', () => {
+  it('returns markdown for unknown GET endpoint', async () => {
+    const res = await app.inject({ method: 'GET', url: '/nonexistent' })
+    expect(res.statusCode).toBe(404)
+    expect(res.headers['content-type']).toContain('text/markdown')
+    expect(res.body).toContain('# 404')
+    expect(res.body).toContain('`GET /nonexistent`')
+  })
+
+  it('returns markdown for unknown POST endpoint', async () => {
+    const res = await app.inject({ method: 'POST', url: '/does-not-exist' })
+    expect(res.statusCode).toBe(404)
+    expect(res.headers['content-type']).toContain('text/markdown')
+    expect(res.body).toContain('`POST /does-not-exist`')
+  })
+
+  it('includes version in the response', async () => {
+    const res = await app.inject({ method: 'GET', url: '/nonexistent' })
+    expect(res.body).toContain('reflectt-node v')
+  })
+
+  it('includes endpoint table with key routes', async () => {
+    const res = await app.inject({ method: 'GET', url: '/nonexistent' })
+    expect(res.body).toContain('/health')
+    expect(res.body).toContain('/capabilities')
+    expect(res.body).toContain('/tasks')
+    expect(res.body).toContain('/inbox/:agent')
+    expect(res.body).toContain('/chat/messages')
+    expect(res.body).toContain('/bootstrap/heartbeat/:agent')
+  })
+
+  it('points to /capabilities for full listing', async () => {
+    const res = await app.inject({ method: 'GET', url: '/nonexistent' })
+    expect(res.body).toContain('`GET /capabilities`')
+  })
+
+  it('strips query params from URL in heading', async () => {
+    const res = await app.inject({ method: 'GET', url: '/nonexistent?foo=bar&baz=1' })
+    expect(res.body).toContain('`GET /nonexistent`')
+    expect(res.body).not.toContain('foo=bar')
+  })
+
+  it('existing endpoints still work normally', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.status).toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary

Global 404 handler returns markdown-formatted guidance instead of bare JSON. Agents hitting wrong URLs get immediate endpoint discovery.

## Example

```
GET /nonexistent → 404 text/markdown

# 404 — `GET /nonexistent` not found

reflectt-node v0.1.0 does not have this endpoint.

## Quick Reference

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/health` | System health + version + stats |
| GET | `/capabilities` | Full endpoint discovery... |
...

> Use `GET /capabilities` for the complete list.
```

## Changes
- `src/server.ts`: +38 lines — `setNotFoundHandler` with markdown table
- `tests/markdown-404.test.ts`: 7 new tests

## Tests
1338 pass (+7 new), 1 skipped. Route-docs: 361/361.

Refs: task-1772066940960-37td6p5oe