### PR TITLE
chore: add process artifact for u7edc3c9y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ process/*
 !process/TASK-47sxe374r.md
 !process/TASK-iwphjvsrl.md
 !process/TASK-task-rcuuep9co.md
+!process/TASK-u7edc3c9y.md

--- a/process/TASK-u7edc3c9y.md
+++ b/process/TASK-u7edc3c9y.md
@@ -1,0 +1,23 @@
+# TASK-u7edc3c9y — Team Polls UI (design)
+
+PR: https://github.com/reflectt/reflectt-node/pull/510
+
+## What shipped
+- `public/polls-mock.html` — interactive HTML mock (creation form, vote, live results bars)
+- Spec doc (Pixel): `shared/process/TASK-u7edc3c9y.md`
+
+## How to view
+1) Checkout PR branch (or pull from main once merged)
+2) Open:
+
+```bash
+open public/polls-mock.html
+```
+
+## Design intent (implementation guidance)
+- Use Reflectt Design Tokens v1 (see `docs/DESIGN-TOKENS.md`)
+- Focus-visible uses tokenized ring / shadow
+- Hover affordances avoid sticky hover on touch devices
+
+## Notes
+This is a design artifact PR (no backend). Implementation should follow in a separate task/PR.


### PR DESCRIPTION
Adds a small process artifact under process/ for task-1772249879438-u7edc3c9y so the task can enter validating with an artifact_path (process/ is gitignored by default).

References the canonical design PR #510 and points to shared/process spec.
