### PR TITLE
feat: persist chat message attachments in database

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -495,6 +495,13 @@ export function runMigrations(db: Database.Database): void {
         );
       `,
     },
+    {
+      version: 18,
+      sql: `
+        -- Chat message attachments (JSON array of file references)
+        ALTER TABLE chat_messages ADD COLUMN attachments TEXT;
+      `,
+    },
   ]
 
   const insertMigration = db.prepare('INSERT INTO _migrations (version) VALUES (?)')

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,14 @@
  * Core types for reflectt-node
  */
 
+export interface ChatAttachment {
+  id: string
+  name: string
+  size: number
+  mimeType: string
+  url: string
+}
+
 export interface AgentMessage {
   id: string
   from: string
@@ -16,6 +24,7 @@ export interface AgentMessage {
   threadId?: string // If set, this message is a reply in that thread
   replyCount?: number // Number of replies (calculated on fetch)
   metadata?: Record<string, unknown>
+  attachments?: ChatAttachment[]
 }
 
 export interface Task {


### PR DESCRIPTION
Files attached via the chat UI were uploaded successfully but silently dropped by the backend. This adds full attachment persistence:

- Add `ChatAttachment` type and `attachments` field to `AgentMessage`
- Add `attachments` to `SendMessageSchema` validation (Zod)
- DB migration v18: `attachments` TEXT column on `chat_messages`
- Serialize/deserialize in `writeMessageToDb()` and `rowToMessage()`
- Allow empty content when attachments are present

All 1517 tests pass.