### PR TITLE
feat: /health/watchdog endpoint + KEEPALIVE.md guide

### DIFF
--- a/docs/KEEPALIVE.md
+++ b/docs/KEEPALIVE.md
@@ -1,0 +1,117 @@
+# Keepalive: Preventing Idle Freeze
+
+Serverless platforms (Cloudflare Workers, AWS Lambda, etc.) recycle containers after idle periods. When a reflectt-node instance goes cold, it loses in-memory state and takes time to restart. This guide covers how to keep your instance warm.
+
+## The Problem
+
+After ~5-15 minutes of inactivity:
+- Cloudflare Workers containers are evicted
+- Cold starts can take 2-10 seconds
+- In-memory state (chat history, event bus) is lost
+- SSE/WebSocket connections drop
+
+## Solution: Keepalive Ping
+
+reflectt-node exposes a lightweight endpoint designed for keepalive:
+
+```
+GET /health/ping
+```
+
+Response:
+```json
+{ "status": "ok", "uptime_seconds": 3600, "ts": 1772238000000 }
+```
+
+No database queries, no computation — instant response. Safe to call every 30-60 seconds.
+
+## Setup Options
+
+### Option 1: Cloudflare Cron Trigger (Recommended for Workers)
+
+Add a cron trigger to your `wrangler.toml`:
+
+```toml
+[triggers]
+crons = ["*/1 * * * *"]  # Every minute
+```
+
+Then handle the scheduled event in your worker:
+
+```typescript
+export default {
+  async fetch(request, env) {
+    // ... your existing fetch handler
+  },
+
+  async scheduled(event, env, ctx) {
+    // Keepalive: hit the health endpoint to prevent idle eviction
+    const url = `${env.REFLECTT_URL || 'http://localhost:4445'}/health/ping`
+    ctx.waitUntil(fetch(url).catch(() => {}))
+  },
+}
+```
+
+### Option 2: External Cron (Any Platform)
+
+Use any cron service to ping your instance:
+
+```bash
+# crontab -e
+* * * * * curl -s https://your-instance.example.com/health/ping > /dev/null
+```
+
+Or use a monitoring service:
+- **UptimeRobot** — Free tier, 5-minute intervals
+- **Cronitor** — Monitors + alerts
+- **Better Uptime** — 3-minute intervals on free tier
+- **GitHub Actions** — schedule workflow with `cron: '*/5 * * * *'`
+
+### Option 3: Docker / systemd (Self-Hosted)
+
+Self-hosted instances don't need keepalive — the process stays running. But you may want health monitoring:
+
+```bash
+# systemd watchdog (add to your .service file)
+[Service]
+WatchdogSec=60
+ExecStartPost=/bin/sh -c 'while true; do curl -sf http://localhost:4445/health/ping || exit 1; sleep 30; done &'
+```
+
+## Monitoring Cold Starts
+
+The `/health` endpoint includes a `cold_start` flag:
+
+```json
+{ "status": "ok", "cold_start": true, "uptime_seconds": 12 }
+```
+
+`cold_start` is `true` when uptime is under 60 seconds. Use this to:
+- Track cold start frequency in your monitoring dashboard
+- Alert on excessive restarts
+- Measure warm-up time
+
+## Host Registry Status
+
+If your instance reports to a host registry (`/hosts`), the status thresholds are:
+- **online**: last seen < 5 minutes ago
+- **stale**: last seen 5-15 minutes ago
+- **offline**: last seen > 15 minutes ago
+
+A keepalive ping every 1-2 minutes keeps the host status as "online".
+
+## Troubleshooting
+
+**Worker still goes cold despite cron trigger:**
+- Cloudflare may evict containers even with cron if there's resource pressure
+- Ensure the cron handler actually makes a fetch to the worker URL (not just runs)
+- Check Workers Analytics for invocation gaps
+
+**High cold start latency:**
+- reflectt-node's `/health/ping` is zero-cost (no DB init)
+- If full `/health` is slow on cold start, the DB initialization is the bottleneck
+- Consider using Durable Objects for persistent state instead of SQLite
+
+**SSE connections drop on cold start:**
+- Expected behavior — clients should reconnect with exponential backoff
+- reflectt-node's SSE client (`src/openclaw.ts`) handles this automatically (1s → 30s cap)

--- a/public/docs.md
+++ b/public/docs.md
@@ -77,6 +77,7 @@ Remote hosts (multi-host installs) phone-home via a lightweight heartbeat so the
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health/ping` | Ultra-lightweight keepalive — no DB access. Returns `{ status, uptime_seconds, ts }`. Use for cron triggers, load balancers, uptime monitors. |
+| GET | `/health/watchdog` | Richer keepalive with cold_start flag, task/chat stats, and remediation hints. For monitoring dashboards. See `docs/KEEPALIVE.md`. |
 | GET | `/health` | System health — task counts, chat stats, inbox stats. Includes `cold_start` flag (true if uptime < 60s). Query: `include_test=1` to include test-harness tasks in stats (excluded by default). |
 | GET | `/team/health` | Team config linter status for `~/.reflectt/TEAM.md`, `TEAM-ROLES.yaml`, `TEAM-STANDARDS.md` (issues, role coverage, last check timestamp) |
 | GET | `/health/team` | Team health metrics with compliance + `staleDoing` snapshot. Per-agent rows include `activeTaskTitle` and `activeTaskPrLink` when an agent has a doing task with PR evidence. Flagged agents also include `actionable_reason` (last comment age, last transition, last mention age, suggested action). |


### PR DESCRIPTION
## Problem

Cloudflare Workers containers go unresponsive after idle. No docs or tooling to prevent this.

## Solution

### New endpoint: `GET /health/watchdog`
Richer keepalive with monitoring data:
```json
{
  "status": "ok",
  "uptime_seconds": 3600,
  "cold_start": false,
  "stats": { "tasks": { "total": 25, "byStatus": {...} }, "chat": { "rooms": 5, "totalMessages": 100 } }
}
```
When `cold_start` is true, includes `remediation` hint pointing to docs.

### New doc: `docs/KEEPALIVE.md`
Comprehensive guide:
- Cloudflare cron trigger setup (wrangler.toml + scheduled handler)
- External cron options (UptimeRobot, Cronitor, GitHub Actions)
- systemd watchdog for self-hosted
- Cold start monitoring
- Host registry status thresholds
- Troubleshooting

## Files
- `src/server.ts` — `/health/watchdog` endpoint
- `public/docs.md` — route docs
- `docs/KEEPALIVE.md` — new guide

## Testing
- `tsc --noEmit` clean
- 1472 tests pass
- Route docs 383/383

Task: task-1772233634233-wm1jd5s9i