### PR TITLE
fix: remove hardcoded paths, use env vars for Docker compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,16 @@ services:
       - PORT=4445
       - HOST=0.0.0.0
       - NODE_ENV=production
-      # Uncomment and set these for OpenClaw gateway connection:
+      - REFLECTT_HOME=/data
+      # ── OpenClaw gateway connection ──
+      # Set these to connect to an OpenClaw instance running on the host
+      # or another container. This is the only config needed — no CLI or
+      # filesystem sharing required.
       # - OPENCLAW_GATEWAY_URL=ws://host.docker.internal:18789
       # - OPENCLAW_GATEWAY_TOKEN=your_token_here
+      # ── Optional auth tokens ──
+      # - REFLECTT_MANAGE_TOKEN=your_manage_token
+      # - REFLECTT_HOST_HEARTBEAT_TOKEN=your_heartbeat_token
     restart: unless-stopped
 
 volumes:

--- a/src/context-budget.ts
+++ b/src/context-budget.ts
@@ -13,6 +13,7 @@
 import { createHash } from 'crypto'
 import { promises as fs } from 'fs'
 import { join } from 'path'
+import { homedir } from 'os'
 import { getDb, safeJsonParse, safeJsonStringify } from './db.js'
 import type { AgentMessage } from './types.js'
 import { memoryManager } from './memory.js'
@@ -240,7 +241,7 @@ function findAgentWorkspace(agent: string): string {
   // Keep consistent with memory.ts; env override supported for CI.
   const base = process.env.OPENCLAW_STATE_DIR
     ? join(process.env.OPENCLAW_STATE_DIR, '')
-    : '/Users/ryan/.openclaw'
+    : (process.env.OPENCLAW_HOME || join(homedir(), '.openclaw'))
   return join(base, `workspace-${agent}`)
 }
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -9,7 +9,9 @@ import { promises as fs } from 'fs'
 import { join } from 'path'
 import { eventBus } from './events.js'
 
-const WORKSPACE_BASE = '/Users/ryan/.openclaw'
+import { homedir } from 'os'
+
+const WORKSPACE_BASE = process.env.OPENCLAW_HOME || join(homedir(), '.openclaw')
 
 interface MemoryEntry {
   path: string


### PR DESCRIPTION
## What

Fixes hardcoded `/Users/ryan/.openclaw` paths that break in Docker/Cloudflare/any non-local environment.

### Problem

`memory.ts` and `context-budget.ts` had hardcoded paths to Ryan's local machine. In Docker, there's no `/Users/ryan` — reflectt-node needs to work with env vars only.

### Fix

| File | Before | After |
|------|--------|-------|
| `src/memory.ts` | `'/Users/ryan/.openclaw'` | `OPENCLAW_HOME \|\| ~/.openclaw` |
| `src/context-budget.ts` | `'/Users/ryan/.openclaw'` | `OPENCLAW_HOME \|\| ~/.openclaw` |
| `docker-compose.yml` | Gateway vars only | + `REFLECTT_HOME=/data`, documented all env vars |

### Env Var Contract

The only config Docker needs:
- `OPENCLAW_GATEWAY_URL` — WebSocket URL to reach OpenClaw gateway
- `OPENCLAW_GATEWAY_TOKEN` — Auth token for the gateway
- `REFLECTT_HOME` — Data directory (defaults to `~/.reflectt`)
- `OPENCLAW_HOME` — OpenClaw workspace root (defaults to `~/.openclaw`)

No CLI, no filesystem sharing, no mount hacks.

Per @kai and @ryan: env vars are the whole contract.