### PR TITLE
fix: cast status check to avoid TS2367 narrowing error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -280,7 +280,7 @@ function checkDefinitionOfReady(data: z.infer<typeof CreateTaskSchema>): string[
   const isExempt = Boolean(meta.reflection_exempt) || !systemHasReflections
   const hasExemptReason = typeof meta.reflection_exempt_reason === 'string' && meta.reflection_exempt_reason.trim().length > 0
 
-  if (data.status !== 'todo' && !hasReflectionSource && !isExempt) {
+  if ((data.status as string) !== 'todo' && !hasReflectionSource && !isExempt) {
     problems.push(
       'Reflection-origin required: tasks must include metadata.source_reflection or metadata.source_insight. ' +
       'If this task legitimately does not originate from a reflection, set metadata.reflection_exempt=true with metadata.reflection_exempt_reason.'


### PR DESCRIPTION
Docker publish is broken — TypeScript narrowing error from PR #549. The early return for 'todo' on line 237 narrows the type, making the safety check on line 283 a TS error. One-char fix: cast to string.