### PR TITLE
feat: dashboard Pause/Resume button + docs

### DIFF
--- a/docs/PAUSE-CONTROLS.md
+++ b/docs/PAUSE-CONTROLS.md
@@ -1,0 +1,79 @@
+# Pause & Resume Controls
+
+Stop and restart agent task pulls without shutting down reflectt-node.
+
+## Dashboard
+
+Click the **⏸️ Pause** button in the header bar. When paused:
+- The button changes to **▶️ Resume**
+- A yellow banner shows who paused and why
+- Agents calling `/tasks/next` or `/heartbeat/:agent` receive a paused response
+- No new tasks are claimed until resumed
+
+Click **▶️ Resume** (header button or banner) to restore normal operation.
+
+## API
+
+### Pause the team
+```bash
+curl -X POST http://127.0.0.1:4445/pause \
+  -H "Content-Type: application/json" \
+  -d '{"target": "team", "pausedBy": "ryan", "reason": "Deploying v2.1"}'
+```
+
+### Pause with a timer (auto-resume after N minutes)
+```bash
+curl -X POST http://127.0.0.1:4445/pause \
+  -H "Content-Type: application/json" \
+  -d '{"target": "team", "durationMin": 30, "pausedBy": "ryan", "reason": "Maintenance window"}'
+```
+
+### Pause a single agent
+```bash
+curl -X POST http://127.0.0.1:4445/pause \
+  -H "Content-Type: application/json" \
+  -d '{"target": "link", "pausedBy": "ryan", "reason": "Reviewing PRs"}'
+```
+
+### Resume
+```bash
+# Resume team
+curl -X DELETE "http://127.0.0.1:4445/pause?target=team"
+
+# Resume specific agent
+curl -X DELETE "http://127.0.0.1:4445/pause?target=link"
+```
+
+### Check status
+```bash
+# All pause entries
+curl http://127.0.0.1:4445/pause/status
+
+# Specific agent
+curl "http://127.0.0.1:4445/pause/status?agent=link"
+```
+
+## How It Works
+
+- `POST /pause` creates a pause entry (team-wide or per-agent)
+- `/tasks/next` and `/heartbeat/:agent` check pause status before returning tasks
+- Timed pauses auto-expire — no manual resume needed
+- Pause state persists across server restarts (stored in DB)
+- The dashboard polls `/pause/status` every 30 seconds to stay in sync
+
+## Intensity Controls
+
+Separate from pause, **intensity** controls how aggressively agents pull tasks:
+
+| Preset | Behavior |
+|--------|----------|
+| 🐢 Low | Fewer pulls, longer delays between tasks |
+| ⚡ Normal | Default cadence |
+| 🔥 High | Aggressive pulls, shorter cooldowns |
+
+Set via the intensity buttons in the dashboard header, or:
+```bash
+curl -X PUT http://127.0.0.1:4445/policy/intensity \
+  -H "Content-Type: application/json" \
+  -d '{"preset": "low"}'
+```

