### PR TITLE
fix(tasks): block duplicate auto-close without canonical refs

### DIFF
--- a/src/duplicateClosureGuard.ts
+++ b/src/duplicateClosureGuard.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Duplicate-closure canonical reference enforcement.
+ *
+ * Why: Auto-close writers (sweeper/automerge/server) can close tasks without
+ * going through interactive precheck flows. If a task is closed as a
+ * "duplicate" without canonical refs, reviewers get churny N/A proof packets.
+ */
+
+export type DuplicateClosureMeta = Record<string, unknown>
+
+export function isDuplicateClosure(meta: DuplicateClosureMeta | null | undefined): boolean {
+  if (!meta) return false
+
+  const autoCloseReason = (meta as any).auto_close_reason
+  const hasDupeReason = typeof autoCloseReason === 'string' && autoCloseReason.toLowerCase().includes('duplicate')
+
+  const hasDupeOf = Boolean((meta as any).duplicate_of)
+  const lane = (meta as any).qa_bundle?.lane
+  const hasDupeLane = typeof lane === 'string' && lane === 'duplicate-closure'
+
+  return hasDupeReason || hasDupeOf || hasDupeLane
+}
+
+function firstString(...candidates: unknown[]): string | null {
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim().length > 0) return c.trim()
+  }
+  return null
+}
+
+function isHttpUrl(s: string | null): boolean {
+  return typeof s === 'string' && (s.startsWith('http://') || s.startsWith('https://'))
+}
+
+/**
+ * Throws if a task is being closed as a duplicate without canonical refs.
+ *
+ * Required fields:
+ * - metadata.duplicate_of (canonical task id)
+ * - metadata.canonical_pr (or metadata.review_handoff.pr_url or metadata.pr_url)
+ * - metadata.canonical_commit (or metadata.review_handoff.commit_sha)
+ */
+export function assertDuplicateClosureHasCanonicalRefs(meta: DuplicateClosureMeta | null | undefined): void {
+  if (!isDuplicateClosure(meta)) return
+  const m = (meta || {}) as any
+
+  const dupeOf = firstString(m.duplicate_of)
+  if (!dupeOf) {
+    throw new Error('Duplicate closure requires metadata.duplicate_of (canonical task id)')
+  }
+
+  const canonicalPr = firstString(m.canonical_pr, m.canonicalPr, m.review_handoff?.pr_url, m.pr_url)
+  if (!isHttpUrl(canonicalPr)) {
+    throw new Error('Duplicate closure requires a canonical PR URL (metadata.canonical_pr or review_handoff.pr_url)')
+  }
+
+  const canonicalCommit = firstString(m.canonical_commit, m.canonicalCommit, m.review_handoff?.commit_sha)
+  if (!canonicalCommit || canonicalCommit.length < 7) {
+    throw new Error('Duplicate closure requires metadata.canonical_commit (or review_handoff.commit_sha)')
+  }
+}

--- a/tests/duplicate-closure-auto-close-guard.test.ts
+++ b/tests/duplicate-closure-auto-close-guard.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+import { describe, it, expect } from 'vitest'
+import { taskManager } from '../src/tasks.js'
+
+describe('Duplicate closure canonical-ref enforcement (server-side)', () => {
+  it('rejects closing a task as duplicate without canonical refs', async () => {
+    const task = await taskManager.createTask({
+      title: 'Test: duplicate closure guard',
+      status: 'todo',
+      assignee: 'link',
+      reviewer: 'sage',
+      createdBy: 'test',
+      done_criteria: ['Has canonical refs'],
+    })
+
+    // Missing canonical_pr + canonical_commit
+    await expect(
+      taskManager.updateTask(task.id, {
+        status: 'done',
+        metadata: {
+          auto_closed: true,
+          auto_close_reason: 'duplicate',
+          duplicate_of: 'task-0000000000000-abcdefg',
+        },
+      })
+    ).rejects.toThrow(/canonical PR URL/i)
+
+    // Canonical PR present but commit missing
+    await expect(
+      taskManager.updateTask(task.id, {
+        status: 'done',
+        metadata: {
+          auto_closed: true,
+          auto_close_reason: 'duplicate',
+          duplicate_of: 'task-0000000000000-abcdefg',
+          canonical_pr: 'https://github.com/reflectt/reflectt-node/pull/123',
+        },
+      })
+    ).rejects.toThrow(/canonical_commit/i)
+
+    // All canonical refs present
+    const updated = await taskManager.updateTask(task.id, {
+      status: 'done',
+      metadata: {
+        auto_closed: true,
+        auto_close_reason: 'duplicate',
+        duplicate_of: 'task-0000000000000-abcdefg',
+        canonical_pr: 'https://github.com/reflectt/reflectt-node/pull/123',
+        canonical_commit: 'abc1234',
+      },
+    })
+
+    expect(updated?.status).toBe('done')
+    expect((updated?.metadata as any)?.duplicate_of).toBe('task-0000000000000-abcdefg')
+  })
+})


### PR DESCRIPTION
Implements task-1772167041800-779arc4rl.

## What
Adds a server-side lifecycle gate so a task cannot be closed as a **duplicate** without canonical references:
- requires `metadata.duplicate_of`
- requires `metadata.canonical_pr` (or `review_handoff.pr_url` / `pr_url`)
- requires `metadata.canonical_commit` (or `review_handoff.commit_sha`)

If missing, update throws (auto-close writers fail safely, task remains unchanged).

## Implementation
- `src/duplicateClosureGuard.ts` (shared helper)
- `src/tasks.ts` calls guard when transitioning to `status: done`

## Tests
- `tests/duplicate-closure-auto-close-guard.test.ts`
- `npm run build`

## Before/After example
**Before (bad):** `{ status: "done", metadata: { auto_close_reason: "duplicate", duplicate_of: "task-..." } }`

**After (good):** `{ status: "done", metadata: { auto_close_reason: "duplicate", duplicate_of: "task-...", canonical_pr: "https://.../pull/...", canonical_commit: "abc1234" } }`
