### PR TITLE
Fix last-mile failures: public GHCR best-effort + role-aware review reassignment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,3 +49,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Ensure GHCR package is public (best effort)
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+        run: |
+          echo "Attempting to set GHCR package visibility to public for $OWNER/$PACKAGE"
+          gh api -X PATCH "/orgs/$OWNER/packages/container/$PACKAGE" -f visibility=public || \
+          gh api -X PATCH "/user/packages/container/$PACKAGE" -f visibility=public || true


### PR DESCRIPTION
Task: task-1772237929130-uvir79zr7

Fixes 2 sources of repeated onboarding/review noise:

1) GHCR unauthorized pulls
- After publishing, best-effort attempt to set GHCR package visibility to public (doesn't fail workflow if permissions prevent it).

2) Reviewer auto-reassign drift
- BoardHealthWorker review-reassign now respects assignment routing guardrails by using suggestReviewer ranking + active presence filtering (no more "most recently active" designer/voice drift).

Tests updated: review-reassignment now makes agent-3 active (eligible reviewer).

Artifact/proof: process/TASK-uvir79zr7-last-mile-onboarding.md