### PR TITLE
feat: multi-host registry — remote hosts phone-home via heartbeat

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -463,6 +463,28 @@ export function runMigrations(db: Database.Database): void {
         CREATE INDEX IF NOT EXISTS idx_context_memos_updated_at ON context_memos(updated_at);
       `,
     },
+    {
+      version: 16,
+      sql: `
+        -- Host registry: remote hosts phone-home via heartbeat
+        CREATE TABLE IF NOT EXISTS hosts (
+          id TEXT PRIMARY KEY,
+          hostname TEXT,
+          os TEXT,
+          arch TEXT,
+          ip TEXT,
+          version TEXT,
+          agents TEXT, -- JSON array of agent names
+          metadata TEXT, -- JSON object
+          status TEXT NOT NULL DEFAULT 'online',
+          last_seen_at INTEGER NOT NULL,
+          registered_at INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_hosts_last_seen ON hosts(last_seen_at);
+        CREATE INDEX IF NOT EXISTS idx_hosts_status ON hosts(status);
+      `,
+    },
   ]
 
   const insertMigration = db.prepare('INSERT INTO _migrations (version) VALUES (?)')

--- a/src/host-registry.ts
+++ b/src/host-registry.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Host registry: remote hosts phone-home via heartbeat
+
+import { getDb, safeJsonStringify, safeJsonParse } from './db.js'
+
+// ── Types ──
+
+export interface HostHeartbeat {
+  hostId: string
+  hostname?: string
+  os?: string
+  arch?: string
+  ip?: string
+  version?: string
+  agents?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface Host {
+  id: string
+  hostname: string | null
+  os: string | null
+  arch: string | null
+  ip: string | null
+  version: string | null
+  agents: string[]
+  metadata: Record<string, unknown>
+  status: 'online' | 'offline' | 'stale'
+  last_seen_at: number
+  registered_at: number
+}
+
+// ── Constants ──
+
+const STALE_THRESHOLD_MS = 5 * 60 * 1000   // 5 minutes without heartbeat → stale
+const OFFLINE_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes → offline
+
+// ── CRUD ──
+
+/**
+ * Register or update a host heartbeat.
+ * Creates the host if it doesn't exist; updates last_seen + metadata if it does.
+ */
+export function upsertHostHeartbeat(input: HostHeartbeat): Host {
+  const db = getDb()
+  const now = Date.now()
+
+  const existing = db.prepare('SELECT * FROM hosts WHERE id = ?').get(input.hostId) as Record<string, unknown> | undefined
+
+  if (existing) {
+    db.prepare(`
+      UPDATE hosts SET
+        hostname = COALESCE(?, hostname),
+        os = COALESCE(?, os),
+        arch = COALESCE(?, arch),
+        ip = COALESCE(?, ip),
+        version = COALESCE(?, version),
+        agents = COALESCE(?, agents),
+        metadata = COALESCE(?, metadata),
+        status = 'online',
+        last_seen_at = ?
+      WHERE id = ?
+    `).run(
+      input.hostname ?? null,
+      input.os ?? null,
+      input.arch ?? null,
+      input.ip ?? null,
+      input.version ?? null,
+      input.agents ? safeJsonStringify(input.agents) : null,
+      input.metadata ? safeJsonStringify(input.metadata) : null,
+      now,
+      input.hostId,
+    )
+  } else {
+    db.prepare(`
+      INSERT INTO hosts (id, hostname, os, arch, ip, version, agents, metadata, status, last_seen_at, registered_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'online', ?, ?)
+    `).run(
+      input.hostId,
+      input.hostname ?? null,
+      input.os ?? null,
+      input.arch ?? null,
+      input.ip ?? null,
+      input.version ?? null,
+      safeJsonStringify(input.agents ?? []),
+      safeJsonStringify(input.metadata ?? {}),
+      now,
+      now,
+    )
+  }
+
+  return getHost(input.hostId)!
+}
+
+/**
+ * Get a single host by ID.
+ */
+export function getHost(hostId: string): Host | null {
+  const db = getDb()
+  const row = db.prepare('SELECT * FROM hosts WHERE id = ?').get(hostId) as Record<string, unknown> | undefined
+  if (!row) return null
+  return rowToHost(row)
+}
+
+/**
+ * List all known hosts, with computed status based on last_seen_at.
+ */
+export function listHosts(opts?: { status?: string }): Host[] {
+  const db = getDb()
+  const rows = db.prepare('SELECT * FROM hosts ORDER BY last_seen_at DESC').all() as Array<Record<string, unknown>>
+
+  const hosts = rows.map(rowToHost)
+
+  if (opts?.status) {
+    return hosts.filter(h => h.status === opts.status)
+  }
+  return hosts
+}
+
+/**
+ * Remove a host from the registry.
+ */
+export function removeHost(hostId: string): boolean {
+  const db = getDb()
+  const result = db.prepare('DELETE FROM hosts WHERE id = ?').run(hostId)
+  return result.changes > 0
+}
+
+// ── Helpers ──
+
+function rowToHost(row: Record<string, unknown>): Host {
+  const now = Date.now()
+  const lastSeen = Number(row.last_seen_at) || 0
+  const age = now - lastSeen
+
+  let status: Host['status'] = 'online'
+  if (age >= OFFLINE_THRESHOLD_MS) status = 'offline'
+  else if (age >= STALE_THRESHOLD_MS) status = 'stale'
+
+  return {
+    id: String(row.id),
+    hostname: row.hostname as string | null,
+    os: row.os as string | null,
+    arch: row.arch as string | null,
+    ip: row.ip as string | null,
+    version: row.version as string | null,
+    agents: safeJsonParse<string[]>(row.agents as string) ?? [],
+    metadata: safeJsonParse<Record<string, unknown>>(row.metadata as string) ?? {},
+    status,
+    last_seen_at: lastSeen,
+    registered_at: Number(row.registered_at) || 0,
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,6 +145,7 @@ import { startReminderEngine, stopReminderEngine, getReminderEngineStats } from 
 import { exportICS, exportEventICS, importICS, parseICS } from './calendar-ical.js'
 import { createDoc, getDoc, listDocs, updateDoc, deleteDoc, countDocs, VALID_CATEGORIES, type CreateDocInput, type UpdateDocInput, type DocCategory } from './knowledge-docs.js'
 import { onTaskShipped, onProcessFileWritten, onDecisionComment, isDecisionComment } from './knowledge-auto-index.js'
+import { upsertHostHeartbeat, getHost, listHosts, removeHost } from './host-registry.js'
 
 // Schemas
 const SendMessageSchema = z.object({
@@ -1981,6 +1982,49 @@ export async function createServer(): Promise<FastifyInstance> {
         promotions_flowing: health.recentPromotions > 0,
       },
     }
+  })
+
+  // ── Host Registry: remote hosts phone-home via heartbeat ──
+
+  app.post('/hosts/heartbeat', async (request) => {
+    const body = request.body as Record<string, unknown>
+    const hostId = typeof body.hostId === 'string' ? body.hostId.trim() : ''
+    if (!hostId) {
+      return { success: false, error: 'hostId is required' }
+    }
+    const host = upsertHostHeartbeat({
+      hostId,
+      hostname: typeof body.hostname === 'string' ? body.hostname : undefined,
+      os: typeof body.os === 'string' ? body.os : undefined,
+      arch: typeof body.arch === 'string' ? body.arch : undefined,
+      ip: typeof body.ip === 'string' ? body.ip : undefined,
+      version: typeof body.version === 'string' ? body.version : undefined,
+      agents: Array.isArray(body.agents) ? body.agents.filter((a: unknown) => typeof a === 'string') : undefined,
+      metadata: typeof body.metadata === 'object' && body.metadata !== null && !Array.isArray(body.metadata)
+        ? body.metadata as Record<string, unknown>
+        : undefined,
+    })
+    return { success: true, host }
+  })
+
+  app.get('/hosts', async (request) => {
+    const query = request.query as Record<string, string>
+    const status = typeof query.status === 'string' ? query.status : undefined
+    const hosts = listHosts({ status })
+    return { hosts, count: hosts.length }
+  })
+
+  app.get('/hosts/:hostId', async (request) => {
+    const { hostId } = request.params as { hostId: string }
+    const host = getHost(hostId)
+    if (!host) return { success: false, error: 'Host not found' }
+    return { host }
+  })
+
+  app.delete('/hosts/:hostId', async (request) => {
+    const { hostId } = request.params as { hostId: string }
+    const removed = removeHost(hostId)
+    return { success: removed, hostId }
   })
 
   // Team configuration linter health (TEAM.md / TEAM-ROLES.yaml / TEAM-STANDARDS.md)

--- a/tests/host-registry.test.ts
+++ b/tests/host-registry.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getDb } from '../src/db.js'
+import { upsertHostHeartbeat, getHost, listHosts, removeHost } from '../src/host-registry.js'
+
+function clearHosts() {
+  try { getDb().prepare('DELETE FROM hosts').run() } catch { /* table may not exist */ }
+}
+
+beforeEach(() => {
+  clearHosts()
+})
+
+describe('host registry', () => {
+  it('registers a new host via heartbeat', () => {
+    const host = upsertHostHeartbeat({
+      hostId: 'pi-cluster-01',
+      hostname: 'raspberrypi',
+      os: 'Linux',
+      arch: 'arm64',
+      version: '0.8.0',
+      agents: ['link', 'sage'],
+    })
+    expect(host.id).toBe('pi-cluster-01')
+    expect(host.hostname).toBe('raspberrypi')
+    expect(host.os).toBe('Linux')
+    expect(host.arch).toBe('arm64')
+    expect(host.version).toBe('0.8.0')
+    expect(host.agents).toEqual(['link', 'sage'])
+    expect(host.status).toBe('online')
+    expect(host.registered_at).toBeGreaterThan(0)
+    expect(host.last_seen_at).toBeGreaterThan(0)
+  })
+
+  it('updates existing host on subsequent heartbeat', () => {
+    upsertHostHeartbeat({ hostId: 'mac-01', hostname: 'MacBook', os: 'Darwin' })
+    const updated = upsertHostHeartbeat({ hostId: 'mac-01', version: '0.9.0', agents: ['kai'] })
+    expect(updated.hostname).toBe('MacBook') // preserved from first heartbeat
+    expect(updated.version).toBe('0.9.0')    // updated
+    expect(updated.agents).toEqual(['kai'])   // updated
+    expect(updated.status).toBe('online')
+  })
+
+  it('lists all hosts', () => {
+    upsertHostHeartbeat({ hostId: 'host-a', hostname: 'alpha' })
+    upsertHostHeartbeat({ hostId: 'host-b', hostname: 'beta' })
+    const hosts = listHosts()
+    expect(hosts).toHaveLength(2)
+    expect(hosts.map(h => h.id).sort()).toEqual(['host-a', 'host-b'])
+  })
+
+  it('gets a single host by ID', () => {
+    upsertHostHeartbeat({ hostId: 'solo', hostname: 'solo-machine' })
+    const host = getHost('solo')
+    expect(host).not.toBeNull()
+    expect(host!.hostname).toBe('solo-machine')
+  })
+
+  it('returns null for unknown host', () => {
+    expect(getHost('nonexistent')).toBeNull()
+  })
+
+  it('removes a host', () => {
+    upsertHostHeartbeat({ hostId: 'temp', hostname: 'temporary' })
+    expect(removeHost('temp')).toBe(true)
+    expect(getHost('temp')).toBeNull()
+    expect(removeHost('temp')).toBe(false) // already gone
+  })
+
+  it('computes stale/offline status based on last_seen_at', () => {
+    const db = getDb()
+    const now = Date.now()
+
+    // Insert a host that last reported 10 minutes ago (should be stale)
+    db.prepare(`
+      INSERT INTO hosts (id, hostname, status, last_seen_at, registered_at, agents, metadata)
+      VALUES (?, ?, 'online', ?, ?, '[]', '{}')
+    `).run('stale-host', 'stale-machine', now - 10 * 60 * 1000, now - 60 * 60 * 1000)
+
+    // Insert a host that last reported 20 minutes ago (should be offline)
+    db.prepare(`
+      INSERT INTO hosts (id, hostname, status, last_seen_at, registered_at, agents, metadata)
+      VALUES (?, ?, 'online', ?, ?, '[]', '{}')
+    `).run('offline-host', 'offline-machine', now - 20 * 60 * 1000, now - 60 * 60 * 1000)
+
+    const hosts = listHosts()
+    const stale = hosts.find(h => h.id === 'stale-host')
+    const offline = hosts.find(h => h.id === 'offline-host')
+
+    expect(stale?.status).toBe('stale')
+    expect(offline?.status).toBe('offline')
+  })
+
+  it('filters hosts by status', () => {
+    upsertHostHeartbeat({ hostId: 'online-host', hostname: 'active' })
+    const db = getDb()
+    db.prepare(`
+      INSERT INTO hosts (id, hostname, status, last_seen_at, registered_at, agents, metadata)
+      VALUES (?, ?, 'online', ?, ?, '[]', '{}')
+    `).run('old-host', 'old', Date.now() - 20 * 60 * 1000, Date.now() - 60 * 60 * 1000)
+
+    const online = listHosts({ status: 'online' })
+    expect(online).toHaveLength(1)
+    expect(online[0].id).toBe('online-host')
+  })
+})


### PR DESCRIPTION
## Summary

Add a host registry so remote hosts (Pi clusters, VPS, laptops) can report in to a central reflectt-node instance. This is the smallest step toward Ryan's multi-host / Pi cluster vision.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/hosts/heartbeat` | Register or update a host heartbeat |
| GET | `/hosts` | List all known hosts (optional `?status=online`) |
| GET | `/hosts/:hostId` | Get a single host |
| DELETE | `/hosts/:hostId` | Remove a host |

## Status computation

Based on `last_seen_at`:
- **online**: seen within 5 minutes
- **stale**: 5–15 minutes since last heartbeat
- **offline**: 15+ minutes

## Curl demo

```bash
# Register a Pi
curl -X POST http://localhost:4445/hosts/heartbeat \
  -H 'Content-Type: application/json' \
  -d '{"hostId":"pi-cluster-01","hostname":"raspberrypi","os":"Linux","arch":"arm64","version":"0.8.0","agents":["link","sage"]}'

# List all hosts
curl http://localhost:4445/hosts

# Get specific host
curl http://localhost:4445/hosts/pi-cluster-01

# Filter by status
curl http://localhost:4445/hosts?status=online
```

## Files changed (4 files, +324 lines)

- `src/host-registry.ts` — Host registry module (upsert, get, list, remove)
- `src/db.ts` — Migration v16 (hosts table + indexes)
- `src/server.ts` — 4 endpoints + import
- `tests/host-registry.test.ts` — 8 tests (all pass)

## Verification

- `tsc --noEmit` passes
- 8/8 host registry tests pass
- Existing test suite unaffected

**Task:** task-1772202822415-nyg09307r