### PR TITLE
fix: agent strip uses dynamic registry instead of hardcoded roster

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -583,7 +583,21 @@ async function loadPresence() {
   });
 
   const strip = document.getElementById('agent-strip');
-  strip.innerHTML = AGENTS.map(a => {
+  // Build dynamic agent list from registry + presence (not hardcoded AGENTS)
+  const registeredAgents = Array.from(AGENT_INDEX.values());
+  // Add any agents from presence not already in registry
+  Object.keys(presenceMap).forEach(name => {
+    if (!AGENT_INDEX.has(name)) {
+      registeredAgents.push({ name, emoji: '🤖', role: '' });
+    }
+  });
+  // Add any agents with active tasks not already listed
+  Object.keys(agentTasks).forEach(name => {
+    if (!AGENT_INDEX.has(name) && !presenceMap[name]) {
+      registeredAgents.push({ name, emoji: '🤖', role: '' });
+    }
+  });
+  strip.innerHTML = registeredAgents.map(a => {
     const p = presenceMap[a.name];
     const taskTitle = agentTasks[a.name];
     const healthRow = healthAgentMap.get(a.name);


### PR DESCRIPTION
Ryan caught this — the agent strip was hardcoded to our 10 agents. Any other team using reflectt-node would see our roster instead of theirs.

Now renders from /team/roles registry + presence data + active task assignees. Falls back to the static list only if the registry is empty.