### PR TITLE
fix: gitleaks false positive on gateway placeholder

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11600,7 +11600,7 @@ export async function createServer(): Promise<FastifyInstance> {
         fix: [
           'Set environment variables in your .env file:',
           '  OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789',
-          '  OPENCLAW_GATEWAY_TOKEN=<your-token>',
+          '  OPENCLAW_GATEWAY_TOKEN=your_token_here',
           '',
           'Find your token: cat ~/.openclaw/openclaw.json | grep gateway_token',
           'Or generate one: openclaw gateway token',


### PR DESCRIPTION
The `<your-token>` placeholder in the gateway remediation hint triggers the `env-dump` gitleaks rule. Changed to `your_token_here` which matches the existing allowlist regex `your_\w+_here`.

One line changed.