### PR TITLE
fix: cap artifacts panels at 50-60vh to prevent infinite scroll

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2239,7 +2239,7 @@ export function getDashboardHTML(): string {
   <!-- File Browser -->
   <div class="panel" style="margin-bottom:var(--space-4)">
     <div class="panel-header">📁 Files <span class="count" id="files-count"></span></div>
-    <div class="panel-body" style="max-height:none">
+    <div class="panel-body" style="max-height:50vh;overflow-y:auto">
       <div class="file-toolbar">
         <input class="file-search" type="search" id="fileSearch" placeholder="Search files…"
                aria-label="Search files" oninput="filterFiles(this.value)">
@@ -2259,7 +2259,7 @@ export function getDashboardHTML(): string {
   <!-- Shared Artifacts (existing) -->
   <div class="panel" id="shared-artifacts-panel">
     <div class="panel-header">📚 Shared Artifacts <span class="count" id="shared-artifacts-count">loading…</span></div>
-    <div class="panel-body" id="shared-artifacts-body" style="max-height:none;overflow-y:auto"></div>
+    <div class="panel-body" id="shared-artifacts-body" style="max-height:60vh;overflow-y:auto"></div>
   </div>
 
   </div><!-- /page-artifacts -->


### PR DESCRIPTION
## What

The Artifacts page files and shared artifacts panels had `max-height:none`, causing the page to stretch infinitely with many files/artifacts.

### Changes

- Files panel: `max-height:50vh` (was `none`)
- Shared Artifacts panel: `max-height:60vh` (was `none`)
- Both already had `overflow-y:auto` — just needed the height caps

2-line change. Same pattern as kanban column cap in #557.

Task: task-1772334507067-8tel709qg