### PR TITLE
chore: process artifact for rcuuep9co (superseded by #463)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ process/*
 # Allow committing specific task artifacts needed for review/proof
 !process/TASK-47sxe374r.md
 !process/TASK-iwphjvsrl.md
+!process/TASK-task-rcuuep9co.md

--- a/process/TASK-task-rcuuep9co.md
+++ b/process/TASK-task-rcuuep9co.md
@@ -1,0 +1,13 @@
+# TASK-rcuuep9co — lane/surface metadata warnings + routing guardrail
+
+This task is **superseded** by merged PR #463.
+
+PR: https://github.com/reflectt/reflectt-node/pull/463
+
+What shipped in #463:
+- Routing guardrail is config-driven via TEAM-ROLES.yaml (role/lane/surface/tags)
+- Warn-only lane/surface hints in task creation + precheck
+- Applied to both assignee suggestion and reviewer autosuggest
+- Regression tests + docs (`docs/LANE_SURFACE_ROUTING.md`)
+
+Close reason: duplicate/superseded by #463.


### PR DESCRIPTION
Adds a small process artifact for task-1772214371814-rcuuep9co documenting that the work shipped via PR #463 (already merged), so the task can be closed cleanly with an artifact_path.
