### PR TITLE
feat: add SlotManager.subscribe for canvas activity detection

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -288,6 +288,12 @@ export async function startCloudIntegration(): Promise<void> {
     markCloudActivity()
   })
 
+  // Canvas slot updates mark activity (ensures burst mode on canvas changes)
+  slotManager.subscribe(() => {
+    if (!state.running) return
+    markCloudActivity()
+  })
+
   // Canvas sync — adaptive: 5s when active, 60s when idle
   // Uses a single 5s tick that skips when idle (unless enough time has passed)
   let lastCanvasSyncAt = 0


### PR DESCRIPTION
## Problem
PR #419 adaptive sync only detects chat and task activity. Canvas changes don't trigger burst mode because SlotManager had no subscribe API — canvas updates sync on the idle 60s interval even when actively updating.

## Solution
1. **`canvas-slots.ts`** — Added `subscribe(callback)` and `notifySubscribers()` matching the existing chatManager/taskManager pattern
2. **`cloud.ts`** — Wired `slotManager.subscribe(() => markCloudActivity())` so canvas slot upserts trigger burst-mode sync

## Files Changed
- `src/canvas-slots.ts` (+24 lines: subscribers Set, subscribe method, notifySubscribers, stats)
- `src/cloud.ts` (+6 lines: slotManager subscriber)

## Verification
- `tsc --noEmit` clean
- Subscribe pattern matches chatManager (Set-based, returns unsubscribe fn, try/catch in notify)

Closes task-1772143258175-dfoqhaj1g