### PR TITLE
feat: task board defaults to open-only view with status filter toggle

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2033,7 +2033,10 @@ export function getDashboardHTML(): string {
 
   <div class="panel">
     <div class="panel-header">📋 Task Board <span class="count" id="task-count"></span></div>
-    <div class="project-tabs" id="project-tabs"></div>
+    <div style="display:flex;align-items:center;gap:8px;padding:10px 18px 0;border-bottom:1px solid var(--border);flex-wrap:wrap">
+      <div class="project-tabs" id="project-tabs" style="border-bottom:none;padding:0;flex:1;min-width:0"></div>
+      <div class="project-tabs" id="status-filter-tabs" style="border-bottom:none;padding:0"></div>
+    </div>
     <div class="kanban" id="kanban"></div>
   </div>
 


### PR DESCRIPTION
## What
Task board now defaults to showing only open tasks (todo, doing, blocked, validating). Done tasks are hidden by default with a toggle to show them.

## Why
New users and daily use: the kanban board was cluttered with completed tasks. Default should show what needs attention.

## How
- Added `currentStatusFilter` state ('open' | 'all'), persisted in localStorage
- Toggle buttons alongside project tabs: 🟢 Open | 📋 All
- Kanban columns filtered by status filter
- Task count updates to reflect filter

## Testing
- All 1517 tests pass
- Build passes (tsc)

Closes task-1772204292496-w819kkziq