### PR TITLE
feat: reflectt-review GitHub Action — task review_state gate

### DIFF
--- a/.github/workflows/reflectt-review.yml
+++ b/.github/workflows/reflectt-review.yml
@@ -1,0 +1,126 @@
+name: reflectt-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  repository_dispatch:
+    types: [reflectt-review-update]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to re-check'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  reflectt-review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check reflectt-node task review state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // ── Resolve PR ──
+            let pr;
+            if (context.eventName === 'pull_request') {
+              pr = context.payload.pull_request;
+            } else {
+              // workflow_dispatch or repository_dispatch — look up PR by number
+              const prNumber = context.payload.inputs?.pr_number
+                || context.payload.client_payload?.pr_number;
+              if (!prNumber) {
+                core.info('No PR context — nothing to check.');
+                return;
+              }
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(prNumber),
+              });
+              pr = data;
+            }
+
+            if (!pr || pr.state !== 'open') {
+              core.info('PR not open — skipping.');
+              return;
+            }
+
+            const nodeUrl = '${{ vars.REFLECTT_NODE_URL }}'.trim();
+
+            // ── Extract task ID from branch or PR body ──
+            const taskIdPattern = /task-\d+-[a-z0-9]+/;
+            const branchMatch = pr.head.ref.match(taskIdPattern);
+            const bodyMatch = (pr.body || '').match(taskIdPattern);
+            const taskId = branchMatch?.[0] || bodyMatch?.[0];
+
+            async function setStatus(state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state,
+                context: 'reflectt-review',
+                description: description.slice(0, 140),
+              });
+            }
+
+            // ── No task ID → pass with warning ──
+            if (!taskId) {
+              await setStatus('success', 'No task ID found — non-task PR, passing');
+              core.warning('No task ID in branch or PR body. Passing (non-task PR).');
+              return;
+            }
+
+            // ── No node URL configured → pass with warning ──
+            if (!nodeUrl) {
+              await setStatus(
+                'success',
+                `Task ${taskId} — REFLECTT_NODE_URL not configured, skipping review check`
+              );
+              core.warning('REFLECTT_NODE_URL not set. Cannot verify review state.');
+              return;
+            }
+
+            // ── Query reflectt-node ──
+            const url = `${nodeUrl.replace(/\/$/, '')}/tasks/${taskId}`;
+            let task;
+            try {
+              const resp = await fetch(url, {
+                headers: { 'Accept': 'application/json' },
+                signal: AbortSignal.timeout(10000),
+              });
+              if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+              const data = await resp.json();
+              task = data.task || data;
+            } catch (err) {
+              // Network failure → don't block the PR, but warn
+              await setStatus(
+                'success',
+                `Cannot reach reflectt-node (${err.message}) — passing with warning`
+              );
+              core.warning(`Failed to reach reflectt-node at ${url}: ${err.message}`);
+              return;
+            }
+
+            // ── Check review_state ──
+            const reviewState = task.metadata?.review_state || 'none';
+            const reviewer = task.reviewer || task.metadata?.reviewer || 'unknown';
+
+            if (reviewState === 'approved') {
+              await setStatus(
+                'success',
+                `✅ Task ${taskId} review approved (reviewer: ${reviewer})`
+              );
+              core.info(`Task ${taskId} review approved by ${reviewer}.`);
+            } else {
+              await setStatus(
+                'pending',
+                `⏳ Task ${taskId} review: ${reviewState} (reviewer: ${reviewer})`
+              );
+              core.info(`Task ${taskId} review state: ${reviewState}. Waiting for approval.`);
+            }

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -132,6 +132,8 @@ You now have:
 - Customize agent SOUL.md files in `~/.reflectt/data/agents/`
 - Check team health: `GET /health/team`
 
+> **Single-auth GitHub teams:** If all agents share one GitHub account, GitHub won't let you approve your own PRs. Use reflectt-node's built-in task review system (`review_state=approved`) as the quality gate instead. The `reflectt-review` GitHub Action enforces this automatically — see `.github/workflows/reflectt-review.yml`.
+
 ---
 
 ## Timed Run (reference)


### PR DESCRIPTION
## Summary
Closes the GitHub single-auth review gap. Adds a GitHub Action that queries reflectt-node's task `review_state` before allowing merge.

## What it does
- **`.github/workflows/reflectt-review.yml`** — New workflow that:
  - Extracts task ID from PR branch name or body (`task-\d+-[a-z0-9]+` pattern)
  - Queries `GET /tasks/:id` on reflectt-node for `review_state`
  - Posts a `reflectt-review` commit status: `success` (approved) or `pending` (waiting)
  - Gracefully passes non-task PRs with warning (no blocking)
  - Gracefully passes when `REFLECTT_NODE_URL` isn't configured or node is unreachable
  - Supports `workflow_dispatch` + `repository_dispatch` for re-checks after review state changes

- **`docs/QUICKSTART.md`** — Added note about single-auth GitHub teams using reflectt-node review as quality gate

## How merge-when-green respects this
`merge-when-green` already checks `getCombinedStatusForRef` which includes commit statuses. A `pending` reflectt-review status makes combined status ≠ `success`, blocking auto-merge. No changes needed.

## Configuration
Set `REFLECTT_NODE_URL` as a GitHub repository variable pointing to your reflectt-node instance (e.g., `https://reflectt.example.com:4445`). If not set, the check passes with a warning.

## Task
`task-1772260820842-bcxcyu5ch`

## Test
- tsc clean, 1504 tests pass, 401/401 route parity