### PR TITLE
fix: responsive polish — agent strip scroll fade, mobile logo fix, snap scroll

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -608,6 +608,21 @@ async function loadPresence() {
       <span class="agent-badge ${badgeClass}">${badgeText}</span>
     </div>`;
   }).join('');
+
+  // Toggle scroll-fade indicator on agent strip wrapper
+  const wrapper = document.getElementById('agent-strip-wrapper');
+  if (wrapper && strip) {
+    const hasOverflow = strip.scrollWidth > strip.clientWidth;
+    wrapper.classList.toggle('has-overflow', hasOverflow);
+    // Update on scroll (hide fade when scrolled to end)
+    if (!strip._overflowListener) {
+      strip._overflowListener = true;
+      strip.addEventListener('scroll', () => {
+        const atEnd = strip.scrollLeft + strip.clientWidth >= strip.scrollWidth - 8;
+        wrapper.classList.toggle('has-overflow', !atEnd && strip.scrollWidth > strip.clientWidth);
+      }, { passive: true });
+    }
+  }
 }
 
 // ---- Tasks ----

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -240,6 +240,7 @@ export function getDashboardHTML(): string {
     .sidebar.open { transform: translateX(0); }
     .sidebar-overlay.open { display: block; }
     .app-layout { flex-direction: column; }
+    .header-left { padding-left: 40px; }
   }
 
   .release-badge {
@@ -268,10 +269,19 @@ export function getDashboardHTML(): string {
     background: var(--green); margin-right: 5px; vertical-align: middle;
     box-shadow: 0 0 6px rgba(63, 185, 80, 0.4);
   }
+  .agent-strip-wrapper {
+    position: relative; overflow: hidden; border-bottom: 1px solid var(--border-subtle); background: var(--surface);
+  }
+  .agent-strip-wrapper::after {
+    content: ''; position: absolute; top: 0; right: 0; bottom: 0; width: 48px; pointer-events: none;
+    background: linear-gradient(to right, transparent, var(--surface));
+    opacity: 0; transition: opacity var(--transition-fast);
+  }
+  .agent-strip-wrapper.has-overflow::after { opacity: 1; }
   .agent-strip {
     display: flex; gap: var(--space-3); padding: var(--space-4) var(--space-8); overflow-x: auto;
-    border-bottom: 1px solid var(--border-subtle); background: var(--surface);
     max-width: 100vw; box-sizing: border-box; scrollbar-width: thin;
+    scroll-snap-type: x proximity; -webkit-overflow-scrolling: touch;
   }
   .agent-strip::-webkit-scrollbar { height: 4px; }
   .agent-strip::-webkit-scrollbar-track { background: transparent; }
@@ -280,6 +290,7 @@ export function getDashboardHTML(): string {
     flex: 0 0 auto; display: flex; align-items: center; gap: var(--space-2);
     padding: var(--space-2) var(--space-3); background: var(--surface-raised); border: 1px solid var(--border);
     border-radius: var(--radius-md); min-width: 160px; max-width: 240px; transition: border-color var(--transition-fast) var(--easing-smooth);
+    scroll-snap-align: start;
   }
   .agent-card:hover { border-color: var(--accent); }
   .agent-card.active { border-left: 3px solid var(--green); }
@@ -872,6 +883,7 @@ export function getDashboardHTML(): string {
 
   @media (max-width: 420px) {
     .header, .agent-strip, .main { padding-left: 12px; padding-right: 12px; }
+    .agent-card { min-width: 150px; }
     .panel-header { padding: 10px 12px; }
     .panel-body { padding: 10px 12px; max-height: 320px; }
     .kanban { padding: 10px 12px; }
@@ -1945,7 +1957,7 @@ export function getDashboardHTML(): string {
   <button id="pause-toggle-btn" class="pause-toggle-btn" onclick="toggleTeamPause()" aria-label="Pause team" tabindex="0">⏸️ Pause</button>
 </div>
 
-<div class="agent-strip" id="agent-strip"></div>
+<div class="agent-strip-wrapper" id="agent-strip-wrapper"><div class="agent-strip" id="agent-strip"></div></div>
 
 <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle sidebar">☰</button>
 <div class="sidebar-overlay" id="sidebar-overlay" onclick="toggleSidebar()"></div>


### PR DESCRIPTION
## What

Responsive polish for the node dashboard based on screenshot audit at 4 viewport sizes (1440, 1024, 768, 375px).

### Changes

1. **Agent strip scroll fade** — gradient fade indicator on right edge when agents overflow. Disappears when scrolled to end. Wrapper element `.agent-strip-wrapper` with `::after` pseudo-element.

2. **Mobile logo clipping fix** — at ≤767px, the hamburger menu overlaps the 'reflectt-node' logo text. Added `padding-left: 40px` to `.header-left` in the mobile breakpoint.

3. **Scroll snap** — `scroll-snap-type: x proximity` + `scroll-snap-align: start` on agent cards for smoother horizontal scrolling on touch devices.

4. **Tighter mobile cards** — agent card `min-width` reduced to 150px at ≤420px for better mobile density.

### Screenshots

Audit screenshots at all 4 viewport sizes in `workspace-pixel/screenshots/responsive-audit/`

### Testing

- `npm test`: 1524 passed, 1 skipped, 3 pre-existing failures (modules.test.ts, not related)
- Visual testing at 375, 768, 1024, 1440px viewports

Task: task-1772328789365-1xzpj07k5