### PR TITLE
feat: reflection dedup — reject identical reflections within 1h window

### DIFF
--- a/tests/reflection-dedup.test.ts
+++ b/tests/reflection-dedup.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+const VALID_REFLECTION = {
+  author: 'dedup-test-agent',
+  role_type: 'agent',
+  confidence: 7,
+  pain: 'Test pain for dedup verification',
+  impact: 'Test impact',
+  evidence: ['evidence item 1', 'evidence item 2'],
+  went_well: 'Test went well',
+  suspected_why: 'Test suspected why',
+  proposed_fix: 'Test proposed fix',
+}
+
+describe('Reflection dedup', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    app = await createServer()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  it('accepts the first reflection', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reflections',
+      payload: VALID_REFLECTION,
+    })
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.reflection.id).toBeTruthy()
+  })
+
+  it('rejects identical reflection from same author within dedup window', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reflections',
+      payload: VALID_REFLECTION,
+    })
+    expect(res.statusCode).toBe(409)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(false)
+    expect(body.code).toBe('DUPLICATE_REFLECTION')
+    expect(body.dedup_hash).toBeTruthy()
+    expect(body.hint).toContain('dedup-test-agent')
+  })
+
+  it('accepts same content from a different author', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reflections',
+      payload: { ...VALID_REFLECTION, author: 'dedup-test-agent-2' },
+    })
+    expect(res.statusCode).toBe(201)
+  })
+
+  it('accepts different content from same author', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reflections',
+      payload: { ...VALID_REFLECTION, pain: 'Completely different pain point' },
+    })
+    expect(res.statusCode).toBe(201)
+  })
+
+  it('dedup is case-insensitive and whitespace-normalized', async () => {
+    // First submission with altered case/whitespace
+    const res1 = await app.inject({
+      method: 'POST',
+      url: '/reflections',
+      payload: { ...VALID_REFLECTION, author: 'case-test', pain: '  Case Test Pain  ' },
+    })
+    expect(res1.statusCode).toBe(201)
+
+    // Same content with different casing
+    const res2 = await app.inject({
+      method: 'POST',
+      url: '/reflections',
+      payload: { ...VALID_REFLECTION, author: 'case-test', pain: 'case test pain' },
+    })
+    expect(res2.statusCode).toBe(409)
+  })
+})


### PR DESCRIPTION
## Problem
A link session submitted the same reflection 18+ times. No dedup existed.

## Fix
Content-hash dedup on POST /reflections. SHA-256 of normalized author+pain+evidence. 1h window. Returns 409 DUPLICATE_REFLECTION. In-memory map with periodic cleanup.

## Tests
5 new tests. 87 files, 1350 passed. Route-docs: 361/361 ✅

Task: task-1772069350968-84xhq7dn9