### PR TITLE
a11y: unify focus-visible + keyboard nav for dashboard

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,4 +1,13 @@
 const BASE = location.origin;
+
+// Keyboard a11y: activate [role="button"] on Enter/Space
+document.addEventListener('keydown', function(e) {
+  if ((e.key === 'Enter' || e.key === ' ') && e.target.getAttribute('role') === 'button') {
+    e.preventDefault();
+    e.target.click();
+  }
+});
+
 let currentChannel = 'all';
 let currentProject = 'all';
 let allMessages = [];
@@ -669,7 +678,7 @@ function renderBacklog() {
     const criteriaCount = criteriaList.length;
     const criteriaPreview = criteriaCount > 0 ? esc(truncate(criteriaList[0], 72)) : 'No done criteria listed';
 
-    return `<div class="backlog-item" style="padding:10px 14px;border-bottom:1px solid var(--border-subtle);cursor:pointer" onclick="openTaskModal('${t.id}')">
+    return `<div class="backlog-item" role="button" tabindex="0" style="padding:10px 14px;border-bottom:1px solid var(--border-subtle);cursor:pointer" onclick="openTaskModal('${t.id}')">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
         ${t.priority ? '<span class="priority-badge ' + t.priority + '">' + t.priority + '</span>' : ''}
         <span style="color:var(--text-bright);font-size:13px;font-weight:500">${esc(truncate(t.title, 70))}</span>
@@ -1474,7 +1483,7 @@ function renderReviewQueue() {
     const duration = formatDuration(t.timeInReview);
     const tags = renderTaskTags(t.tags);
 
-    return '<div class="review-item" onclick="openTaskModal(\'' + esc(t.id) + '\')">'
+    return '<div class="review-item" role="button" tabindex="0" onclick="openTaskModal(\'' + esc(t.id) + '\')">'
       + '<div class="review-item-left">'
       + '<div class="review-item-title">' + esc(truncate(t.title, 70)) + '</div>'
       + '<div class="review-item-meta">'
@@ -1896,7 +1905,7 @@ async function runTaskSearch() {
       const title = esc(truncate(t.title || t.id, 80));
       const id = esc(t.id);
       const status = esc(t.status || 'todo');
-      return '<div class="backlog-item" style="padding:10px 14px;border-bottom:1px solid var(--border-subtle);cursor:pointer" onclick="openTaskModal(\'' + id + '\')">'
+      return '<div class="backlog-item" role="button" tabindex="0" style="padding:10px 14px;border-bottom:1px solid var(--border-subtle);cursor:pointer" onclick="openTaskModal(\'' + id + '\')">'
         + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">'
         + pri
         + '<span style="color:var(--text-bright);font-size:13px;font-weight:500">' + title + '</span>'

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -822,6 +822,28 @@ export function getDashboardHTML(): string {
     outline-offset: 4px;
   }
 
+  /* Focus-visible parity: match hover styles for keyboard navigation */
+  button:focus-visible, .button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+  .task-card:focus-visible { border-color: var(--accent); }
+  .health-card:focus-visible { border-color: var(--accent); }
+  .agent-card:focus-visible .agent-emoji { transform: scale(1.1) rotate(5deg); }
+  .channel-tab:focus-visible { background: var(--surface-raised); color: var(--text); }
+  .project-tab:focus-visible { color: var(--text); }
+  .focus-toggle:focus-visible { border-color: var(--accent); color: var(--text); }
+  .status-btn:focus-visible { border-color: var(--accent); color: var(--accent); }
+  .artifact-btn:focus-visible { border-color: var(--accent); color: var(--accent); }
+  .modal-copy-btn:focus-visible { border-color: var(--accent); color: var(--accent); }
+  .copy-template-btn:focus-visible { border-color: var(--accent); color: var(--accent); }
+  .modal-close:focus-visible { color: var(--text); }
+  .modal-btn-primary:focus-visible { opacity: 0.85; }
+  .modal-btn-secondary:focus-visible { background: var(--text-muted); }
+  .done-toggle:focus-visible { color: var(--text); }
+  .review-item:focus-visible { background: var(--surface-raised); }
+  .gs-link:focus-visible { text-decoration: underline; }
+
   /* Reduced Motion Preferences */
   @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {


### PR DESCRIPTION
## What changed

**CSS (src/dashboard.ts):**
- Added `:focus-visible` parity for 16 interactive classes that had `:hover` but no keyboard focus styles
- Covers: task-card, health-card, channel-tab, project-tab, focus-toggle, status-btn, artifact-btn, modal buttons, copy buttons, review-item, getting-started links
- All use existing tokens (no new variables)

**JS (public/dashboard.js):**
- Added `role="button"` + `tabindex="0"` to clickable divs (backlog-item, review-item) 
- Added global `keydown` listener for Enter/Space activation on `role="button"` elements

**Scope:** Only 2 files changed per task criteria.

Addresses `task-1772224215585-1woxlzkff`