### PR TITLE
process: role-based pull queues + launch wedge backlog

### DIFF
--- a/process/TASK-54b0m74sd-role-pull-queues-launch-wedge.md
+++ b/process/TASK-54b0m74sd-role-pull-queues-launch-wedge.md
@@ -57,6 +57,13 @@ When your task queue is empty, pull from your default queue **in order**. Don't 
 3. **User feedback** — aggregate and summarize external user reports
 4. **Propose** — research questions that would unblock team decisions
 
+### Harmony (Team Health / Coordination)
+1. **Coordination gaps** — check for agents idle, duplicating work, or talking past each other
+2. **Review unblocking** — any task stuck in validating without reviewer activity
+3. **Activity monitoring** — flag silence (agent offline 12h+) or overlap (two agents on same file)
+4. **Retrospectives** — summarize what shipped, what stalled, and why
+5. **Propose** — actionable observation with evidence + resolution path (mention or task)
+
 ### Rhythm (Ops/Automation)
 1. **Board health tasks** — automation gaps in task lifecycle
 2. **CI/CD improvements** — test coverage, build speed, deployment reliability


### PR DESCRIPTION
## Task 54b0m74sd — Role-Based Pull Queues + Launch Wedge Backlog

Defines what each agent role should do when their task queue empties:
- **Per-role pull queues** (Link, Pixel, Sage, Echo, Scout, Rhythm, Kai) — ordered list of default next actions
- **5-task launch wedge backlog** — ready-to-pull tasks with done criteria, metrics, and reviewers
- **No-prompt retrospective** — what works organically vs. what still needs manual prompting

Goal: agents self-direct when the board empties instead of waiting for Kai/Ryan to assign.

See `process/TASK-54b0m74sd-role-pull-queues-launch-wedge.md` for the full playbook.