### PR TITLE
feat: include tcomment id in [task-comment] chat emissions

### DIFF
--- a/src/messageRouter.ts
+++ b/src/messageRouter.ts
@@ -191,11 +191,15 @@ export async function routeMessage(msg: RoutedMessage): Promise<RoutingResult> {
   // Send to resolved channel (skip if this was purely a task-comment route and comment failed)
   const skipChat = taskCommentFailed && decision.reason === 'status-update-to-task-comment'
   if (!skipChat) {
+    // Append tcomment id for traceability when comment was successfully created
+    const chatContent = commentId
+      ? `${msg.content} [tcomment:${commentId}]`
+      : msg.content
     try {
       const sent = await chatManager.sendMessage({
         from: msg.from,
         channel: decision.channel,
-        content: msg.content,
+        content: chatContent,
       })
       messageId = sent?.id || null
     } catch {

--- a/tests/tcomment-traceability.test.ts
+++ b/tests/tcomment-traceability.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock taskManager and chatManager before importing routeMessage
+const mockAddTaskComment = vi.fn()
+const mockSendMessage = vi.fn()
+
+vi.mock('../src/tasks.js', () => ({
+  taskManager: {
+    addTaskComment: (...args: any[]) => mockAddTaskComment(...args),
+  },
+}))
+
+vi.mock('../src/chat.js', () => ({
+  chatManager: {
+    sendMessage: (...args: any[]) => mockSendMessage(...args),
+  },
+}))
+
+describe('tcomment traceability in chat emissions', () => {
+  beforeEach(() => {
+    mockAddTaskComment.mockReset()
+    mockSendMessage.mockReset()
+  })
+
+  it('includes tcomment id in chat message when comment succeeds', async () => {
+    const { routeMessage } = await import('../src/messageRouter.js')
+
+    mockAddTaskComment.mockResolvedValue({ id: 'tcomment-abc123' })
+    mockSendMessage.mockResolvedValue({ id: 'msg-xyz' })
+
+    const result = await routeMessage({
+      from: 'link',
+      content: 'Status update on task',
+      category: 'status-update',
+      severity: 'info',
+      taskId: 'task-123',
+    })
+
+    // Chat message should include the tcomment id
+    const sentContent = mockSendMessage.mock.calls[0]?.[0]?.content || ''
+    expect(sentContent).toContain('[tcomment:tcomment-abc123]')
+    expect(result.commentId).toBe('tcomment-abc123')
+  })
+
+  it('does not include tcomment tag when no comment created', async () => {
+    const { routeMessage } = await import('../src/messageRouter.js')
+
+    mockSendMessage.mockResolvedValue({ id: 'msg-xyz' })
+
+    const result = await routeMessage({
+      from: 'link',
+      content: 'General message no task',
+      category: 'system-info',
+      severity: 'info',
+    })
+
+    const sentContent = mockSendMessage.mock.calls[0]?.[0]?.content || ''
+    expect(sentContent).not.toContain('[tcomment:')
+  })
+})


### PR DESCRIPTION
## What

When messageRouter successfully creates a task comment, the emitted chat message now includes `[tcomment:<id>]` for traceability.

**Before:** `@link [task-comment:task-xxx] Starting work on this`
**After:** `@link [task-comment:task-xxx] Starting work on this [tcomment:tcomment-abc123]`

## Why

Debugging phantom/orphaned chat lines requires mapping chat → DB comment. Without the tcomment id, this requires timestamp correlation which is unreliable.

## Changes
- `src/messageRouter.ts` — append `[tcomment:<id>]` to chat content when commentId exists
- `tests/tcomment-traceability.test.ts` — mock-based regression test

## No behavior change when:
- Comment creation fails (still no chat emission per PR #397)
- No taskId present (no comment attempted)

Fixes task-1772080447476-z9kpn6h46