### PR TITLE
feat(dashboard): Shared Artifacts panel (process/)

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1093,6 +1093,11 @@ export function getDashboardHTML(): string {
     <div class="panel-body" id="truth-body"></div>
   </div>
 
+  <div class="panel focus-collapse" id="shared-artifacts-panel">
+    <div class="panel-header">📚 Shared Artifacts <span class="count" id="shared-artifacts-count">loading…</span></div>
+    <div class="panel-body" id="shared-artifacts-body" style="max-height:260px;overflow-y:auto"></div>
+  </div>
+
   <div class="panel">
     <div class="panel-header">📋 Task Board <span class="count" id="task-count"></span></div>
     <div class="project-tabs" id="project-tabs"></div>


### PR DESCRIPTION
Adds a **Shared Artifacts** panel to the dashboard so agents/humans can self-pull board materials + task artifacts from the shared workspace without asking in chat.

## What
- Dashboard panel lists `GET /shared/list?path=process/` entries with direct links to `/shared/view?path=...`
- Includes a pinned slot for **RYANS-THOUGHTS.md** when it is symlinked into `workspace-shared/process/`

## Why (ties to Ryan’s vision)
- Reduces human-dependent “where is the doc?” loops
- Improves signal: docs/artifacts become discoverable in one place

## Note
To surface Ryan’s thoughts in this panel, symlink once:
```bash
ln -s ../RYANS-THOUGHTS.md ~/.openclaw/workspace-shared/process/RYANS-THOUGHTS.md
```

No secrets required.