### PR TITLE
fix: support hyphenated agent names in @mention parsing

### DIFF
--- a/plugins/reflectt-channel/src/channel.ts
+++ b/plugins/reflectt-channel/src/channel.ts
@@ -410,7 +410,7 @@ async function handleChatMessage(
 
 function extractAgentMentions(content: string, cfg: OpenClawConfig): string[] {
   const mentions: string[] = [];
-  const mentionPattern = /@(\w+)/g;
+  const mentionPattern = /@([\w][\w-]*[\w]|[\w]+)/g;
   
   let match;
   while ((match = mentionPattern.exec(content)) !== null) {


### PR DESCRIPTION
## What

Fix @mention regex in reflectt-channel to support hyphenated agent names.

### Problem

`/@(\w+)/g` splits `@finance-agent` into `@finance`, which doesn't match the registered agent ID. Also breaks generic names from PR #458 (`agent-1`, `agent-2`, `agent-3`).

### Fix

Updated regex to `/@([\w][\w-]*[\w]|[\w]+)/g`:
- `@finance-agent` → `finance-agent` ✅
- `@agent-1` → `agent-1` ✅
- `@link` → `link` ✅
- `@foo-` → `foo` (trailing hyphen stripped) ✅

### Files Changed
- `plugins/reflectt-channel/src/channel.ts` — 1 line change

Task: task-1772218257657-9imacy2qy