### PR TITLE
feat: dashboard Getting Started panel — 3-step onboarding checklist

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2490,7 +2490,8 @@ async function checkGettingStarted() {
     if (!res.ok) return;
     const health = await res.json();
 
-    const hasHeartbeat = health.uptime_seconds > 0;
+    // Step 1 done: check if system health loops are ticking (not just uptime > 0)
+    const hasHeartbeat = !!(health.system?.loops?.lastTickAt || (health.tasks?.total > 0));
     const hasTasks = (health.tasks?.total || 0) > 0;
     const hasMessages = (health.chat?.total || 0) > 0;
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1079,6 +1079,7 @@ export function getDashboardHTML(): string {
     padding: 4px 8px; border-radius: var(--radius-sm);
   }
   .getting-started .dismiss-btn:hover { color: var(--text); background: var(--accent-dim); }
+  .getting-started .dismiss-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   .getting-started .gs-steps { padding: 16px 18px; display: flex; flex-direction: column; gap: 14px; }
   .getting-started .gs-step {
     display: flex; align-items: flex-start; gap: 12px;
@@ -1131,7 +1132,7 @@ export function getDashboardHTML(): string {
   <div class="getting-started" id="getting-started">
     <div class="panel-header">
       🚀 Getting Started
-      <button class="dismiss-btn" onclick="dismissGettingStarted()">Dismiss ✕</button>
+      <button class="dismiss-btn" onclick="dismissGettingStarted()" aria-label="Dismiss Getting Started panel">Dismiss ✕</button>
     </div>
     <div class="gs-steps" id="gs-steps">
       <div class="gs-step" id="gs-preflight">
@@ -1147,7 +1148,7 @@ export function getDashboardHTML(): string {
         <div class="gs-content">
           <div class="gs-title">Connect to your team</div>
           <div class="gs-desc">Bootstrap your host or connect to Reflectt Cloud for team coordination.</div>
-          <a class="gs-link" href="/bootstrap/team" target="_blank">POST /bootstrap/team →</a>
+          <a class="gs-link" href="/docs" target="_blank">Setup docs →</a>
         </div>
       </div>
       <div class="gs-step" id="gs-task">


### PR DESCRIPTION
## What

Adds a Getting Started panel to `/dashboard` that guides new users through first-run setup in <10 seconds.

### 3 Steps

| # | Step | Auto-done when | Link |
|---|------|---------------|------|
| 1 | Run preflight checks | Server healthy (uptime > 0) | `/health` |
| 2 | Connect to your team | At least 1 host enrolled | `/bootstrap/team` |
| 3 | Create your first task | Any task or message exists | `/docs` |

### Behavior

- **Auto-hides** when all 3 steps are complete (no manual action needed)
- **Dismiss button** persists via `localStorage` (`reflectt-gs-dismissed`)
- Steps mark as done with green checkmarks on page load
- Uses existing dashboard design tokens (`--surface`, `--accent`, `--border`, etc.)
- Accent border makes it visually distinct from other panels

### Files Changed
- `src/dashboard.ts` — HTML template + CSS for the panel
- `public/dashboard.js` — Status checking + auto-hide logic

Task: task-1772217828727-2vjt8lcc4