### PR TITLE
Add Dockerfile + CI to publish reflectt-node images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# dependencies
+node_modules
+
+# build output (built inside the image)
+dist
+
+# git + editor
+.git
+.github
+.DS_Store
+
+# local runtime state
+process
+artifacts
+incidents
+*.log
+
+# secrets / local env
+.env
+.env.*
+
+# tests not needed for runtime image
+tests

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,54 @@
+name: docker-image
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1.7
+
+# reflectt-node Docker image
+# - Multi-stage build (TypeScript -> dist)
+# - Uses Debian slim for better-sqlite3 compatibility
+
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+# Install deps (includes devDeps for build)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source + runtime assets
+COPY tsconfig.json ./
+COPY src ./src
+COPY public ./public
+COPY defaults ./defaults
+COPY templates ./templates
+COPY config ./config
+COPY data ./data
+
+# Compile TypeScript
+RUN npm run build
+
+
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Persist all state under /reflectt (maps to REFLECTT_HOME)
+ENV REFLECTT_HOME=/reflectt
+
+# git is used for build metadata (/health/build, release diff endpoints)
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install production deps only
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev \
+  && npm cache clean --force
+
+# App output + runtime assets
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/public ./public
+COPY --from=build /app/defaults ./defaults
+COPY --from=build /app/templates ./templates
+COPY --from=build /app/config ./config
+COPY --from=build /app/data ./data
+
+# Volume for SQLite + inbox + templates in REFLECTT_HOME
+RUN mkdir -p /reflectt \
+  && chown -R node:node /reflectt
+
+USER node
+VOLUME ["/reflectt"]
+
+EXPOSE 4445
+
+CMD ["node", "dist/index.js"]

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -8,6 +8,20 @@ Get reflectt-node running in 5 minutes.
 - OpenClaw installed and running
 - Git
 
+## Docker option (skip local Node install)
+
+If you prefer running reflectt-node as a container:
+
+```bash
+docker run --rm -p 4445:4445 \
+  -v reflectt-node:/reflectt \
+  -e OPENCLAW_GATEWAY_URL=ws://host.docker.internal:18789 \
+  -e OPENCLAW_GATEWAY_TOKEN=your_token_here \
+  ghcr.io/reflectt/reflectt-node:latest
+```
+
+Then jump to **Step 5: Test It**.
+
 ## Step 1: Clone
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ You should see the live dashboard with task board, team health, chat, and activi
 
 **That's it. You're running.**
 
+### Docker (prebuilt image)
+
+If you want a containerized install (and persistent state via a Docker volume):
+
+```bash
+docker run --rm -p 4445:4445 \
+  -v reflectt-node:/reflectt \
+  ghcr.io/reflectt/reflectt-node:latest
+```
+
+Optional — connect to OpenClaw:
+
+```bash
+docker run --rm -p 4445:4445 \
+  -v reflectt-node:/reflectt \
+  -e OPENCLAW_GATEWAY_URL=ws://host.docker.internal:18789 \
+  -e OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here \
+  ghcr.io/reflectt/reflectt-node:latest
+```
+
 ### Optional: one-command cloud enrollment (dogfooding)
 
 If you have a Reflectt Cloud host join token, you can enroll this node and start heartbeats in one command:


### PR DESCRIPTION
Linked task: task-1772207592473-2ln1jxbw8\n\nFixes stale Docker image problem by adding:\n- Dockerfile + .dockerignore\n- GitHub Actions workflow to build & push multi-arch images to GHCR on main/tags\n- Docs: docker run snippets in README/QUICKSTART\n\nNotes:\n- Image uses /reflectt as REFLECTT_HOME volume for persistence.\n- Built assets (defaults/templates/public) are included.\n