### PR TITLE
feat: request tracking + error logging for launch-day visibility

### DIFF
--- a/src/request-tracker.ts
+++ b/src/request-tracker.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Lightweight request tracking for launch-day visibility.
+ * Tracks request counts per endpoint group and last N errors.
+ * No external dependencies — pure in-memory counters.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface ErrorEntry {
+  ts: number
+  method: string
+  url: string
+  status: number
+  message: string
+  userAgent?: string
+}
+
+interface EndpointGroup {
+  pattern: RegExp
+  name: string
+}
+
+// ── Configuration ──────────────────────────────────────────────────────────
+
+const MAX_ERRORS = 20
+const TRACKED_GROUPS: EndpointGroup[] = [
+  { pattern: /^\/health/, name: 'health' },
+  { pattern: /^\/bootstrap/, name: 'bootstrap' },
+  { pattern: /^\/tasks/, name: 'tasks' },
+  { pattern: /^\/api\/hosts/, name: 'cloud_hosts' },
+  { pattern: /^\/openclaw/, name: 'openclaw' },
+  { pattern: /^\/chat/, name: 'chat' },
+  { pattern: /^\/mcp/, name: 'mcp' },
+]
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+const requestCounts: Record<string, number> = {}
+const errorCounts: Record<string, number> = {}
+const recentErrors: ErrorEntry[] = []
+let totalRequests = 0
+let totalErrors = 0
+const startedAt = Date.now()
+
+// ── Core ───────────────────────────────────────────────────────────────────
+
+function classifyUrl(url: string): string {
+  for (const group of TRACKED_GROUPS) {
+    if (group.pattern.test(url)) return group.name
+  }
+  return 'other'
+}
+
+/**
+ * Record a request. Call from Fastify onResponse hook.
+ */
+export function trackRequest(method: string, url: string, statusCode: number, userAgent?: string): void {
+  totalRequests++
+  const group = classifyUrl(url)
+  requestCounts[group] = (requestCounts[group] || 0) + 1
+
+  if (statusCode >= 400) {
+    totalErrors++
+    errorCounts[group] = (errorCounts[group] || 0) + 1
+  }
+
+  if (statusCode >= 500) {
+    recentErrors.push({
+      ts: Date.now(),
+      method,
+      url: url.length > 200 ? url.slice(0, 200) + '…' : url,
+      status: statusCode,
+      message: `${method} ${url} → ${statusCode}`,
+      userAgent: userAgent?.slice(0, 100),
+    })
+    if (recentErrors.length > MAX_ERRORS) {
+      recentErrors.shift()
+    }
+  }
+}
+
+/**
+ * Record a caught error (for non-HTTP errors like unhandled promise rejections).
+ */
+export function trackError(context: string, error: unknown): void {
+  totalErrors++
+  const msg = error instanceof Error ? error.message : String(error)
+  recentErrors.push({
+    ts: Date.now(),
+    method: 'INTERNAL',
+    url: context,
+    status: 0,
+    message: msg.slice(0, 500),
+  })
+  if (recentErrors.length > MAX_ERRORS) {
+    recentErrors.shift()
+  }
+}
+
+// ── Metrics ────────────────────────────────────────────────────────────────
+
+export function getRequestMetrics(): {
+  total: number
+  errors: number
+  uptimeMs: number
+  byGroup: Record<string, { requests: number; errors: number }>
+  recentErrors: ErrorEntry[]
+  rps: number
+} {
+  const uptimeMs = Date.now() - startedAt
+  const uptimeSec = uptimeMs / 1000
+  const rps = uptimeSec > 0 ? Math.round((totalRequests / uptimeSec) * 100) / 100 : 0
+
+  const byGroup: Record<string, { requests: number; errors: number }> = {}
+  for (const group of TRACKED_GROUPS) {
+    const name = group.name
+    byGroup[name] = {
+      requests: requestCounts[name] || 0,
+      errors: errorCounts[name] || 0,
+    }
+  }
+  if (requestCounts['other']) {
+    byGroup['other'] = {
+      requests: requestCounts['other'] || 0,
+      errors: errorCounts['other'] || 0,
+    }
+  }
+
+  return {
+    total: totalRequests,
+    errors: totalErrors,
+    uptimeMs,
+    byGroup,
+    recentErrors: [...recentErrors].reverse(), // Most recent first
+    rps,
+  }
+}
+
+/** Reset (for testing) */
+export function resetRequestMetrics(): void {
+  totalRequests = 0
+  totalErrors = 0
+  for (const key of Object.keys(requestCounts)) delete requestCounts[key]
+  for (const key of Object.keys(errorCounts)) delete errorCounts[key]
+  recentErrors.length = 0
+}

