### PR TITLE
feat: pause/sleep controls — pause agent or whole team with resume time

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -691,6 +691,9 @@ Autonomous work-continuity system. Monitors agent queue floors and auto-replenis
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/team/manifest` | Team charter manifest from `~/.reflectt/TEAM.md`. Returns parsed sections, version hash, update timestamp, and raw markdown. Returns `404` if TEAM.md is missing with creation hint. |
+| GET | `/team/pause` | Current pause status for team and all agents. Returns `{ team, agents[] }` with paused, pausedUntil, reason. |
+| POST | `/team/pause` | Pause team or agent. Body: `{ scope: "team"|"agent-name", durationMinutes?, pausedUntil?, reason?, pausedBy? }`. Auto-resumes when pausedUntil passes. |
+| POST | `/team/resume` | Resume team or agent. Body: `{ scope: "team"|"agent-name" }`. |
 | GET | `/team/roles` | TEAM-ROLES routing matrix — agent skills, affinity scores, WIP caps |
 
 ## Other

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1219,6 +1219,8 @@ export function getDashboardHTML(): string {
 </head>
 <body>
 
+<div id="pause-banner" style="display:none;background:var(--yellow-dim);color:var(--yellow);padding:var(--space-2) var(--space-4);text-align:center;font-size:var(--text-sm);border-bottom:1px solid var(--yellow)"></div>
+
 <div class="header">
   <div class="header-left">
     <div class="header-logo">⚡ <span>reflectt</span>-node</div>

--- a/src/pause.ts
+++ b/src/pause.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Pause/sleep controls — pause agent or whole team with optional resume time.
+//
+// Storage: SQLite table `pause_state` with scope (agent name or '__team__'),
+// paused flag, optional pausedUntil timestamp, and reason.
+
+import { getDb } from './db.js'
+
+const TEAM_SCOPE = '__team__'
+
+export interface PauseEntry {
+  scope: string
+  paused: boolean
+  pausedAt: number | null
+  pausedUntil: number | null
+  reason: string | null
+  pausedBy: string | null
+}
+
+function ensureTable(): void {
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pause_state (
+      scope TEXT PRIMARY KEY,
+      paused INTEGER NOT NULL DEFAULT 0,
+      paused_at INTEGER,
+      paused_until INTEGER,
+      reason TEXT,
+      paused_by TEXT
+    )
+  `)
+}
+
+/** Pause an agent or the whole team. */
+export function setPaused(opts: {
+  scope: 'team' | string
+  paused: boolean
+  pausedUntil?: number
+  reason?: string
+  pausedBy?: string
+}): PauseEntry {
+  ensureTable()
+  const db = getDb()
+  const key = opts.scope === 'team' ? TEAM_SCOPE : opts.scope.toLowerCase()
+  const now = Date.now()
+
+  if (opts.paused) {
+    db.prepare(`
+      INSERT INTO pause_state (scope, paused, paused_at, paused_until, reason, paused_by)
+      VALUES (?, 1, ?, ?, ?, ?)
+      ON CONFLICT(scope) DO UPDATE SET
+        paused = 1,
+        paused_at = excluded.paused_at,
+        paused_until = excluded.paused_until,
+        reason = excluded.reason,
+        paused_by = excluded.paused_by
+    `).run(key, now, opts.pausedUntil ?? null, opts.reason ?? null, opts.pausedBy ?? null)
+  } else {
+    db.prepare(`
+      UPDATE pause_state SET paused = 0, paused_until = NULL WHERE scope = ?
+    `).run(key)
+  }
+
+  return getEntry(key)
+}
+
+function getEntry(scope: string): PauseEntry {
+  ensureTable()
+  const db = getDb()
+  const row = db.prepare('SELECT * FROM pause_state WHERE scope = ?').get(scope) as {
+    scope: string; paused: number; paused_at: number | null;
+    paused_until: number | null; reason: string | null; paused_by: string | null
+  } | undefined
+
+  if (!row) {
+    return { scope, paused: false, pausedAt: null, pausedUntil: null, reason: null, pausedBy: null }
+  }
+
+  // Auto-resume: if pausedUntil has passed, clear the pause
+  if (row.paused && row.paused_until && row.paused_until <= Date.now()) {
+    db.prepare('UPDATE pause_state SET paused = 0, paused_until = NULL WHERE scope = ?').run(scope)
+    return { scope, paused: false, pausedAt: row.paused_at, pausedUntil: null, reason: row.reason, pausedBy: row.paused_by }
+  }
+
+  return {
+    scope,
+    paused: row.paused === 1,
+    pausedAt: row.paused_at,
+    pausedUntil: row.paused_until,
+    reason: row.reason,
+    pausedBy: row.paused_by,
+  }
+}
+
+/** Check if an agent is paused (either individually or team-wide). */
+export function isPaused(agent?: string): {
+  paused: boolean
+  scope: 'team' | 'agent' | null
+  entry: PauseEntry | null
+  remainingMs: number | null
+} {
+  // Check team-wide pause first
+  const teamEntry = getEntry(TEAM_SCOPE)
+  if (teamEntry.paused) {
+    return {
+      paused: true,
+      scope: 'team',
+      entry: teamEntry,
+      remainingMs: teamEntry.pausedUntil ? Math.max(0, teamEntry.pausedUntil - Date.now()) : null,
+    }
+  }
+
+  // Check agent-specific pause
+  if (agent) {
+    const agentEntry = getEntry(agent.toLowerCase())
+    if (agentEntry.paused) {
+      return {
+        paused: true,
+        scope: 'agent',
+        entry: agentEntry,
+        remainingMs: agentEntry.pausedUntil ? Math.max(0, agentEntry.pausedUntil - Date.now()) : null,
+      }
+    }
+  }
+
+  return { paused: false, scope: null, entry: null, remainingMs: null }
+}
+
+/** Get all pause entries (for dashboard). */
+export function getPauseStatus(): { team: PauseEntry; agents: PauseEntry[] } {
+  ensureTable()
+  const db = getDb()
+  const rows = db.prepare('SELECT * FROM pause_state').all() as Array<{
+    scope: string; paused: number; paused_at: number | null;
+    paused_until: number | null; reason: string | null; paused_by: string | null
+  }>
+
+  let team = getEntry(TEAM_SCOPE)
+  const agents: PauseEntry[] = []
+
+  for (const row of rows) {
+    if (row.scope === TEAM_SCOPE) continue
+    const entry = getEntry(row.scope)
+    if (entry.paused) agents.push(entry)
+  }
+
+  return { team, agents }
+}
+
+/** Format remaining time for display. */
+export function formatRemaining(ms: number | null): string {
+  if (ms === null) return 'indefinite'
+  if (ms <= 0) return 'resuming now'
+  const mins = Math.ceil(ms / 60000)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remainMins = mins % 60
+  return remainMins > 0 ? `${hours}h ${remainMins}m` : `${hours}h`
+}


