### PR TITLE
fix: remove redundant todo status check that breaks tsc

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -280,7 +280,7 @@ function checkDefinitionOfReady(data: z.infer<typeof CreateTaskSchema>): string[
   const isExempt = Boolean(meta.reflection_exempt) || !systemHasReflections
   const hasExemptReason = typeof meta.reflection_exempt_reason === 'string' && meta.reflection_exempt_reason.trim().length > 0
 
-  if (data.status !== 'todo' && !hasReflectionSource && !isExempt) {
+  if (!hasReflectionSource && !isExempt) {
     problems.push(
       'Reflection-origin required: tasks must include metadata.source_reflection or metadata.source_insight. ' +
       'If this task legitimately does not originate from a reflection, set metadata.reflection_exempt=true with metadata.reflection_exempt_reason.'


### PR DESCRIPTION
## Problem
`src/server.ts(283,7): error TS2367` — the `data.status !== 'todo'` check is dead code because the early return at line 240 already excludes todo tasks. TypeScript correctly flags this as unreachable. **Blocks all Docker image builds.**

## Fix
Remove the redundant check. The early return handles todo exclusion.

## Testing
- 0 TypeScript errors (`tsc --noEmit` clean)
- All 1527 tests pass
- 1 line changed