### PR TITLE
fix: done_criteria .min(1) conflicts with .optional().default([])

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -187,7 +187,7 @@ const CreateTaskSchema = z.object({
   status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done']).default('todo'),
   assignee: z.string().trim().min(1).optional().default('unassigned'),
   reviewer: z.string().trim().min(1).or(z.literal('auto')).default('auto'), // 'auto' triggers load-balanced assignment
-  done_criteria: z.array(z.string().trim().min(1)).min(1).optional().default([]),
+  done_criteria: z.array(z.string().trim().min(1)).optional().default([]),
   eta: z.string().trim().min(1).optional(),
   createdBy: z.string().min(1).optional().default('user'),
   priority: z.enum(['P0', 'P1', 'P2', 'P3']).default('P3'),

--- a/tests/modules.test.ts
+++ b/tests/modules.test.ts
@@ -1024,17 +1024,19 @@ describe('Task Intake Schema Enforcement', () => {
     expect(res.body.error).toContain('Unknown task type')
   })
 
-  it('POST /tasks rejects missing required fields (zod validation)', async () => {
+  it('POST /tasks accepts minimal fields for todo tasks (relaxed onboarding schema)', async () => {
     const res = await req('POST', '/tasks', {
-      title: 'Missing required fields test',
+      title: 'TEST: Minimal todo task for onboarding validation smoke test',
     })
-    // Should fail zod validation (missing assignee, reviewer, etc.)
-    expect(res.status).toBe(400)
+    // Relaxed schema: todo tasks only require title
+    expect(res.status).toBe(200)
+    const data = await res.json() as any
+    if (data.task?.id) await req('DELETE', `/tasks/${data.task.id}`)
   })
 
-  it('POST /tasks rejects empty done_criteria', async () => {
+  it('POST /tasks accepts empty done_criteria for todo tasks', async () => {
     const res = await req('POST', '/tasks', {
-      title: 'TEST: task with empty done criteria',
+      title: 'TEST: task with empty done criteria for onboarding flow validation',
       assignee: 'link',
       reviewer: 'kai',
       done_criteria: [],
@@ -1042,7 +1044,10 @@ describe('Task Intake Schema Enforcement', () => {
       createdBy: 'test',
       priority: 'P2',
     })
-    expect(res.status).toBe(400)
+    // done_criteria defaults to [] and is no longer required for todo tasks
+    expect(res.status).toBe(200)
+    const data = await res.json() as any
+    if (data.task?.id) await req('DELETE', `/tasks/${data.task.id}`)
   })
 
   it('POST /tasks accepts well-formed task with TEST: prefix', async () => {

--- a/tests/reflection-origin-gate.test.ts
+++ b/tests/reflection-origin-gate.test.ts
@@ -58,7 +58,8 @@ async function postTask(body: Record<string, any>): Promise<any> {
 describe('Reflection-origin gate', () => {
   it('rejects task without source_reflection or source_insight', async (ctx) => {
     if (!serverUp) return ctx.skip()
-    const data = await postTask(taskBody({ metadata: { is_test: true } }))
+    // Use status=doing to bypass the todo early-return that skips quality checks
+    const data = await postTask(taskBody({ status: 'doing', metadata: { is_test: true, eta: '~1h' } }))
     expect(data.success).toBe(false)
     expect(data.code).toBe('DEFINITION_OF_READY')
     expect(data.problems?.some((p: string) => p.includes('Reflection-origin required'))).toBe(true)
@@ -105,8 +106,10 @@ describe('Reflection-origin gate', () => {
 
   it('rejects exempt task without reason', async (ctx) => {
     if (!serverUp) return ctx.skip()
+    // Use status=doing to bypass the todo early-return that skips quality checks
     const data = await postTask(taskBody({
-      metadata: { reflection_exempt: true, is_test: true },
+      status: 'doing',
+      metadata: { reflection_exempt: true, is_test: true, eta: '~1h' },
     }))
     expect(data.success).toBe(false)
     expect(data.problems?.some((p: string) => p.includes('reflection_exempt_reason'))).toBe(true)


### PR DESCRIPTION
## Problem
PR #549 made `done_criteria` optional with `.optional().default([])`, but left `.min(1)` on the array. Zod runs `.min(1)` after `.default([])`, so the default empty array immediately fails validation. Result: `POST /tasks {"title": "My first task"}` still returns 400.

This means the onboarding fix from #549 **doesn't actually work** — new users still can't create tasks with just a title.

## Fix
- Remove `.min(1)` from `done_criteria` — the definition-of-ready check already validates criteria quality for non-todo tasks
- Update `reflection-origin-gate.test.ts`: rejection tests use `status: 'doing'` since todo tasks skip quality checks via early return
- Update `modules.test.ts`: schema tests match relaxed onboarding behavior

## Testing
- `tsc --noEmit`: 0 errors
- reflection-origin-gate tests: 6/6 pass
- Full suite needs CI (live server tests hit deployed code)

## Related
- PR #549 (relaxed schema, introduced the bug)
- PR #547 (reflection-origin auto-exempt)
- PR #552 (TS narrowing fix)