### PR TITLE
refactor: /bootstrap/team → schema+examples (delete keyword matcher)

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -161,7 +161,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | GET | `/tasks/active` | Get active (doing) task for agent. Query: `agent`, `compact`. Returns null if no doing tasks. |
 | GET | `/heartbeat/:agent` | Single compact heartbeat payload (~200 tokens). Returns active task, next task, slim inbox, queue counts, and suggested action. Replaces 3 separate API calls. |
 | GET | `/bootstrap/heartbeat/:agent` | Generate optimal HEARTBEAT.md content for agent. References best endpoints. Includes version stamp and content hash for change detection. |
-| POST | `/bootstrap/team` | Recommend team composition, initial tasks, and heartbeat configs for a use case. Body: `{ useCase, constraints?, models?, channels? }`. Returns `{ agents[], initialTasks[], heartbeatSnippets{}, teamRolesYaml, nextSteps[] }`. |
+| POST | `/bootstrap/team` | Returns TEAM-ROLES.yaml schema, constraints, well-formed examples, and save endpoint. The calling agent composes the team itself. Body: `{ useCase?, maxAgents? }`. Returns `{ schema, constraints, examples[], saveEndpoint, nextSteps[] }`. |
 | GET | `/manage/status` | Remote management: unified status (version + health + uptime). Auth: `x-manage-token` header or `Authorization: Bearer`. |
 | GET | `/manage/config` | Remote management: config introspection with secrets redacted. Auth required. |
 | GET | `/manage/logs` | Remote management: bounded log tail. Query: `level`, `since`, `limit`, `format=text`. Auth required. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -8877,15 +8877,10 @@ export async function createServer(): Promise<FastifyInstance> {
 
   // ── Bootstrap Team: recommend composition + initial tasks + heartbeat configs ──
   app.post<{ Body: BootstrapTeamRequest }>('/bootstrap/team', async (request) => {
-    const body = request.body as BootstrapTeamRequest
-    if (!body?.useCase || typeof body.useCase !== 'string' || body.useCase.trim().length < 3) {
-      return { error: 'useCase is required (min 3 chars). Describe what this team will do.', status: 400 }
-    }
+    const body = (request.body || {}) as BootstrapTeamRequest
     return bootstrapTeam({
-      useCase: body.useCase.trim(),
-      constraints: body.constraints,
-      models: body.models,
-      channels: body.channels,
+      useCase: typeof body.useCase === 'string' ? body.useCase.trim() : undefined,
+      maxAgents: typeof body.maxAgents === 'number' ? body.maxAgents : undefined,
     })
   })
 
@@ -8903,7 +8898,7 @@ export async function createServer(): Promise<FastifyInstance> {
         endpoints: [
           { method: 'GET', path: '/heartbeat/:agent', hint: 'Single compact payload (~200 tokens). Replaces /tasks/active + /tasks/next + /inbox.' },
           { method: 'GET', path: '/bootstrap/heartbeat/:agent', hint: 'Generate optimal HEARTBEAT.md. Re-fetch when version changes.' },
-          { method: 'POST', path: '/bootstrap/team', hint: 'Recommend team composition, initial tasks, and heartbeat configs. Body: { useCase, constraints?, models?, channels? }' },
+          { method: 'POST', path: '/bootstrap/team', hint: 'Returns TEAM-ROLES.yaml schema, constraints, examples, and save endpoint. The calling agent composes the team. Body: { useCase?, maxAgents? }' },
         ],
       },
       tasks: {


### PR DESCRIPTION
## Design Pivot (from Ryan via Kai)

The agents calling `/bootstrap/team` are AI. They already know what a back-office/dev/content team needs. The keyword matcher was adding complexity without value.

## Before → After

**Before:** POST with `{ useCase: 'managed hosting' }` → keyword lookup → fixed team template  
**After:** POST (body optional) → schema + constraints + examples → agent composes team

## What the endpoint now returns

```json
{
  "schema": { fields: [...], filePath, hotReload },
  "constraints": { maxAgents, wipCapRange, routingModes, reservedNames },
  "examples": [ devTeam, contentTeam, soloAgent ],
  "saveEndpoint": { method: 'PUT', path: '/config/team-roles' },
  "nextSteps": [...]
}
```

## Deleted
- 3 keyword templates (support/content/dev)
- `matchTemplate()` function
- `generateTeamRolesYaml()`, `generateHeartbeatSnippet()`
- `InitialTask`, `HeartbeatSnippet` interfaces
- Required `useCase` validation (now optional context)

Net **-62 lines**.

All 1470 tests pass. `tsc --noEmit` clean.

Addresses `task-1772235804948-2mshr6zej`