--- a/docs/PAUSE.md
+++ b/docs/PAUSE.md
@@ -1,0 +1,84 @@
+# Pause Controls
+
+Pause an agent or the entire team. While paused, `/tasks/next` refuses to assign new work and heartbeats show `PAUSED` status. Auto-resumes when the optional duration expires.
+
+## Quick Start
+
+### Pause the whole team for 30 minutes
+
+```bash
+curl -X POST http://localhost:4445/pause \
+  -H "Content-Type: application/json" \
+  -d '{"target": "team", "durationMin": 30, "reason": "Standup meeting", "pausedBy": "ryan"}'
+```
+
+### Pause a single agent indefinitely
+
+```bash
+curl -X POST http://localhost:4445/pause \
+  -H "Content-Type: application/json" \
+  -d '{"target": "kale", "reason": "Too fast, needs to slow down", "pausedBy": "jake"}'
+```
+
+### Resume
+
+```bash
+# Resume the team
+curl -X DELETE "http://localhost:4445/pause?target=team"
+
+# Resume a specific agent
+curl -X DELETE "http://localhost:4445/pause?target=kale"
+```
+
+### Check status
+
+```bash
+# All pause entries
+curl http://localhost:4445/pause/status
+
+# Specific agent (checks team-wide + agent-specific)
+curl "http://localhost:4445/pause/status?agent=kale"
+```
+
+## API Reference
+
+### `POST /pause`
+
+Pause an agent or team.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `target` | string | yes | Agent name or `"team"` for team-wide |
+| `durationMin` | number | no | Auto-resume after N minutes |
+| `pausedUntil` | number | no | Unix timestamp to auto-resume (alternative to durationMin) |
+| `reason` | string | no | Human-readable reason (default: "Manual pause") |
+| `pausedBy` | string | no | Who triggered the pause |
+
+### `DELETE /pause?target=<name>`
+
+Resume an agent or team. Query parameter `target` is required.
+
+### `GET /pause/status?agent=<name>`
+
+Check pause status. Without `agent`, returns all pause entries. With `agent`, checks team-wide pause first, then agent-specific.
+
+## Behavior
+
+- **Task pulls blocked**: `/tasks/next` returns `{ task: null, paused: true, message: "..." }` when the requested agent or team is paused.
+- **Heartbeats show paused**: `/heartbeat/:agent` includes `paused: true` and `pauseMessage` fields. Action shows `PAUSED: <reason>`.
+- **Auto-resume**: When `pausedUntil` timestamp passes, the next status check auto-clears the pause.
+- **Scope priority**: Team-wide pause takes precedence over agent-specific state. An agent is paused if either team or agent is paused.
+- **Persistence**: Pause state is stored in SQLite and survives server restarts.
+
+## Dashboard UI
+
+- **Intensity bar**: The ⏸️ Pause / ▶️ Resume button sits next to the intensity control.
+- **Banner**: When paused, a banner appears at the top of the dashboard with the reason and a Resume button.
+- Both update every 30 seconds automatically.
+
+## Use Cases
+
+1. **"Slow them down"**: Jake's agents were completing tasks too fast. Pause the team, review what they've done, then resume.
+2. **Meeting time**: Pause during standup so agents don't interrupt with task claims.
+3. **Debugging**: Pause an agent that's misbehaving while you investigate.
+4. **Off-hours**: Pause the team overnight with `durationMin: 480` (8 hours).

--- a/process/task-imir2x4eg-pause-controls.md
+++ b/process/task-imir2x4eg-pause-controls.md
@@ -1,0 +1,12 @@
+# task-1772254677757-imir2x4eg — Pause Controls
+
+## Summary
+Dashboard Pause/Resume toggle + comprehensive docs for pause/intensity controls.
+
+## Changes
+- `src/dashboard.ts`: Pause button in header (yellow highlight when active, focus-visible)
+- `public/dashboard.js`: Toggle logic syncing with /pause API + banner
+- `docs/PAUSE-CONTROLS.md`: API reference, examples, intensity controls
+
+## PR
+https://github.com/reflectt/reflectt-node/pull/519

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1105,6 +1105,19 @@ export function getDashboardHTML(): string {
   }
   .focus-toggle .focus-icon { font-size: var(--text-md); }
 
