### PR TITLE
fix: update tests for relaxed onboarding schema

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -522,9 +522,11 @@ describe('Mention Rescue', () => {
 
 describe('Validation Error Shape', () => {
   it('returns structured fields for malformed POST /tasks payload', async () => {
+    // With relaxed onboarding schema, missing fields on todo tasks no longer
+    // triggers validation errors. Use an invalid field value instead.
     const { status, body } = await req('POST', '/tasks', {
-      title: 'bad task',
-      description: 'missing required fields',
+      title: 'bad',  // too short (<10 chars), triggers definition-of-ready
+      priority: 'INVALID_PRIORITY',
     })
     expect(status).toBe(400)
     expect(body.success).toBe(false)

--- a/tests/modules.test.ts
+++ b/tests/modules.test.ts
@@ -1025,17 +1025,16 @@ describe('Task Intake Schema Enforcement', () => {
   })
 
   it('POST /tasks accepts minimal fields for todo tasks (relaxed onboarding schema)', async () => {
-    const res = await req('POST', '/tasks', {
+    const { status, body } = await req('POST', '/tasks', {
       title: 'TEST: Minimal todo task for onboarding validation smoke test',
     })
     // Relaxed schema: todo tasks only require title
-    expect(res.status).toBe(200)
-    const data = await res.json() as any
-    if (data.task?.id) await req('DELETE', `/tasks/${data.task.id}`)
+    expect(status).toBe(200)
+    if (body.task?.id) await req('DELETE', `/tasks/${body.task.id}`)
   })
 
   it('POST /tasks accepts empty done_criteria for todo tasks', async () => {
-    const res = await req('POST', '/tasks', {
+    const { status, body } = await req('POST', '/tasks', {
       title: 'TEST: task with empty done criteria for onboarding flow validation',
       assignee: 'link',
       reviewer: 'kai',
@@ -1045,9 +1044,8 @@ describe('Task Intake Schema Enforcement', () => {
       priority: 'P2',
     })
     // done_criteria defaults to [] and is no longer required for todo tasks
-    expect(res.status).toBe(200)
-    const data = await res.json() as any
-    if (data.task?.id) await req('DELETE', `/tasks/${data.task.id}`)
+    expect(status).toBe(200)
+    if (body.task?.id) await req('DELETE', `/tasks/${body.task.id}`)
   })
 
   it('POST /tasks accepts well-formed task with TEST: prefix', async () => {


### PR DESCRIPTION
## Problem
Tests in api.test.ts and modules.test.ts expect `POST /tasks` with minimal fields to return 400, but the relaxed onboarding schema (#549, #554) now accepts these. Also modules.test.ts used `res.json()` which doesn't exist on the inject helper (returns `{status, body}`).

## Fix
- api.test.ts: use invalid priority value to trigger validation error
- modules.test.ts: use `{status, body}` destructuring, clean up created tasks

## Testing
- reflection-origin-gate: 6/6 pass locally
- 2 files changed, +10/-10