### PR TITLE
task-4371d5dx4: Ready-floor digest copy should say in-flight when agent active

### DIFF
--- a/src/boardHealthWorker.ts
+++ b/src/boardHealthWorker.ts
@@ -516,7 +516,7 @@ export class BoardHealthWorker {
 
         const msg = isBreach
           ? `⚠️ Ready-queue floor (idle): @${agent} has ${readyCount}/${rqf.minReady} unblocked todo tasks (need ${deficit} more). @sage @pixel — please spec/assign tasks to keep engineering lane fed.${breakdown}\n  🕐 snapshot: ${snapshotTime}`
-          : `ℹ️ Ready-queue low (agent active): @${agent} has ${readyCount}/${rqf.minReady} unblocked todo tasks (need ${deficit} more). Not a breach because doing=${doingTasks.length}, validating=${validatingTasks.length}.${breakdown}\n  🕐 snapshot: ${snapshotTime}`
+          : `ℹ️ Ready-queue in-flight: @${agent} is active (doing=${doingTasks.length}, validating=${validatingTasks.length}). Next-task queue below floor (unblocked todo=${readyCount}, floor=${rqf.minReady}, need ${deficit} more).${breakdown}\n  🕐 snapshot: ${snapshotTime}`
 
         if (!dryRun) {
           try {


### PR DESCRIPTION
Adjust ready-queue floor digest copy to avoid misleading 0/2 todo phrasing when an agent is active (doing/validating).\n\n- Info message now leads with in-flight state + doing/validating counts\n- Still includes queue deficit details, but avoids the 0/2 framing\n\nTask: task-1772226933401-4371d5dx4\nReviewer: @harmony