### PR TITLE
feat(dashboard): render chat attachments in message bubbles

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -149,6 +149,7 @@ function formatProductiveText(agent) {
   return 'Last shipped signal: ' + ago(agent.lastProductiveAt) + ' ago';
 }
 function esc(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+function formatBytes(b) { if (!b || b < 1024) return b + ' B'; if (b < 1048576) return (b/1024).toFixed(1) + ' KB'; return (b/1048576).toFixed(1) + ' MB'; }
 function truncate(s, n) { return s && s.length > n ? s.slice(0, n) + '…' : (s || ''); }
 function renderTaskTags(tags) {
   if (!Array.isArray(tags) || tags.length === 0) return '';
@@ -1019,6 +1020,14 @@ function renderChat() {
         ${editedTag}
       </div>
       <div class="msg-content">${renderMessageContentWithTaskLinks(m.content)}</div>
+      ${m.attachments && m.attachments.length ? '<div class="msg-attachments">' + m.attachments.map(a => {
+        const isImage = a.mimeType && a.mimeType.startsWith('image/');
+        const url = a.url || ('/files/' + a.fileId);
+        const name = a.name || a.fileId || 'file';
+        const size = a.size ? ' <span class="att-size">(' + formatBytes(a.size) + ')</span>' : '';
+        if (isImage) return '<a href="' + esc(url) + '" target="_blank" class="msg-att-img"><img src="' + esc(url) + '" alt="' + esc(name) + '" loading="lazy"></a>';
+        return '<a href="' + esc(url) + '" target="_blank" class="msg-att-file">📎 ' + esc(name) + size + '</a>';
+      }).join('') + '</div>' : ''}
     </div>`;
   }).join('');
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -551,6 +551,13 @@ export function getDashboardHTML(): string {
     outline-offset: 2px;
     border-radius: 3px;
   }
+  .msg-attachments { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+  .msg-att-file { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px; background: var(--surface-raised); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--accent); font-size: 11px; text-decoration: none; transition: background var(--transition-fast); }
+  .msg-att-file:hover { background: var(--accent-dim); }
+  .msg-att-file .att-size { color: var(--text-muted); font-size: 10px; }
+  .msg-att-img { display: inline-block; max-width: 200px; border-radius: var(--radius-sm); overflow: hidden; border: 1px solid var(--border); }
+  .msg-att-img img { display: block; max-width: 100%; max-height: 150px; object-fit: cover; }
+  .msg-att-img:hover { border-color: var(--accent); }
   .msg-content.collapsed { max-height: 80px; overflow: hidden; position: relative; cursor: pointer; }
   .msg-content.collapsed::after {
     content: '▼ click to expand'; display: block; position: absolute; bottom: 0; left: 0; right: 0;


### PR DESCRIPTION
## Summary
Renders file attachments in chat message bubbles. Completes the frontend side of chat attachments (backend shipped in PR #537).

## Changes
- **Image attachments**: Inline thumbnails (max 200px wide, 150px tall), clickable to open full size
- **File attachments**: Styled chips with 📎 icon, filename, and human-readable size
- **`formatBytes()`** helper for KB/MB display
- CSS: `.msg-attachments` flex container, `.msg-att-file`, `.msg-att-img` styles using existing design tokens

## Testing
- All 1517 tests pass
- 2 files changed, +16 lines

## Related
- Backend: PR #537 (merged)
- Upload UI: PR #534 (merged)