### PR TITLE
config: designer role neverRoute exclusions (lane enforcement)

### DIFF
--- a/defaults/TEAM-ROLES.yaml
+++ b/defaults/TEAM-ROLES.yaml
@@ -36,6 +36,17 @@ agents:
       - ux
       - css
       - visual
+    neverRoute:
+      - ops
+      - infra
+      - ci
+      - deploy
+      - compliance
+      - backend
+      - api
+      - docker
+      - monitoring
+      - database
     wipCap: 1
 
   - name: agent-3


### PR DESCRIPTION
## Problem

Designer agents could potentially get ops/infra/backend tasks routed to them via the insight→task bridge if keyword overlap occurred. While `routingMode: opt-in` already restricts the designer to design-lane tasks, there was no explicit `neverRoute` safety net.

## Change

Added `neverRoute` list to the default designer role in `defaults/TEAM-ROLES.yaml`:
```yaml
neverRoute:
  - ops, infra, ci, deploy, compliance
  - backend, api, docker, monitoring, database
```

**Config-only change** — the assignment engine (`agentEligibleForTask()`) already enforces `neverRoute`. No code changes needed.

## Verification

- `suggestAssignee()` calls `agentEligibleForTask()` which checks `neverRoute` before scoring
- The insight-task bridge uses `suggestAssignee()` for all auto-routing
- All 1470 tests pass

Implements `task-1772214273421-5o3mmidg6` (Pixel design lane enforcement)