### PR TITLE
chore: add process artifact for fp0l0cvaq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ process/*
 !process/TASK-iwphjvsrl.md
 !process/TASK-task-rcuuep9co.md
 !process/TASK-u7edc3c9y.md
+!process/TASK-fp0l0cvaq.md

--- a/process/TASK-fp0l0cvaq.md
+++ b/process/TASK-fp0l0cvaq.md
@@ -1,0 +1,16 @@
+# TASK-fp0l0cvaq — Ready-queue floor breach semantics
+
+PR: https://github.com/reflectt/reflectt-node/pull/521
+
+## What changed
+- Ready-queue floor warning now distinguishes:
+  - **breach (warning)** only when below floor AND agent has **no active work** (doing + validating == 0)
+  - **info** when below floor but agent is active (doing/validating > 0)
+- Idle escalation now counts validating as active (prevents validating-only false idle)
+- Added regression tests for validating-only semantics
+
+## Proof
+CI green on PR #521.
+
+## Notes
+This is a noise-reduction reliability fix (beta onboarding).


### PR DESCRIPTION
Adds a process artifact for task-1772217837983-fp0l0cvaq so the task can be closed cleanly with an artifact_path.

Canonical fix shipped + merged in PR #521.
