### PR TITLE
fix(test): add metadata.eta to WIP-limit test fixture

### DIFF
--- a/tests/ready-queue-engine.test.ts
+++ b/tests/ready-queue-engine.test.ts
@@ -165,6 +165,7 @@ describe('Ready-queue engine v1', () => {
         reviewer: 'sage',
         createdBy: 'test',
         done_criteria: ['done'],
+        metadata: { eta: '~1h', lane: TEST_LANE.name, reflection_exempt: true, reflection_exempt_reason: 'test fixture' },
       })
       createdTaskIds.push(t.id)
     }


### PR DESCRIPTION
Fixes red main from PR #546.

The lifecycle gate requires `metadata.eta` for tasks with `status: doing`. The ready-queue-engine WIP-limit test was creating doing tasks without it.

**Fix:** Added `metadata: { eta: '~1h', lane: TEST_LANE.name, reflection_exempt: true, reflection_exempt_reason: 'test fixture' }` to the task creation in the WIP-limit test.

**Tests:** ready-queue-engine.test.ts: 10/10 pass, api.test.ts: 218/218 pass.