### PR TITLE
fix(tasks): relax duplicate closure gate

### DIFF
--- a/src/duplicateClosureGuard.ts
+++ b/src/duplicateClosureGuard.ts
@@ -36,29 +36,60 @@ function isHttpUrl(s: string | null): boolean {
 }
 
 /**
- * Throws if a task is being closed as a duplicate without canonical refs.
+ * Throws if a task is being closed as a duplicate without canonical proof.
  *
- * Required fields:
- * - metadata.duplicate_of (canonical task id)
- * - metadata.canonical_pr (or metadata.review_handoff.pr_url or metadata.pr_url)
- * - metadata.canonical_commit (or metadata.review_handoff.commit_sha)
+ * Intended acceptance rule (2026-02-26):
+ * - metadata.duplicate_of must be a canonical task id (must start with "task-")
+ * - metadata.duplicate_proof (or duplicate_of.proof) must be present and not "N/A"
+ * - AND at least one of:
+ *   - metadata.canonical_pr (GitHub PR URL) OR
+ *   - metadata.canonical_commit (>=7 hex)
+ *
+ * Fallbacks allowed:
+ * - PR/commit may also come from metadata.review_handoff.{pr_url,commit_sha} or metadata.pr_url
+ *
+ * Note: we do NOT require both PR+commit.
  */
 export function assertDuplicateClosureHasCanonicalRefs(meta: DuplicateClosureMeta | null | undefined): void {
   if (!isDuplicateClosure(meta)) return
   const m = (meta || {}) as any
 
-  const dupeOf = firstString(m.duplicate_of)
-  if (!dupeOf) {
+  const dupeOfId = firstString(
+    m.duplicate_of,
+    m.duplicateOf,
+    m.duplicate_of?.task_id,
+    m.duplicateOf?.task_id,
+  )
+
+  if (!dupeOfId) {
     throw new Error('Duplicate closure requires metadata.duplicate_of (canonical task id)')
   }
 
-  const canonicalPr = firstString(m.canonical_pr, m.canonicalPr, m.review_handoff?.pr_url, m.pr_url)
-  if (!isHttpUrl(canonicalPr)) {
-    throw new Error('Duplicate closure requires a canonical PR URL (metadata.canonical_pr or review_handoff.pr_url)')
+  if (!/^task-/.test(dupeOfId)) {
+    throw new Error('Duplicate closure requires metadata.duplicate_of to be a canonical task id (must start with "task-")')
   }
 
+  const proof = firstString(
+    m.duplicate_proof,
+    m.duplicateProof,
+    m.duplicate_of?.proof,
+    m.duplicateOf?.proof,
+    m.duplicate_of_proof,
+  )
+
+  if (!proof || /^n\/?a$/i.test(proof.trim())) {
+    throw new Error('Duplicate closure requires metadata.duplicate_proof (non-empty, not "N/A")')
+  }
+
+  const canonicalPr = firstString(m.canonical_pr, m.canonicalPr, m.review_handoff?.pr_url, m.pr_url)
   const canonicalCommit = firstString(m.canonical_commit, m.canonicalCommit, m.review_handoff?.commit_sha)
-  if (!canonicalCommit || canonicalCommit.length < 7) {
-    throw new Error('Duplicate closure requires metadata.canonical_commit (or review_handoff.commit_sha)')
+
+  const hasPr = isHttpUrl(canonicalPr)
+  const hasCommit = typeof canonicalCommit === 'string'
+    && canonicalCommit.length >= 7
+    && /^[0-9a-f]+$/i.test(canonicalCommit)
+
+  if (!hasPr && !hasCommit) {
+    throw new Error('Duplicate closure requires canonical_pr (PR URL) or canonical_commit (>=7 hex)')
   }
 }

--- a/tests/duplicate-closure-auto-close-guard.test.ts
+++ b/tests/duplicate-closure-auto-close-guard.test.ts
@@ -4,18 +4,17 @@
 import { describe, it, expect } from 'vitest'
 import { taskManager } from '../src/tasks.js'
 
-describe('Duplicate closure canonical-ref enforcement (server-side)', () => {
-  it('rejects closing a task as duplicate without canonical refs', async () => {
+describe('Duplicate closure canonical proof enforcement (server-side)', () => {
+  it('rejects duplicate_of only (missing proof and pr/commit)', async () => {
     const task = await taskManager.createTask({
       title: 'Test: duplicate closure guard',
       status: 'todo',
       assignee: 'link',
       reviewer: 'sage',
       createdBy: 'test',
-      done_criteria: ['Has canonical refs'],
+      done_criteria: ['Has canonical duplicate closure proof'],
     })
 
-    // Missing canonical_pr + canonical_commit
     await expect(
       taskManager.updateTask(task.id, {
         status: 'done',
@@ -25,34 +24,54 @@ describe('Duplicate closure canonical-ref enforcement (server-side)', () => {
           duplicate_of: 'task-0000000000000-abcdefg',
         },
       })
-    ).rejects.toThrow(/canonical PR URL/i)
+    ).rejects.toThrow(/duplicate_proof/i)
+  })
 
-    // Canonical PR present but commit missing
-    await expect(
-      taskManager.updateTask(task.id, {
-        status: 'done',
-        metadata: {
-          auto_closed: true,
-          auto_close_reason: 'duplicate',
-          duplicate_of: 'task-0000000000000-abcdefg',
-          canonical_pr: 'https://github.com/reflectt/reflectt-node/pull/123',
-        },
-      })
-    ).rejects.toThrow(/canonical_commit/i)
+  it('accepts duplicate_of + proof + canonical_pr', async () => {
+    const task = await taskManager.createTask({
+      title: 'Test: duplicate closure guard (pr)',
+      status: 'todo',
+      assignee: 'link',
+      reviewer: 'sage',
+      createdBy: 'test',
+      done_criteria: ['Has canonical duplicate closure proof'],
+    })
 
-    // All canonical refs present
     const updated = await taskManager.updateTask(task.id, {
       status: 'done',
       metadata: {
         auto_closed: true,
         auto_close_reason: 'duplicate',
         duplicate_of: 'task-0000000000000-abcdefg',
+        duplicate_proof: 'Duplicate of task-0000000000000-abcdefg — already fixed in PR #123',
         canonical_pr: 'https://github.com/reflectt/reflectt-node/pull/123',
+      },
+    })
+
+    expect(updated?.status).toBe('done')
+  })
+
+  it('accepts duplicate_of + proof + canonical_commit', async () => {
+    const task = await taskManager.createTask({
+      title: 'Test: duplicate closure guard (commit)',
+      status: 'todo',
+      assignee: 'link',
+      reviewer: 'sage',
+      createdBy: 'test',
+      done_criteria: ['Has canonical duplicate closure proof'],
+    })
+
+    const updated = await taskManager.updateTask(task.id, {
+      status: 'done',
+      metadata: {
+        auto_closed: true,
+        auto_close_reason: 'duplicate',
+        duplicate_of: 'task-0000000000000-abcdefg',
+        duplicate_proof: 'Duplicate of task-0000000000000-abcdefg — already fixed in commit abc1234',
         canonical_commit: 'abc1234',
       },
     })
 
     expect(updated?.status).toBe('done')
-    expect((updated?.metadata as any)?.duplicate_of).toBe('task-0000000000000-abcdefg')
   })
 })


### PR DESCRIPTION
Follow-up to PR #437 per @sage contract.

New intended duplicate-closure lifecycle gate:
- require `metadata.duplicate_of` (canonical task id starting with `task-`)
- require `metadata.duplicate_proof` (non-empty, not N/A)
- require either:
  - canonical PR URL (`metadata.canonical_pr`), or
  - canonical commit (>=7 hex; `metadata.canonical_commit`)
- allow PR/commit fallbacks from `metadata.review_handoff.{pr_url,commit_sha}`

Regression tests:
- reject: duplicate_of only
- accept: duplicate_of + proof + canonical_pr
- accept: duplicate_of + proof + canonical_commit

Tests: npm test (1441 passed, 1 skipped)
Build: npm run build