--- a/tests/request-tracker.test.ts
+++ b/tests/request-tracker.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach } from 'vitest'
+import { trackRequest, trackError, getRequestMetrics, resetRequestMetrics } from '../src/request-tracker.js'
+
+describe('request-tracker', () => {
+  beforeEach(() => {
+    resetRequestMetrics()
+  })
+
+  it('tracks total request count', () => {
+    trackRequest('GET', '/health', 200)
+    trackRequest('GET', '/tasks', 200)
+    trackRequest('POST', '/tasks', 201)
+    const m = getRequestMetrics()
+    expect(m.total).toBe(3)
+    expect(m.errors).toBe(0)
+  })
+
+  it('classifies requests by endpoint group', () => {
+    trackRequest('GET', '/health', 200)
+    trackRequest('GET', '/health/system', 200)
+    trackRequest('GET', '/bootstrap/team', 200)
+    trackRequest('GET', '/tasks/next', 200)
+    trackRequest('POST', '/chat/send', 200)
+    const m = getRequestMetrics()
+    expect(m.byGroup.health.requests).toBe(2)
+    expect(m.byGroup.bootstrap.requests).toBe(1)
+    expect(m.byGroup.tasks.requests).toBe(1)
+    expect(m.byGroup.chat.requests).toBe(1)
+  })
+
+  it('tracks 4xx as errors in counts', () => {
+    trackRequest('POST', '/tasks', 400)
+    trackRequest('GET', '/health', 200)
+    const m = getRequestMetrics()
+    expect(m.errors).toBe(1)
+    expect(m.byGroup.tasks.errors).toBe(1)
+    expect(m.byGroup.health.errors).toBe(0)
+  })
+
+  it('stores 5xx errors in recentErrors', () => {
+    trackRequest('GET', '/health', 500, 'curl/7.81')
+    const m = getRequestMetrics()
+    expect(m.recentErrors).toHaveLength(1)
+    expect(m.recentErrors[0]!.status).toBe(500)
+    expect(m.recentErrors[0]!.method).toBe('GET')
+    expect(m.recentErrors[0]!.userAgent).toBe('curl/7.81')
+  })
+
+  it('does not store 4xx in recentErrors (only 5xx)', () => {
+    trackRequest('POST', '/tasks', 400)
+    trackRequest('POST', '/tasks', 404)
+    const m = getRequestMetrics()
+    expect(m.recentErrors).toHaveLength(0)
+  })
+
+  it('caps recentErrors at 20', () => {
+    for (let i = 0; i < 25; i++) {
+      trackRequest('GET', `/fail-${i}`, 500)
+    }
+    const m = getRequestMetrics()
+    expect(m.recentErrors).toHaveLength(20)
+    // Most recent first
+    expect(m.recentErrors[0]!.url).toBe('/fail-24')
+  })
+
+  it('calculates rps', () => {
+    trackRequest('GET', '/health', 200)
+    trackRequest('GET', '/health', 200)
+    const m = getRequestMetrics()
+    expect(m.rps).toBeGreaterThan(0)
+    expect(m.uptimeMs).toBeGreaterThan(0)
+  })
+
+  it('tracks internal errors via trackError', () => {
+    trackError('cloud-sync', new Error('connection refused'))
+    const m = getRequestMetrics()
+    expect(m.errors).toBe(1)
+    expect(m.recentErrors).toHaveLength(1)
+    expect(m.recentErrors[0]!.method).toBe('INTERNAL')
+    expect(m.recentErrors[0]!.message).toContain('connection refused')
+  })
+
+  it('resets cleanly', () => {
+    trackRequest('GET', '/health', 200)
+    trackRequest('GET', '/health', 500)
+    resetRequestMetrics()
+    const m = getRequestMetrics()
+    expect(m.total).toBe(0)
+    expect(m.errors).toBe(0)
+    expect(m.recentErrors).toHaveLength(0)
+  })
+
+  it('truncates long URLs', () => {
+    const longUrl = '/health/' + 'x'.repeat(300)
+    trackRequest('GET', longUrl, 500)
+    const m = getRequestMetrics()
+    expect(m.recentErrors[0]!.url.length).toBeLessThanOrEqual(201) // 200 + ellipsis
+  })
+})


### PR DESCRIPTION
## Task
task-1772326387933-d7wuj78x8

## Changes
- `src/request-tracker.ts`: Lightweight request counter + error tracker
- `/health` now includes `request_counts` (total, errors, rps, byGroup)
- `GET /health/errors` returns last 20 5xx errors + error rate
- Fastify onResponse hook wired

## Tests
10 new + 1527 existing = 1537 passed