### PR TITLE
docs: refresh README for launch — bootstrap-first, concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,444 +1,180 @@
 # reflectt-node
 
-Local coordination server for AI agent teams. Provides real-time chat, task management, health monitoring, and a live dashboard — all running on your machine.
+**Local coordination server for AI agent teams.** Tasks, chat, memory, reflections, file uploads, and a live dashboard — running on your hardware.
 
-Built for [OpenClaw](https://github.com/openclaw/openclaw) agent workflows.
+Tell your AI agent to follow the bootstrap: **[reflectt.ai/bootstrap](https://reflectt.ai/bootstrap)**
 
-## Quick Start with Docker
+> 🚀 Running in production: 3 teams (bare metal + Docker + Fly.io), 9 agents, shipping daily.
 
-```bash
-docker run -d --name reflectt-node -p 4445:4445 -v reflectt-data:/data ghcr.io/reflectt/reflectt-node:latest
+---
+
+## Get Started
+
+### Option 1: Tell your agent
+
+Paste this into any AI chat (OpenClaw, Claude, ChatGPT, Cursor — anything with web access):
+
+```
+Follow the bootstrap instructions at reflectt.ai/bootstrap
 ```
 
-Open [http://localhost:4445/dashboard](http://localhost:4445/dashboard) — that's it.
+Your agent reads the instructions, installs reflectt-node, and starts coordinating.
 
-> See [docs/QUICKSTART.md](docs/QUICKSTART.md) for docker-compose, OpenClaw gateway connection, and troubleshooting.
+### Option 2: Docker (fastest)
 
-## Deployment Requirements
+```bash
+docker run -d --name reflectt-node \
+  -p 4445:4445 \
+  -v reflectt-data:/data \
+  ghcr.io/reflectt/reflectt-node:latest
+```
 
-reflectt-node is a **stateful server** — it stores tasks, reflections, config, and history in a local SQLite database and JSONL files under `~/.reflectt/data/`. It requires a **persistent filesystem**.
-
-**Supported:**
-- Bare metal / VPS (any Linux, macOS, or Windows with Node.js 22+)
-- Docker (with a mounted volume for `/data`)
-- Raspberry Pi, home server, cloud VM
-
-**Not supported:**
-- ❌ Cloudflare Workers (ephemeral filesystem — all state lost on cold start)
-- ❌ AWS Lambda / serverless functions (same reason)
-- ❌ Any platform without persistent local storage
-
-> **Why?** Serverless platforms wipe the filesystem between invocations. reflectt-node needs its data to survive restarts. A $5/mo VPS or Docker container with a volume mount is the right deployment target.
-
-## From Source
-
-### Prerequisites
-
-- **Node.js** 22+ (`node -v`)
-- **npm** 9+ (`npm -v`)
-- **Git** (`git --version`)
-
-### 1. Clone and install
+### Option 3: From source
 
 ```bash
 git clone https://github.com/reflectt/reflectt-node.git
 cd reflectt-node
-npm install
+npm install && npm run build && npm start
 ```
 
-### 2. Configure
+**Then open:** [http://localhost:4445/dashboard](http://localhost:4445/dashboard)
+
+---
+
+## What You Get
+
+| Feature | What it does |
+|---------|-------------|
+| **Task Board** | Full CRUD with priority, assignees, reviewers, state machine gates |
+| **Agent Chat** | Real-time messaging via REST + WebSocket, file attachments |
+| **Live Dashboard** | 8-page browser UI — tasks, chat, reviews, health, outcomes, research, artifacts |
+| **File Uploads** | Drag-drop upload, file browser (grid/list), chat attachments via 📎 |
+| **Team Health** | Presence tracking, blocker detection, idle nudges, compliance metrics |
+| **Reflections** | Agents capture learnings, auto-clustered into insights |
+| **Review Process** | Every task has an assignee + reviewer — nothing ships without a second set of eyes |
+| **Inbox System** | Per-agent message queues for async coordination |
+| **UI Kit** | Living design reference at `/ui-kit` — tokens, components, states |
+| **Content Negotiation** | `/bootstrap` serves HTML to browsers, markdown to agents (via Accept header) |
+
+## Deploy Anywhere
+
+reflectt-node is **stateful** — it stores data in SQLite + JSONL files. It needs persistent storage.
+
+| Platform | Works | Notes |
+|----------|-------|-------|
+| Mac / Linux / Pi | ✅ | Node.js 22+ required |
+| Docker | ✅ | Mount a volume for `/data` |
+| Fly.io | ✅ | Persistent volume, ~$3-5/mo |
+| Railway / Render | ✅ | Any container host with volumes |
+| VPS ($5/mo) | ✅ | Ideal for always-on teams |
+| Cloudflare Workers | ❌ | No persistent filesystem |
+| AWS Lambda | ❌ | No persistent filesystem |
+
+## Cloud Sync (Optional)
+
+Connect to [Reflectt Cloud](https://app.reflectt.ai) to see all your teams in one dashboard:
+
+```bash
+reflectt host connect --join-token <token>
+```
+
+Self-hosted nodes sync tasks, presence, and health to the cloud control plane. Free. Optional.
+
+---
+
+## API Quick Reference
+
+```bash
+# Health check
+curl http://localhost:4445/health
+
+# List tasks
+curl http://localhost:4445/tasks
+
+# Create a task
+curl -X POST http://localhost:4445/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{"title": "Ship the feature", "assignee": "link", "priority": "P1"}'
+
+# Get next task for an agent
+curl "http://localhost:4445/tasks/next?agent=link"
+
+# Send a chat message
+curl -X POST http://localhost:4445/chat/messages \
+  -H 'Content-Type: application/json' \
+  -d '{"from": "link", "content": "Done!", "channel": "general"}'
+
+# Upload a file
+curl -X POST http://localhost:4445/files -F "file=@screenshot.png"
+
+# API discovery
+curl http://localhost:4445/capabilities
+```
+
+**WebSocket:** `ws://localhost:4445/chat/ws`
+
+**Full API:** Every endpoint is discoverable at [`/capabilities`](http://localhost:4445/capabilities).
+
+---
+
+## Configuration
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your settings:
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `4445` | Server port |
+| `HOST` | `127.0.0.1` | Bind address |
+| `OPENCLAW_GATEWAY_URL` | — | WebSocket URL for OpenClaw gateway |
+| `OPENCLAW_GATEWAY_TOKEN` | — | Auth token for gateway connection |
+| `SUPABASE_URL` | — | Enables cloud task sync |
+| `SUPABASE_SERVICE_ROLE_KEY` | — | Supabase service role key |
 
-```env
-PORT=4445
-HOST=127.0.0.1
-NODE_ENV=development
-```
-
-**Optional — OpenClaw gateway connection:**
-
-If you're running OpenClaw agents that need to communicate through reflectt-node:
-
-```env
-OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789
-OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here
-```
-
-Find your gateway token in `~/.openclaw/openclaw.json` or set one:
+## Connect OpenClaw Agents
 
 ```bash
-openclaw config set gateway.auth.token "your-token-here"
-```
-
-### 3. Build and run
-
-```bash
-npm run build
-npm start
-```
-
-Or for development with hot reload:
-
-```bash
-npm run dev
-```
-
-### 4. Verify it works
-
-```bash
-curl http://127.0.0.1:4445/health
-```
-
-You should see:
-
-```json
-{
-  "status": "ok",
-  "chat": { "totalMessages": 0, "rooms": 1 },
-  "tasks": { "total": 0 }
-}
-```
-
-Open the dashboard in your browser:
-
-```
-http://127.0.0.1:4445/dashboard
-```
-
-You should see the live dashboard with task board, team health, chat, and activity panels.
-
-**That's it. You're running.**
-
-### Connect OpenClaw agents
-
-To route your OpenClaw agents through reflectt-node, install the channel plugin:
-
-```bash
-# From the reflectt-node repo root
 openclaw plugins install ./plugins/reflectt-channel
-
-# Configure the connection
 openclaw config set channels.reflectt.enabled true
 openclaw config set channels.reflectt.url "http://127.0.0.1:4445"
-
-# Restart gateway
 openclaw gateway restart
-
-# Verify
-openclaw plugins list
 ```
-
-See [`plugins/reflectt-channel/README.md`](plugins/reflectt-channel/README.md) for details.
-
-### Optional: one-command cloud enrollment (dogfooding)
-
-If you have a Reflectt Cloud host join token, you can enroll this node and start heartbeats in one command:
-
-```bash
-reflectt host connect --join-token <token> --cloud-url http://127.0.0.1:3001
-```
-
-If your cloud API still requires a user JWT for `/api/hosts/claim`, use temporary compatibility mode:
-
-```bash
-reflectt host connect --join-token <token> --cloud-url http://127.0.0.1:3001 --auth-token <jwt>
-```
-
-This command:
-- registers the host with cloud,
-- stores cloud credential + host metadata in `~/.reflectt/config.json`,
-- restarts/starts local reflectt-node,
-- verifies heartbeat via `GET /cloud/status`.
-
-Check enrollment/runtime status anytime:
-
-```bash
-reflectt host status
-```
-
----
-
-## What reflectt-node Does
-
-| Feature | Description |
-|---------|-------------|
-| **Agent Chat** | Real-time messaging between agents via REST + WebSocket |
-| **Task Board** | Full CRUD task management with status, priority, assignees (SQLite + WAL) |
-| **Live Dashboard** | Browser-based dashboard with task board, health, compliance, chat |
-| **Team Health** | Agent presence tracking, blocker detection, overlap warnings |
-| **Collaboration Compliance** | Cadence monitoring, status freshness, escalation tracking |
-| **Inbox System** | Per-agent message queues for async coordination |
-| **OpenClaw Integration** | Connects to your local OpenClaw gateway for agent orchestration |
-
-## API Reference
-
-### Health
-
-```bash
-# Server health + stats
-curl http://127.0.0.1:4445/health
-```
-
-### Tasks
-
-```bash
-# List all tasks
-curl http://127.0.0.1:4445/tasks
-
-# List tasks with filters
-curl "http://127.0.0.1:4445/tasks?status=doing&assignee=link"
-
-# Get a single task
-curl http://127.0.0.1:4445/tasks/<task-id>
-
-# Create a task
-curl -X POST http://127.0.0.1:4445/tasks \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "title": "Ship the feature",
-    "status": "todo",
-    "assignee": "link",
-    "reviewer": "pixel",
-    "priority": "P1",
-    "tags": ["reflectt-node"]
-  }'
-
-# Update a task
-curl -X PATCH http://127.0.0.1:4445/tasks/<task-id> \
-  -H 'Content-Type: application/json' \
-  -d '{"status": "done"}'
-
-# Get next task for an agent
-curl "http://127.0.0.1:4445/tasks/next?agent=link"
-```
-
-### Chat
-
-```bash
-# Get recent messages
-curl "http://127.0.0.1:4445/chat/messages?limit=50"
-
-# Send a message
-curl -X POST http://127.0.0.1:4445/chat/messages \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "from": "link",
-    "content": "Task complete!",
-    "channel": "general"
-  }'
-
-# List channels
-curl http://127.0.0.1:4445/chat/rooms
-```
-
-**WebSocket (real-time):**
-
-```
-ws://127.0.0.1:4445/chat/ws
-```
-
-### Inbox
-
-```bash
-# Check agent inbox
-curl http://127.0.0.1:4445/inbox/link
-
-# Send to agent inbox
-curl -X POST http://127.0.0.1:4445/inbox/link \
-  -H 'Content-Type: application/json' \
-  -d '{"from": "kai", "content": "Please review the PR"}'
-```
-
-### Dashboard
-
-```
-# Open in browser
-http://127.0.0.1:4445/dashboard
-```
-
-The dashboard auto-refreshes and shows:
-- Task board with drag-and-drop columns
-- Agent presence and health status
-- Collaboration compliance metrics
-- Real-time chat with task-ID deep linking
-- Promotion SSOT panel (when configured)
-
-## Running as a Service (macOS)
-
-To run reflectt-node as a persistent background service:
-
-```bash
-# Create a launchd plist (adjust paths to your setup)
-cat > ~/Library/LaunchAgents/com.reflectt.node.plist << 'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>com.reflectt.node</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/bin/node</string>
-    <string>dist/index.js</string>
-  </array>
-  <key>WorkingDirectory</key>
-  <string>/path/to/reflectt-node</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-</dict>
-</plist>
-EOF
-
-# Load the service
-launchctl load ~/Library/LaunchAgents/com.reflectt.node.plist
-
-# Restart the service
-launchctl kickstart -k gui/$(id -u)/com.reflectt.node
-```
-
-## Deploy Coordination (Code ↔ Server Sync)
-
-When the repo changes but the running process has not been restarted, dashboard/API behavior can drift from source code.
-
-Use these endpoints to make deploy state explicit:
-
-```bash
-# Compare startup snapshot vs current repo state
-curl -s http://127.0.0.1:4445/release/status
-
-# Generate release notes from completed tasks (since last deploy marker by default)
-curl -s http://127.0.0.1:4445/release/notes
-
-# Mark a deploy event after restart/verification
-curl -s -X POST http://127.0.0.1:4445/release/deploy \
-  -H 'Content-Type: application/json' \
-  -d '{"deployedBy":"ryan","note":"restart after task-comments ship"}'
-```
-
-Dashboard header shows a deploy badge (`in sync` vs `stale`) backed by `/release/status`.
 
 ## Running Tests
 
 ```bash
-# Build first
 npm run build
-
-# Task-linkify regression suite
-npm run test:task-linkify:regression
-
-# SSOT indicator state tests
-npm run test:ssot-indicator:regression
-
-# Dry-run transcript validator
-npm run test:task-linkify:dryrun-validator -- <transcript-path>
-
-# Negative-fixture validator tests
-npm run test:task-linkify:dryrun-negative-fixtures
+npm test        # 1500+ tests
 ```
 
 ## Project Structure
 
 ```
 src/
-  index.ts        # Entry point
-  server.ts       # Fastify server + route registration
-  chat.ts         # Chat message manager + WebSocket
-  tasks.ts        # Task CRUD + lifecycle gates
-  dashboard.ts    # Live dashboard (HTML/CSS/JS served inline)
-  health.ts       # Team health + presence aggregation
+  server.ts       # Fastify server + routes
+  dashboard.ts    # Live dashboard (inline HTML/CSS/JS)
+  tasks.ts        # Task CRUD + state machine
+  chat.ts         # Chat + WebSocket
+  health.ts       # Team health + presence
   inbox.ts        # Per-agent async inbox
-  presence.ts     # Agent presence tracking
-  config.ts       # Configuration loader
-  openclaw.ts     # OpenClaw gateway client
-  analytics.ts    # Usage analytics
-  types.ts        # TypeScript type definitions
+  config.ts       # Configuration
+  types.ts        # TypeScript types
 
-tools/                          # Test harnesses and operational scripts
-docs/                           # Promotion runbooks and operational docs
-artifacts/                      # CI/test artifacts and evidence
+public/
+  dashboard.js    # Dashboard client-side JS
+  bootstrap.md    # Agent bootstrap instructions
 ```
 
-## Environment Variables
+---
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `PORT` | No | `4445` | Server port |
-| `HOST` | No | `127.0.0.1` | Bind address |
-| `NODE_ENV` | No | `development` | Environment |
-| `OPENCLAW_GATEWAY_URL` | No | — | WebSocket URL for OpenClaw gateway |
-| `OPENCLAW_GATEWAY_TOKEN` | No | — | Auth token for gateway connection |
-| `IDLE_NUDGE_ENABLED` | No | `false` | Enable idle agent nudge system |
-| `SUPABASE_URL` | No | — | Enables cloud task state sync when set with service role key |
-| `SUPABASE_SERVICE_ROLE_KEY` | No | — | Supabase service role for task state sync writes |
-| `REFLECTT_TASKS_TABLE` | No | `tasks` | Supabase table name for persisted task state |
+## Links
 
-Task-state migration + cloud sync guide: `docs/TASK_STATE_SUPABASE_MIGRATION.md`
-
-## Troubleshooting
-
-### Server won't start
-
-```bash
-# Check if port is already in use
-lsof -i :4445  # or: /usr/sbin/lsof -i :4445
-
-# Kill existing process if needed
-kill $(lsof -t -i :4445)
-
-# Rebuild and try again
-npm run build
-npm start
-```
-
-### Health check returns error
-
-```bash
-# Verify the server is running
-curl -v http://127.0.0.1:4445/health
-
-# Check logs for errors
-npm run dev  # dev mode shows full logs
-```
-
-### Dashboard is blank or panels missing
-
-```bash
-# Force rebuild (clears compiled JS)
-rm -rf dist/
-npm run build
-
-# Restart service
-launchctl kickstart -k gui/$(id -u)/com.reflectt.node
-```
-
-### OpenClaw connection fails
-
-```bash
-# Verify gateway is running
-openclaw status
-
-# Check your token matches
-cat ~/.openclaw/openclaw.json | grep token
-
-# Verify .env has correct URL and token
-cat .env
-```
-
-### Build fails
-
-```bash
-# Clear and reinstall
-rm -rf node_modules dist
-npm install
-npm run build
-```
+- **Website:** [reflectt.ai](https://reflectt.ai)
+- **Cloud:** [app.reflectt.ai](https://app.reflectt.ai)
+- **Bootstrap:** [reflectt.ai/bootstrap](https://reflectt.ai/bootstrap)
+- **Agent directory:** [forAgents.dev](https://forAgents.dev)
+- **Discord:** [discord.gg/reflectt](https://discord.gg/reflectt)
 
 ## License
 
@@ -446,4 +182,4 @@ Apache-2.0
 
 ---
 
-**Built by [Team Reflectt](https://reflectt.ai)**
+**Built by [Team Reflectt](https://reflectt.ai)** · Design by pixel 🎨


### PR DESCRIPTION
Cut from ~450 lines to ~180. Bootstrap-first onboarding, updated feature table, deploy matrix, cloud sync. What Show HN and dev.to link to.