### PR TITLE
Fix: chat-detected approvals auto-close validating tasks

### DIFF
--- a/tests/chat-approval-detector.test.ts
+++ b/tests/chat-approval-detector.test.ts
@@ -238,7 +238,7 @@ describe('Chat Approval Detector', () => {
       })
 
       getTaskSpy.mockReturnValue(task)
-      updateTaskSpy.mockResolvedValue({ ...task, metadata: { reviewer_approved: true } })
+      updateTaskSpy.mockResolvedValue({ ...task, status: 'done', metadata: { reviewer_approved: true } })
       addCommentSpy.mockResolvedValue(undefined)
 
       const signal: ApprovalSignal = {
@@ -255,6 +255,7 @@ describe('Chat Approval Detector', () => {
       expect(updateTaskSpy).toHaveBeenCalledWith(
         task.id,
         expect.objectContaining({
+          status: 'done',
           metadata: expect.objectContaining({
             reviewer_approved: true,
             review_state: 'approved',
@@ -273,7 +274,7 @@ describe('Chat Approval Detector', () => {
       })
 
       getTaskSpy.mockReturnValue(task)
-      updateTaskSpy.mockResolvedValue({ ...task, metadata: { reviewer_approved: true } })
+      updateTaskSpy.mockResolvedValue({ ...task, status: 'done', metadata: { reviewer_approved: true } })
       addCommentSpy.mockResolvedValue(undefined)
 
       const signal: ApprovalSignal = {
@@ -340,7 +341,7 @@ describe('Chat Approval Detector', () => {
       })
 
       getTaskSpy.mockReturnValue(task)
-      updateTaskSpy.mockResolvedValue({ ...task, metadata: { reviewer_approved: true } })
+      updateTaskSpy.mockResolvedValue({ ...task, status: 'done', metadata: { reviewer_approved: true } })
       addCommentSpy.mockResolvedValue(undefined)
 
       const signal: ApprovalSignal = {


### PR DESCRIPTION
When reviewer approval is detected via chat-approval-detector, we were only setting metadata.reviewer_approved/review_state and leaving the task in validating. That can create 'approved but stuck validating' states.\n\nThis change auto-transitions validating→done when applyApproval() runs, mirroring the behavior of POST /tasks/:id/review.\n\n- Adds auto_closed metadata stamps\n- Updates tests\n\nFixes: task-1772123124672-7iuzfbtcl