### PR TITLE
feat: decouple reflectt-node from OpenClaw filesystem — env-only config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - HOST=0.0.0.0
       - NODE_ENV=production
       - REFLECTT_HOME=/data
+      - OPENCLAW_HOME=/data
+      - REFLECTT_SHARED_WORKSPACE=/data/workspace-shared
       # ── OpenClaw gateway connection ──
       # Set these to connect to an OpenClaw instance running on the host
       # or another container. This is the only config needed — no CLI or

--- a/src/server.ts
+++ b/src/server.ts
@@ -4377,7 +4377,7 @@ export async function createServer(): Promise<FastifyInstance> {
   })
 
   // ── Shared Workspace Read API ──────────────────────────────────────
-  // Read-only access to shared artifacts (process/ under ~/.openclaw/workspace-shared).
+  // Read-only access to shared artifacts (process/ under REFLECTT_SHARED_WORKSPACE).
   // Security: path validation, traversal protection, extension + size limits.
 
   app.get('/shared/list', async (request, reply) => {

--- a/src/team-doctor.ts
+++ b/src/team-doctor.ts
@@ -149,7 +149,7 @@ function checkGateway(gatewayUrl?: string): DoctorCheck {
       name: 'gateway',
       status: 'fail',
       message: 'No gateway URL configured',
-      fix: 'Set OPENCLAW_GATEWAY_URL in .env or run `openclaw setup`',
+      fix: 'Set OPENCLAW_GATEWAY_URL in .env (e.g. ws://localhost:18789)',
     }
   }
 
@@ -158,7 +158,7 @@ function checkGateway(gatewayUrl?: string): DoctorCheck {
       name: 'gateway',
       status: 'warn',
       message: `Gateway URL set (${url}) but no token configured`,
-      fix: 'Set OPENCLAW_GATEWAY_TOKEN in .env (find it in ~/.openclaw/openclaw.json)',
+      fix: 'Set OPENCLAW_GATEWAY_TOKEN in .env',
     }
   }
 
@@ -202,7 +202,7 @@ function checkModelAuth(provider?: string): DoctorCheck {
 
 function checkOpenClawBootstrap(): DoctorCheck {
   try {
-    const stateDir = process.env.OPENCLAW_STATE_DIR || join(homedir(), '.openclaw')
+    const stateDir = process.env.OPENCLAW_STATE_DIR || process.env.OPENCLAW_HOME || join(homedir(), '.openclaw')
 
     const candidates: string[] = []
 
@@ -229,7 +229,7 @@ function checkOpenClawBootstrap(): DoctorCheck {
         name: 'openclaw_bootstrap',
         status: 'warn',
         message: `No OpenClaw workspaces found under ${stateDir}`,
-        fix: 'If OpenClaw is installed, ensure OPENCLAW_STATE_DIR is set correctly (or create ~/.openclaw/workspace)',
+        fix: 'Set OPENCLAW_STATE_DIR to point to your OpenClaw workspace root, or ensure workspaces exist under the configured path',
       }
     }
 


### PR DESCRIPTION
## What

Removes all direct OpenClaw CLI calls and hardcoded `~/.openclaw` filesystem dependencies. In Docker/Cloudflare, reflectt-node and OpenClaw are separate containers with no shared filesystem — the only contract is `OPENCLAW_GATEWAY_URL` + `OPENCLAW_GATEWAY_TOKEN`.

## Changes (5 files)

### `src/preflight.ts`
- Gateway check: replaced `openclaw gateway status` CLI call with HTTP health probe against `OPENCLAW_GATEWAY_URL`
- Works in Docker (no CLI needed), warns clearly when env var not set

### `src/team-doctor.ts`
- Removed `~/.openclaw/openclaw.json` reference in fix hints
- Added `OPENCLAW_HOME` as env var fallback before `~/.openclaw`

### `src/artifact-mirror.ts`
- `getSharedWorkspace()`: respects `OPENCLAW_HOME` before `~/.openclaw` fallback
- Workspace scan: uses `OPENCLAW_HOME` env var
- Updated error messages to be path-agnostic

### `docker-compose.yml`
- Added `OPENCLAW_HOME=/data` and `REFLECTT_SHARED_WORKSPACE=/data/workspace-shared`

### `src/server.ts`
- Updated comment (cosmetic)

## Design principle
All remaining `homedir()/.openclaw` references follow **env-var-first**: `OPENCLAW_HOME` wins, filesystem is last-resort backwards-compat for bare-metal installs.

## Proof
- `tsc --noEmit`: clean
- `vitest run`: **103 files, 1454 tests pass, 0 failures**
- No `openclaw` CLI calls remain in source (verified via grep)

Task: `task-1772220560899-ypxh3tjxi`
@itskai-dev — reviewer (per Ryan's request)