### PR TITLE
fix: remove duplicate pause button (kai review #519)

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2765,51 +2765,6 @@ async function resumeFromBanner() {
 }
 
 // ── Pause toggle button ──
-let _teamPaused = false;
-
-function updatePauseToggle(paused) {
-  _teamPaused = paused;
-  const btn = document.getElementById('pause-toggle');
-  const icon = document.getElementById('pause-toggle-icon');
-  const label = document.getElementById('pause-toggle-label');
-  if (!btn) return;
-  if (paused) {
-    btn.classList.add('paused');
-    icon.textContent = '▶️';
-    label.textContent = 'Resume';
-    btn.title = 'Resume team task pulls';
-  } else {
-    btn.classList.remove('paused');
-    icon.textContent = '⏸️';
-    label.textContent = 'Pause';
-    btn.title = 'Pause team task pulls';
-  }
-}
-
-async function togglePause() {
-  try {
-    if (_teamPaused) {
-      await fetch(BASE + '/pause?target=team', { method: 'DELETE' });
-    } else {
-      await fetch(BASE + '/pause', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ target: 'team', pausedBy: 'dashboard', reason: 'Paused from dashboard' }),
-      });
-    }
-    checkPauseBanner();
-  } catch {}
-}
-
-// Enhance checkPauseBanner to also update the toggle button
-const _origCheckPause = checkPauseBanner;
-checkPauseBanner = async function() {
-  await _origCheckPause();
-  // Sync toggle state from banner visibility
-  const banner = document.getElementById('pause-banner');
-  updatePauseToggle(banner && banner.style.display !== 'none');
-};
-
 // Poll pause status every 30s
 setInterval(checkPauseBanner, 30000);
 checkPauseBanner();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1105,19 +1105,6 @@ export function getDashboardHTML(): string {
   }
   .focus-toggle .focus-icon { font-size: var(--text-md); }
 
-  .pause-toggle {
-    display: inline-flex; align-items: center; gap: 6px;
-    padding: 5px 12px; border-radius: var(--radius-full); font-size: 12px; font-weight: 600;
-    cursor: pointer; border: 1px solid var(--border); background: var(--surface-raised);
-    color: var(--text-muted); transition: all var(--transition-base) var(--easing-smooth);
-    user-select: none;
-  }
-  .pause-toggle:hover { border-color: var(--yellow, #eab308); color: var(--text); }
-  .pause-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-  .pause-toggle.paused {
-    background: var(--yellow-dim, rgba(234, 179, 8, 0.15)); border-color: var(--yellow, #eab308); color: var(--yellow, #eab308);
-  }
-
   /* Focus mode active: dim non-active kanban columns */
   body.focus-mode .kanban-col:not([data-status="doing"]) {
     opacity: 0.3;
@@ -1541,9 +1528,6 @@ export function getDashboardHTML(): string {
     <span><span class="status-dot"></span>Running</span>
     <button class="focus-toggle" id="focus-toggle" onclick="toggleFocusMode()" title="Focus Mode: highlight active work, collapse noise">
       <span class="focus-icon">🎯</span> Focus
-    </button>
-    <button class="pause-toggle" id="pause-toggle" onclick="togglePause()" title="Pause/Resume team task pulls" aria-label="Pause or resume team">
-      <span id="pause-toggle-icon">⏸️</span> <span id="pause-toggle-label">Pause</span>
     </button>
     <span id="release-badge" class="release-badge" title="Deploy status">deploy: checking…</span>
     <span id="build-badge" class="release-badge" title="Build info">build: loading…</span>


### PR DESCRIPTION
Removes the first pause-toggle implementation from the header. Keeps the intensity-bar toggle (`#pause-toggle-btn` + `toggleTeamPause()`) which has the duration prompt and clean state sync via `syncPauseToggle()`.

Drops:
- `#pause-toggle` button from header HTML
- `.pause-toggle` CSS (12 lines)
- `updatePauseToggle()`, `togglePause()`, `_origCheckPause` monkey-patch (49 lines)

Tests: 1493 ✅ | Routes: 401/401 | tsc: clean

Addresses @kai review on PR #519.