### PR TITLE
feat: team intensity/pacing controls — low/normal/high presets

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -700,6 +700,8 @@ Autonomous work-continuity system. Monitors agent queue floors and auto-replenis
 | POST | `/polls/:id/vote` | Cast a vote. Body: `{ voter, choice }` (choice is 0-indexed). Allows changing vote. |
 | POST | `/polls/:id/close` | Close a poll manually. |
 | GET | `/team/roles` | TEAM-ROLES routing matrix — agent skills, affinity scores, WIP caps |
+| GET | `/policy/intensity` | Current intensity preset + limits (wipLimit, maxPullsPerHour, batchIntervalMs). |
+| PUT | `/policy/intensity` | Set intensity preset. Body: `{ preset: "low"|"normal"|"high", updatedBy? }`. Returns new state. |
 
 ## Other
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1373,6 +1373,24 @@ export function getDashboardHTML(): string {
     color: var(--accent); text-decoration: none;
   }
   .getting-started .gs-step .gs-link:hover { text-decoration: underline; }
+
+  /* Intensity control */
+  .intensity-control {
+    display: flex; align-items: center; gap: 8px; padding: 8px 16px;
+    background: var(--surface, #1a1a2e); border-bottom: 1px solid var(--border, #2a2a4a);
+  }
+  .intensity-label { font-size: var(--text-xs, 11px); color: var(--text-muted, #888); text-transform: uppercase; letter-spacing: 0.05em; margin-right: 4px; }
+  .intensity-btn {
+    font-size: var(--text-sm, 13px); padding: 4px 12px; border-radius: var(--radius-sm, 4px);
+    border: 1px solid var(--border, #2a2a4a); background: transparent; color: var(--text-secondary, #aaa);
+    cursor: pointer; transition: all 0.15s ease;
+  }
+  .intensity-btn:hover { border-color: var(--accent, #60a5fa); color: var(--text-primary, #e0e0e0); }
+  .intensity-btn:focus-visible { outline: 2px solid var(--accent, #60a5fa); outline-offset: 2px; }
+  .intensity-btn.intensity-active {
+    background: var(--accent, #60a5fa); color: #fff; border-color: var(--accent, #60a5fa);
+  }
+  .intensity-info { font-size: var(--text-xs, 11px); color: var(--text-muted, #888); margin-left: 8px; }
 </style>
 <link rel="stylesheet" href="/dashboard-animations.css">
 </head>
@@ -1396,6 +1414,13 @@ export function getDashboardHTML(): string {
   <span class="pause-icon">⏸️</span>
   <span id="pause-message">Team paused</span>
   <button onclick="resumeFromBanner()" class="pause-resume-btn">Resume</button>
+</div>
+<div id="intensity-control" class="intensity-control" role="radiogroup" aria-label="Team intensity">
+  <span class="intensity-label">Intensity</span>
+  <button role="radio" aria-checked="false" class="intensity-btn" data-preset="low" onclick="setIntensity('low')" tabindex="0">🐢 Low</button>
+  <button role="radio" aria-checked="true" class="intensity-btn intensity-active" data-preset="normal" onclick="setIntensity('normal')" tabindex="-1">⚡ Normal</button>
+  <button role="radio" aria-checked="false" class="intensity-btn" data-preset="high" onclick="setIntensity('high')" tabindex="-1">🔥 High</button>
+  <span id="intensity-info" class="intensity-info"></span>
 </div>
 
 <div class="agent-strip" id="agent-strip"></div>

--- a/src/intensity.ts
+++ b/src/intensity.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Team pacing / intensity controls
+//
+// Maps a human-friendly intensity preset (low/normal/high) to concrete limits:
+//   wipLimit        – max simultaneous doing tasks per agent
+//   maxPullsPerHour – rate-limit on /tasks/next pulls per agent
+//   batchIntervalMs – message batching window (0 = immediate)
+//
+// Persisted in SQLite (survives restarts). Exposed via GET/PUT /policy/intensity.
+
+import { getDb } from './db.js'
+
+// ── Types ──
+
+export type IntensityPreset = 'low' | 'normal' | 'high'
+
+export interface IntensityLimits {
+  wipLimit: number
+  maxPullsPerHour: number
+  batchIntervalMs: number
+}
+
+export interface IntensityState {
+  preset: IntensityPreset
+  limits: IntensityLimits
+  updatedAt: number
+  updatedBy: string
+}
+
+// ── Preset definitions ──
+
+const PRESETS: Record<IntensityPreset, IntensityLimits> = {
+  low:    { wipLimit: 1, maxPullsPerHour: 2,  batchIntervalMs: 10 * 60_000 },
+  normal: { wipLimit: 2, maxPullsPerHour: 10, batchIntervalMs: 0 },
+  high:   { wipLimit: 3, maxPullsPerHour: 30, batchIntervalMs: 0 },
+}
+
+export function getPresetLimits(preset: IntensityPreset): IntensityLimits {
+  return { ...PRESETS[preset] }
+}
+
+export function isValidPreset(v: unknown): v is IntensityPreset {
+  return typeof v === 'string' && (v === 'low' || v === 'normal' || v === 'high')
+}
+
+// ── DB persistence ──
+
+function ensureTable(): void {
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS intensity (
+      key       TEXT PRIMARY KEY DEFAULT 'global',
+      preset    TEXT NOT NULL DEFAULT 'normal',
+      updated_at INTEGER NOT NULL,
+      updated_by TEXT NOT NULL DEFAULT 'system'
+    )
+  `)
+}
+
+/** Read current intensity. Returns 'normal' if never set. */
+export function getIntensity(): IntensityState {
+  ensureTable()
+  const db = getDb()
+  const row = db.prepare('SELECT preset, updated_at, updated_by FROM intensity WHERE key = ?').get('global') as
+    { preset: string; updated_at: number; updated_by: string } | undefined
+
+  const preset: IntensityPreset = row && isValidPreset(row.preset) ? row.preset : 'normal'
+  return {
+    preset,
+    limits: getPresetLimits(preset),
+    updatedAt: row?.updated_at ?? 0,
+    updatedBy: row?.updated_by ?? 'default',
+  }
+}
+
+/** Set intensity preset. Returns new state. */
+export function setIntensity(preset: IntensityPreset, updatedBy: string): IntensityState {
+  ensureTable()
+  const db = getDb()
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO intensity (key, preset, updated_at, updated_by)
+    VALUES ('global', ?, ?, ?)
+    ON CONFLICT(key) DO UPDATE SET preset = excluded.preset, updated_at = excluded.updated_at, updated_by = excluded.updated_by
+  `).run(preset, now, updatedBy)
+
+  return {
+    preset,
+    limits: getPresetLimits(preset),
+    updatedAt: now,
+    updatedBy,
+  }
+}
+
+// ── Pull rate limiting ──
+
+// In-memory sliding window per agent (resets on restart — acceptable since
+// restarts are infrequent and the limit is soft/UX-oriented, not security).
+const pullLog: Map<string, number[]> = new Map()
+
+/** Record a task pull for an agent. Returns { allowed, remaining, resetsInMs }. */
+export function recordPull(agent: string): { allowed: boolean; remaining: number; resetsInMs: number } {
+  const { limits } = getIntensity()
+  const now = Date.now()
+  const windowMs = 60 * 60_000 // 1 hour
+
+  const log = pullLog.get(agent) ?? []
+  // Prune entries older than window
+  const recent = log.filter(ts => now - ts < windowMs)
+
+  if (recent.length >= limits.maxPullsPerHour) {
+    const oldest = recent[0]!
+    return { allowed: false, remaining: 0, resetsInMs: windowMs - (now - oldest) }
+  }
+
+  recent.push(now)
+  pullLog.set(agent, recent)
+  return { allowed: true, remaining: limits.maxPullsPerHour - recent.length, resetsInMs: 0 }
+}
+
+/** Check pull budget without recording. */
+export function checkPullBudget(agent: string): { remaining: number; limit: number; windowMs: number } {
+  const { limits } = getIntensity()
+  const now = Date.now()
+  const windowMs = 60 * 60_000
+  const log = pullLog.get(agent) ?? []
+  const recent = log.filter(ts => now - ts < windowMs)
+  return { remaining: limits.maxPullsPerHour - recent.length, limit: limits.maxPullsPerHour, windowMs }
+}

--- a/tests/intensity.test.ts
+++ b/tests/intensity.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+// We test the exported functions directly — they use SQLite via getDb()
+// which vitest sets up with an in-memory DB via the test helper.
+
+describe('intensity', () => {
+  let mod: typeof import('../src/intensity.js')
+
+  beforeEach(async () => {
+    // Fresh import each time to reset module state
+    mod = await import('../src/intensity.js')
+  })
+
+  it('defaults to normal preset', () => {
+    const state = mod.getIntensity()
+    expect(state.preset).toBe('normal')
+    expect(state.limits.wipLimit).toBe(2)
+    expect(state.limits.maxPullsPerHour).toBe(10)
+    expect(state.limits.batchIntervalMs).toBe(0)
+  })
+
+  it('validates presets', () => {
+    expect(mod.isValidPreset('low')).toBe(true)
+    expect(mod.isValidPreset('normal')).toBe(true)
+    expect(mod.isValidPreset('high')).toBe(true)
+    expect(mod.isValidPreset('turbo')).toBe(false)
+    expect(mod.isValidPreset('')).toBe(false)
+    expect(mod.isValidPreset(42)).toBe(false)
+  })
+
+  it('sets and persists intensity', () => {
+    const state = mod.setIntensity('low', 'test-user')
+    expect(state.preset).toBe('low')
+    expect(state.limits.wipLimit).toBe(1)
+    expect(state.limits.maxPullsPerHour).toBe(2)
+    expect(state.limits.batchIntervalMs).toBe(10 * 60_000)
+    expect(state.updatedBy).toBe('test-user')
+    expect(state.updatedAt).toBeGreaterThan(0)
+
+    // Read back
+    const read = mod.getIntensity()
+    expect(read.preset).toBe('low')
+  })
+
+  it('switches between presets', () => {
+    mod.setIntensity('high', 'admin')
+    expect(mod.getIntensity().limits.wipLimit).toBe(3)
+    expect(mod.getIntensity().limits.maxPullsPerHour).toBe(30)
+
+    mod.setIntensity('normal', 'admin')
+    expect(mod.getIntensity().limits.wipLimit).toBe(2)
+  })
+
+  it('records pulls and enforces rate limit', () => {
+    mod.setIntensity('low', 'test') // 2 pulls/hr
+
+    const pull1 = mod.recordPull('agent-a')
+    expect(pull1.allowed).toBe(true)
+    expect(pull1.remaining).toBe(1)
+
+    const pull2 = mod.recordPull('agent-a')
+    expect(pull2.allowed).toBe(true)
+    expect(pull2.remaining).toBe(0)
+
+    const pull3 = mod.recordPull('agent-a')
+    expect(pull3.allowed).toBe(false)
+    expect(pull3.resetsInMs).toBeGreaterThan(0)
+  })
+
+  it('tracks pulls per agent independently', () => {
+    mod.setIntensity('low', 'test') // 2 pulls/hr
+
+    mod.recordPull('agent-a')
+    mod.recordPull('agent-a')
+
+    // agent-b should still have budget
+    const pull = mod.recordPull('agent-b')
+    expect(pull.allowed).toBe(true)
+  })
+
+  it('checkPullBudget reports remaining without consuming', () => {
+    mod.setIntensity('low', 'test') // 2 pulls/hr
+
+    const before = mod.checkPullBudget('agent-c')
+    expect(before.remaining).toBe(2)
+    expect(before.limit).toBe(2)
+
+    // Should still be 2 — checkPullBudget doesn't consume
+    const after = mod.checkPullBudget('agent-c')
+    expect(after.remaining).toBe(2)
+  })
+
+  it('preset limits are correct for each level', () => {
+    const low = mod.getPresetLimits('low')
+    expect(low).toEqual({ wipLimit: 1, maxPullsPerHour: 2, batchIntervalMs: 600000 })
+
+    const normal = mod.getPresetLimits('normal')
+    expect(normal).toEqual({ wipLimit: 2, maxPullsPerHour: 10, batchIntervalMs: 0 })
+
+    const high = mod.getPresetLimits('high')
+    expect(high).toEqual({ wipLimit: 3, maxPullsPerHour: 30, batchIntervalMs: 0 })
+  })
+})


### PR DESCRIPTION
## Summary
Team pacing controls + dashboard UI. Maps intensity preset (low/normal/high) to concrete limits. Direct response to Jake's "slow them down" signal.

## Changes
- **`src/intensity.ts`** (new, 119 lines): SQLite-persisted intensity with preset→limits mapping
  - `low`: wipLimit=1, 2 pulls/hr, 10m batch interval
  - `normal`: wipLimit=2, 10 pulls/hr, immediate
  - `high`: wipLimit=3, 30 pulls/hr, immediate
- **`src/server.ts`**: `GET/PUT /policy/intensity` endpoints + pull rate-limit in `/tasks/next` + intensity info in heartbeat
- **`src/dashboard.ts`**: Intensity control bar HTML + CSS (design tokens)
- **`public/dashboard.js`**: `loadIntensityControl()`, `setIntensity()`, keyboard nav (arrow keys in radiogroup)
- **`public/docs.md`**: Route documentation
- **`tests/intensity.test.ts`** (new, 8 tests): Presets, persistence, rate limiting

## A11y
- `role="radiogroup"` with `aria-label`
- Each button: `role="radio"` + `aria-checked` + roving `tabindex`
- Arrow key navigation (Left/Right/Up/Down)
- `focus-visible` outline using design tokens

## Proof
```
Test Files  111 passed (111)
Tests       1482 passed | 1 skipped (1483)
Route docs: 396/396 ✅
tsc: clean
```

Closes task-1772244618671-i6yrar478, task-1772251612104-ogin2za1t