### PR TITLE
fix: add reflection metadata to internal task creation callers

### DIFF
--- a/process/TASK-z16dkyu8o-reflection-origin-gate.md
+++ b/process/TASK-z16dkyu8o-reflection-origin-gate.md
@@ -1,0 +1,32 @@
+# Task z16dkyu8o — Reflection-Origin Gate on Task Creation
+
+## Summary
+
+Enforces that all tasks created via `POST /tasks` must trace back to a reflection or insight, unless explicitly exempted with a reason.
+
+## What Was Already Done
+
+The core validation was already implemented in `checkDefinitionOfReady()` (server.ts lines ~247-263):
+- Checks for `metadata.source_reflection`, `metadata.source_insight`, or `metadata.source === 'reflection_pipeline'`
+- If `metadata.reflection_exempt === true`, requires `metadata.reflection_exempt_reason`
+- Enforced on both `POST /tasks` and `POST /tasks/batch-create`
+
+Tests existed and pass: `tests/reflection-origin-gate.test.ts` (6 tests covering reject/accept/exempt paths).
+
+## What Was Added
+
+Fixed 3 internal callers that bypass the HTTP-level check to include proper reflection metadata:
+
+1. **Feedback triage** (line ~6862): Added `reflection_exempt: true` + reason "System-created from user feedback triage"
+2. **Insight triage** (line ~7556): Added `source_insight` and `source_reflection` from the insight being triaged (these were missing despite the task originating from an insight)
+3. **Research handoff** (line ~8535): Added `reflection_exempt: true` + reason "System-created from research handoff pipeline"
+
+The orphan insight reconciliation path (line ~7338) already had proper `source_insight`/`source_reflection` metadata.
+
+## Verification
+
+- `tsc --noEmit`: Clean
+- `vitest run tests/reflection-origin-gate.test.ts`: 6/6 pass
+- All done criteria met:
+  - ✅ Task creation rejects without reflection source
+  - ✅ Exempt tasks require reason

--- a/src/server.ts
+++ b/src/server.ts
@@ -6871,6 +6871,8 @@ export async function createServer(): Promise<FastifyInstance> {
       metadata: {
         ...triage.metadata,
         ...(triage.lane ? { lane: triage.lane } : {}),
+        reflection_exempt: true,
+        reflection_exempt_reason: 'System-created from user feedback triage',
       },
     })
 
@@ -7554,6 +7556,8 @@ export async function createServer(): Promise<FastifyInstance> {
         done_criteria: ['Root cause addressed', 'Evidence validated', 'Follow-up reflection submitted'],
         metadata: {
           insight_id: insight.id,
+          source_insight: insight.id,
+          source_reflection: insight.reflection_ids?.[0],
           promotion_reason: 'triage_approved',
           severity: insight.severity_max,
           source: 'triage',
@@ -8526,6 +8530,8 @@ export async function createServer(): Promise<FastifyInstance> {
         metadata: {
           ...(data.metadata || {}),
           eta: data.eta,
+          reflection_exempt: true,
+          reflection_exempt_reason: 'System-created from research handoff pipeline',
           source: {
             kind: 'research-handoff',
             requestId: data.requestId,


### PR DESCRIPTION
## Summary

Hardens internal task creation callers that bypass the HTTP-level `checkDefinitionOfReady` to include proper reflection metadata.

### Changes

1. **Feedback triage** — Added `reflection_exempt: true` + reason
2. **Insight triage** — Added `source_insight` and `source_reflection` from the insight being triaged
3. **Research handoff** — Added `reflection_exempt: true` + reason

### Verification

- `tsc --noEmit`: Clean
- `vitest run tests/reflection-origin-gate.test.ts`: 6/6 pass

Task: task-1772083947911-z16dkyu8o