### PR TITLE
feat: wire chat attachments end-to-end

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -495,6 +495,13 @@ export function runMigrations(db: Database.Database): void {
         );
       `,
     },
+    {
+      version: 18,
+      sql: `
+        -- Chat message attachments (JSON array of file references)
+        ALTER TABLE chat_messages ADD COLUMN attachments TEXT;
+      `,
+    },
   ]
 
   const insertMigration = db.prepare('INSERT INTO _migrations (version) VALUES (?)')

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,14 @@
  * Core types for reflectt-node
  */
 
+export interface ChatAttachment {
+  id: string
+  name: string
+  size: number
+  mimeType: string
+  url: string
+}
+
 export interface AgentMessage {
   id: string
   from: string
@@ -16,6 +24,7 @@ export interface AgentMessage {
   threadId?: string // If set, this message is a reply in that thread
   replyCount?: number // Number of replies (calculated on fetch)
   metadata?: Record<string, unknown>
+  attachments?: ChatAttachment[]
 }
 
 export interface Task {


### PR DESCRIPTION
## What

Ryan found this dogfooding: the dashboard file upload UI (📎 button) accepts files into an attachment tray, but clicking Send drops them — the backend silently discards the `attachments` field.

## Root Cause

`SendMessageSchema` didn't include `attachments`, `AgentMessage` type didn't have the field, `chat_messages` table had no column for it, and `writeMessageToDb`/`rowToMessage` didn't handle it. The frontend JS (`dashboard.js`) was sending attachments correctly — the plumbing stopped at the API boundary.

## Changes (4 files, 40 lines)

- **types.ts**: Add `ChatAttachment` interface + `attachments?` to `AgentMessage`
- **server.ts**: Add `attachments` to `SendMessageSchema`, allow attachment-only messages (`content` defaults to empty string), validate at least one of content/attachments is present
- **db.ts**: Migration v18 adds `attachments TEXT` column to `chat_messages`
- **chat.ts**: Persist attachments as JSON in both `writeMessageToDb` and `importMessages`, parse on read in `rowToMessage`

## Testing
- `npm run build` — clean
- `npm test` — 1517 passed, 0 regressions
- Manual: `POST /chat/messages` with attachments → stored and returned on GET