+  .pause-toggle {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 5px 12px; border-radius: var(--radius-full); font-size: 12px; font-weight: 600;
+    cursor: pointer; border: 1px solid var(--border); background: var(--surface-raised);
+    color: var(--text-muted); transition: all var(--transition-base) var(--easing-smooth);
+    user-select: none;
+  }
+  .pause-toggle:hover { border-color: var(--yellow, #eab308); color: var(--text); }
+  .pause-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .pause-toggle.paused {
+    background: var(--yellow-dim, rgba(234, 179, 8, 0.15)); border-color: var(--yellow, #eab308); color: var(--yellow, #eab308);
+  }
+
   /* Focus mode active: dim non-active kanban columns */
   body.focus-mode .kanban-col:not([data-status="doing"]) {
     opacity: 0.3;
@@ -1502,6 +1515,19 @@ export function getDashboardHTML(): string {
     background: var(--accent, #60a5fa); color: #fff; border-color: var(--accent, #60a5fa);
   }
   .intensity-info { font-size: var(--text-xs, 11px); color: var(--text-muted, #888); margin-left: 8px; }
+  .intensity-sep { color: var(--border, #2a2a4a); margin: 0 4px; }
+  .pause-toggle-btn {
+    font-size: var(--text-sm, 13px); padding: 4px 12px; border-radius: var(--radius-sm, 4px);
+    border: 1px solid var(--border, #2a2a4a); background: transparent; color: var(--text-secondary, #aaa);
+    cursor: pointer; transition: all 0.15s ease;
+  }
+  .pause-toggle-btn:hover { border-color: var(--red, #f87171); color: var(--red, #f87171); }
+  .pause-toggle-btn:focus-visible { outline: 2px solid var(--accent, #60a5fa); outline-offset: 2px; }
+  .pause-toggle-btn.paused {
+    background: var(--red-dim, rgba(248,113,113,0.12)); color: var(--red, #f87171);
+    border-color: var(--red, #f87171);
+  }
+  .pause-toggle-btn.paused:hover { background: var(--green-dim, rgba(74,222,128,0.12)); color: var(--green, #4ade80); border-color: var(--green, #4ade80); }
 </style>
 <link rel="stylesheet" href="/dashboard-animations.css">
 </head>
@@ -1515,6 +1541,9 @@ export function getDashboardHTML(): string {
     <span><span class="status-dot"></span>Running</span>
     <button class="focus-toggle" id="focus-toggle" onclick="toggleFocusMode()" title="Focus Mode: highlight active work, collapse noise">
       <span class="focus-icon">🎯</span> Focus
+    </button>
+    <button class="pause-toggle" id="pause-toggle" onclick="togglePause()" title="Pause/Resume team task pulls" aria-label="Pause or resume team">
+      <span id="pause-toggle-icon">⏸️</span> <span id="pause-toggle-label">Pause</span>
     </button>
     <span id="release-badge" class="release-badge" title="Deploy status">deploy: checking…</span>
     <span id="build-badge" class="release-badge" title="Build info">build: loading…</span>
@@ -1532,6 +1561,8 @@ export function getDashboardHTML(): string {
   <button role="radio" aria-checked="true" class="intensity-btn intensity-active" data-preset="normal" onclick="setIntensity('normal')" tabindex="-1">⚡ Normal</button>
   <button role="radio" aria-checked="false" class="intensity-btn" data-preset="high" onclick="setIntensity('high')" tabindex="-1">🔥 High</button>
   <span id="intensity-info" class="intensity-info"></span>
+  <span class="intensity-sep">|</span>
+  <button id="pause-toggle-btn" class="pause-toggle-btn" onclick="toggleTeamPause()" aria-label="Pause team" tabindex="0">⏸️ Pause</button>
 </div>
 
 <div class="agent-strip" id="agent-strip"></div>


### PR DESCRIPTION
## Summary
Finish the pause controls loop: dashboard UI entry point + comprehensive docs + proof.

## Changes
- **`src/dashboard.ts`**: Pause toggle button (⏸️/▶️) next to intensity control with token-based styling, red/green state colors, focus-visible
- **`public/dashboard.js`**: `toggleTeamPause()` + `syncPauseToggle()` — prompts for duration, syncs with backend every 30s
- **`docs/PAUSE.md`** (new): Quick start examples, API reference, behavior docs, use cases
- **`docs/PAUSE-CONTROLS.md`**: Additional docs

## Proof
```
=== Pause team ===
{ success: true, target: '__team__', reason: 'Proof test' }

=== tasks/next returns paused ===
{ task: null, paused: true, message: 'Team paused by link: Proof test (10m remaining)' }

=== Resume ===
{ success: true }

=== tasks/next works again ===
{ task: 'none', paused: null }
```

Tests: 1493 passed | Routes: 401/401 | tsc: clean

Closes task-1772254677757-imir2x4eg