### PR DESCRIPTION
## Problem

External user (Jake, 15) has autonomous agents completing tasks too fast and needs a way to slow them down. No pause/sleep mechanism exists.

## Solution

### New module: `src/pause.ts` (159 lines)
- SQLite table `pause_state` — persists across restarts
- Per-agent and team-wide pause with optional `pausedUntil` timestamp
- Auto-resume when `pausedUntil` passes (checked on every read)

### API
| Endpoint | Description |
|---|---|
| `GET /team/pause` | Current pause status for team + all agents |
| `POST /team/pause` | Pause. Body: `{ scope, durationMinutes?, reason?, pausedBy? }` |
| `POST /team/resume` | Resume. Body: `{ scope }` |

### Integration
- `/tasks/next` — refuses pulls when paused, returns clear message with remaining time
- `/heartbeat/:agent` — shows pause status, suppresses next task suggestion
- Dashboard — yellow banner with pause reason + resume button

### Usage
```bash
# Pause entire team for 30 minutes
curl -X POST localhost:4445/team/pause -H 'Content-Type: application/json' \
  -d '{"scope": "team", "durationMinutes": 30, "reason": "taking a break"}'

# Pause one agent indefinitely
curl -X POST localhost:4445/team/pause -d '{"scope": "builder", "reason": "debugging"}'

# Resume
curl -X POST localhost:4445/team/resume -d '{"scope": "team"}'
```

## Testing
- `tsc --noEmit` clean
- 1474 tests pass (110 files)
- Route docs 390/390

Task: task-1772244618703-59j5lashg