### PR TITLE
feat: file upload API — POST/GET/DELETE /files with multipart support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",
+        "@fastify/multipart": "^9.4.0",
         "@fastify/websocket": "^11.0.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -499,6 +500,12 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cors": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-10.1.0.tgz",
@@ -518,6 +525,22 @@
         "fastify-plugin": "^5.0.0",
         "mnemonist": "0.40.0"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -587,6 +610,29 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.4.0.tgz",
+      "integrity": "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@fastify/cors": "^10.0.1",
+    "@fastify/multipart": "^9.4.0",
     "@fastify/websocket": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@supabase/supabase-js": "^2.95.3",

--- a/public/docs.md
+++ b/public/docs.md
@@ -686,6 +686,16 @@ Autonomous work-continuity system. Monitors agent queue floors and auto-replenis
 |--------|------|-------------|
 | GET | `/shipped-heartbeat/stats` | Shipped-artifact heartbeat stats: messages sent, errors, last heartbeat timestamp. |
 
+## Files
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/files` | Upload a file (multipart/form-data). Fields: `file` (required), `uploadedBy`, `tags` (JSON array). Returns `{ success, file }`. 50MB limit. |
+| GET | `/files/:id` | Download file bytes with correct Content-Type. Images served inline, others as attachment. |
+| GET | `/files/:id/meta` | File metadata only (no bytes). Returns `{ success, file }`. |
+| GET | `/files` | List files. Query: `uploadedBy`, `tag`, `limit` (default 50), `offset`. Returns `{ files[], total }`. |
+| DELETE | `/files/:id` | Delete file (disk + metadata). Returns `{ success }`. |
+
 ## Team
 
 | Method | Path | Description |

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// File upload/download/management
+//
+// Stores file bytes under REFLECTT_HOME/files/<uuid>.<ext>
+// Metadata in SQLite `files` table.
+// 50MB upload limit. Extension allowlist for safety.
+
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync, statSync } from 'node:fs'
+import { join, extname } from 'node:path'
+import { getDb } from './db.js'
+import { REFLECTT_HOME } from './config.js'
+
+// ── Types ──
+
+export interface FileMeta {
+  id: string
+  originalName: string
+  storedPath: string
+  mimeType: string
+  sizeBytes: number
+  uploadedBy: string
+  tags: string[]
+  createdAt: number
+}
+
+// ── Constants ──
+
+const FILES_DIR = join(REFLECTT_HOME, 'files')
+const MAX_SIZE_BYTES = 50 * 1024 * 1024 // 50MB
+
+// Extension → MIME type mapping (allowlist)
+const ALLOWED_EXTENSIONS: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.csv': 'text/csv',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.xls': 'application/vnd.ms-excel',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.json': 'application/json',
+  '.yaml': 'text/yaml',
+  '.yml': 'text/yaml',
+  '.zip': 'application/zip',
+  '.log': 'text/plain',
+}
+
+const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'])
+
+export { MAX_SIZE_BYTES, FILES_DIR }
+
+// ── DB ──
+
+function ensureTable(): void {
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS files (
+      id          TEXT PRIMARY KEY,
+      original_name TEXT NOT NULL,
+      stored_path TEXT NOT NULL,
+      mime_type   TEXT NOT NULL,
+      size_bytes  INTEGER NOT NULL,
+      uploaded_by TEXT NOT NULL DEFAULT 'anonymous',
+      tags        TEXT NOT NULL DEFAULT '[]',
+      created_at  INTEGER NOT NULL
+    )
+  `)
+  mkdirSync(FILES_DIR, { recursive: true })
+}
+
+// ── Core operations ──
+
+export interface UploadInput {
+  filename: string
+  buffer: Buffer
+  uploadedBy?: string
+  tags?: string[]
+  mimeType?: string
+}
+
+export interface UploadResult {
+  success: boolean
+  file?: FileMeta
+  error?: string
+}
+
+/** Upload a file. Returns metadata or error. */
+export function uploadFile(input: UploadInput): UploadResult {
+  ensureTable()
+
+  const { filename, buffer, uploadedBy = 'anonymous', tags = [] } = input
+
+  // Size check
+  if (buffer.length > MAX_SIZE_BYTES) {
+    return { success: false, error: `File exceeds ${MAX_SIZE_BYTES / (1024 * 1024)}MB limit (got ${(buffer.length / (1024 * 1024)).toFixed(1)}MB)` }
+  }
+
+  // Extension check
+  const ext = extname(filename).toLowerCase()
+  if (!ALLOWED_EXTENSIONS[ext]) {
+    return { success: false, error: `File extension "${ext}" is not allowed. Allowed: ${Object.keys(ALLOWED_EXTENSIONS).join(', ')}` }
+  }
+
+  const id = randomUUID()
+  const storedName = `${id}${ext}`
+  const storedPath = join(FILES_DIR, storedName)
+  const mimeType = input.mimeType || ALLOWED_EXTENSIONS[ext] || 'application/octet-stream'
+
+  // Write to disk
+  writeFileSync(storedPath, buffer)
+
+  // Write metadata
+  const now = Date.now()
+  const db = getDb()
+  db.prepare(`
+    INSERT INTO files (id, original_name, stored_path, mime_type, size_bytes, uploaded_by, tags, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, filename, storedPath, mimeType, buffer.length, uploadedBy, JSON.stringify(tags), now)
+
+  const file: FileMeta = {
+    id,
+    originalName: filename,
+    storedPath,
+    mimeType,
+    sizeBytes: buffer.length,
+    uploadedBy,
+    tags,
+    createdAt: now,
+  }
+
+  return { success: true, file }
+}
+
+/** Get file metadata by ID. */
+export function getFile(id: string): FileMeta | null {
+  ensureTable()
+  const db = getDb()
+  const row = db.prepare('SELECT * FROM files WHERE id = ?').get(id) as Record<string, unknown> | undefined
+  if (!row) return null
+  return rowToMeta(row)
+}
+
+/** Read file bytes. Returns null if not found. */
+export function readFile(id: string): { meta: FileMeta; buffer: Buffer } | null {
+  const meta = getFile(id)
+  if (!meta) return null
+  if (!existsSync(meta.storedPath)) return null
+  return { meta, buffer: readFileSync(meta.storedPath) }
+}
+
+/** List files with optional filters. */
+export function listFiles(opts: { uploadedBy?: string; tag?: string; limit?: number; offset?: number } = {}): { files: FileMeta[]; total: number } {
+  ensureTable()
+  const db = getDb()
+  const conditions: string[] = []
+  const params: unknown[] = []
+
+  if (opts.uploadedBy) {
+    conditions.push('uploaded_by = ?')
+    params.push(opts.uploadedBy)
+  }
+  if (opts.tag) {
+    conditions.push("tags LIKE ?")
+    params.push(`%"${opts.tag}"%`)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  const limit = Math.min(opts.limit || 50, 200)
+  const offset = opts.offset || 0
+
+  const total = (db.prepare(`SELECT COUNT(*) as c FROM files ${where}`).get(...params) as { c: number }).c
+  const rows = db.prepare(`SELECT * FROM files ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`).all(...params, limit, offset) as Array<Record<string, unknown>>
+
+  return { files: rows.map(rowToMeta), total }
+}
+
+/** Delete a file (metadata + disk). */
+export function deleteFile(id: string): { success: boolean; error?: string } {
+  ensureTable()
+  const meta = getFile(id)
+  if (!meta) return { success: false, error: 'File not found' }
+
+  // Remove from disk
+  if (existsSync(meta.storedPath)) {
+    unlinkSync(meta.storedPath)
+  }
+
+  // Remove metadata
+  const db = getDb()
+  db.prepare('DELETE FROM files WHERE id = ?').run(id)
+
+  return { success: true }
+}
+
+/** Check if a MIME type is an image (for inline preview). */
+export function isImage(mimeType: string): boolean {
+  return IMAGE_MIMES.has(mimeType)
+}
+
+// ── Helpers ──
+
+function rowToMeta(row: Record<string, unknown>): FileMeta {
+  let tags: string[] = []
+  try { tags = JSON.parse(String(row.tags || '[]')) } catch { tags = [] }
+  return {
+    id: String(row.id),
+    originalName: String(row.original_name),
+    storedPath: String(row.stored_path),
+    mimeType: String(row.mime_type),
+    sizeBytes: Number(row.size_bytes) || 0,
+    uploadedBy: String(row.uploaded_by || 'anonymous'),
+    tags,
+    createdAt: Number(row.created_at) || 0,
+  }
+}

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('files', () => {
+  let mod: typeof import('../src/files.js')
+
+  beforeEach(async () => {
+    mod = await import('../src/files.js')
+    // Ensure files dir exists (uses REFLECTT_HOME from test env)
+    mkdirSync(mod.FILES_DIR, { recursive: true })
+    // Clean DB table between tests to avoid cross-test pollution
+    const { getDb } = await import('../src/db.js')
+    const db = getDb()
+    try { db.exec('DELETE FROM files') } catch {}
+  })
+
+  afterEach(() => {
+    // Clean up test files
+    if (existsSync(mod.FILES_DIR)) {
+      try { rmSync(mod.FILES_DIR, { recursive: true, force: true }) } catch {}
+    }
+  })
+
+  it('uploads a valid file', () => {
+    const result = mod.uploadFile({
+      filename: 'test.pdf',
+      buffer: Buffer.from('fake pdf content'),
+      uploadedBy: 'ryan',
+      tags: ['bank-statement'],
+    })
+    expect(result.success).toBe(true)
+    expect(result.file).toBeDefined()
+    expect(result.file!.originalName).toBe('test.pdf')
+    expect(result.file!.mimeType).toBe('application/pdf')
+    expect(result.file!.uploadedBy).toBe('ryan')
+    expect(result.file!.tags).toEqual(['bank-statement'])
+    expect(result.file!.sizeBytes).toBe(16)
+    expect(result.file!.id).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it('rejects disallowed extensions', () => {
+    const result = mod.uploadFile({
+      filename: 'hack.exe',
+      buffer: Buffer.from('malware'),
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not allowed')
+  })
+
+  it('rejects oversized files', () => {
+    // Create a buffer just over the limit
+    const result = mod.uploadFile({
+      filename: 'huge.pdf',
+      buffer: Buffer.alloc(mod.MAX_SIZE_BYTES + 1),
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('50MB limit')
+  })
+
+  it('retrieves file by ID', () => {
+    const upload = mod.uploadFile({
+      filename: 'doc.txt',
+      buffer: Buffer.from('hello world'),
+    })
+    expect(upload.success).toBe(true)
+
+    const result = mod.readFile(upload.file!.id)
+    expect(result).not.toBeNull()
+    expect(result!.meta.originalName).toBe('doc.txt')
+    expect(result!.buffer.toString()).toBe('hello world')
+  })
+
+  it('returns null for missing file', () => {
+    expect(mod.getFile('nonexistent-id')).toBeNull()
+    expect(mod.readFile('nonexistent-id')).toBeNull()
+  })
+
+  it('lists files', () => {
+    mod.uploadFile({ filename: 'a.txt', buffer: Buffer.from('a'), uploadedBy: 'alice' })
+    mod.uploadFile({ filename: 'b.pdf', buffer: Buffer.from('b'), uploadedBy: 'bob' })
+    mod.uploadFile({ filename: 'c.txt', buffer: Buffer.from('c'), uploadedBy: 'alice', tags: ['important'] })
+
+    const all = mod.listFiles()
+    expect(all.total).toBe(3)
+    expect(all.files.length).toBe(3)
+
+    const byAlice = mod.listFiles({ uploadedBy: 'alice' })
+    expect(byAlice.total).toBe(2)
+
+    const byTag = mod.listFiles({ tag: 'important' })
+    expect(byTag.total).toBe(1)
+    expect(byTag.files[0].originalName).toBe('c.txt')
+  })
+
+  it('lists with pagination', () => {
+    for (let i = 0; i < 5; i++) {
+      mod.uploadFile({ filename: `file${i}.txt`, buffer: Buffer.from(`content ${i}`) })
+    }
+    const page1 = mod.listFiles({ limit: 2, offset: 0 })
+    expect(page1.files.length).toBe(2)
+    expect(page1.total).toBe(5)
+
+    const page2 = mod.listFiles({ limit: 2, offset: 2 })
+    expect(page2.files.length).toBe(2)
+  })
+
+  it('deletes a file', () => {
+    const upload = mod.uploadFile({ filename: 'delete-me.txt', buffer: Buffer.from('bye') })
+    expect(upload.success).toBe(true)
+
+    const del = mod.deleteFile(upload.file!.id)
+    expect(del.success).toBe(true)
+
+    // Verify gone
+    expect(mod.getFile(upload.file!.id)).toBeNull()
+    expect(existsSync(upload.file!.storedPath)).toBe(false)
+  })
+
+  it('delete returns error for missing file', () => {
+    const result = mod.deleteFile('nonexistent')
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+
+  it('isImage detects image MIME types', () => {
+    expect(mod.isImage('image/png')).toBe(true)
+    expect(mod.isImage('image/jpeg')).toBe(true)
+    expect(mod.isImage('application/pdf')).toBe(false)
+    expect(mod.isImage('text/plain')).toBe(false)
+  })
+
+  it('supports all expected file types', () => {
+    const types = ['.pdf', '.png', '.jpg', '.jpeg', '.gif', '.csv', '.xlsx', '.txt', '.md', '.json', '.yaml', '.zip']
+    for (const ext of types) {
+      const result = mod.uploadFile({ filename: `test${ext}`, buffer: Buffer.from('x') })
+      expect(result.success).toBe(true)
+      expect(result.file!.mimeType).toBeTruthy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
File upload/download API for reflectt-node. Ryan needs to share bank statements with the back office team — this unblocks any workflow where humans share docs with agents.

## Changes
- **`src/files.ts`** (new, 185 lines): Core module
  - SQLite `files` table for metadata
  - Disk storage in `REFLECTT_HOME/files/<uuid>.<ext>`
  - Extension allowlist (pdf, png, jpg, gif, webp, svg, csv, xlsx, xls, doc, docx, txt, md, json, yaml, yml, zip, log)
  - 50MB limit enforced
  - `uploadFile()`, `getFile()`, `readFile()`, `listFiles()`, `deleteFile()`, `isImage()`
- **`src/server.ts`**: 5 new endpoints + `@fastify/multipart` registration
  - `POST /files` — multipart upload with `uploadedBy` + `tags` fields
  - `GET /files/:id` — serve bytes (inline for images, attachment otherwise)
  - `GET /files/:id/meta` — metadata only
  - `GET /files` — list with filters + pagination
  - `DELETE /files/:id` — remove disk + metadata
- **`public/docs.md`**: Route documentation
- **`tests/files.test.ts`** (new, 11 tests): Full coverage

## Security
- Extension allowlist rejects `.exe`, `.sh`, etc.
- UUID filenames on disk (no path traversal via original name)
- `Content-Disposition: attachment` for non-images
- 50MB enforced at both fastify and application layer

## Proof
```
Test Files  112 passed (112)
Tests       1493 passed | 1 skipped (1494)
Route docs: 401/401 ✅
tsc: clean
```

Closes task-1772253890056-hzdnp2dsl