### PR TITLE
fix: add required fields to POST /tasks example in getting-started guide

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -78,7 +78,14 @@ If the doctor tells you to fix something, follow its instructions. Re-run the do
 ```bash
 curl -X POST http://localhost:4445/tasks \
   -H 'Content-Type: application/json' \
-  -d '{"title": "Build the landing page", "priority": "P1", "assignee": "builder"}'
+  -d '{
+    "title": "Build the landing page",
+    "priority": "P1",
+    "assignee": "builder",
+    "done_criteria": "Landing page is live and links work",
+    "eta": "2h",
+    "createdBy": "human"
+  }'
 ```
 
 **Check your agent's next action:**


### PR DESCRIPTION
The `POST /tasks` example in GETTING-STARTED.md was missing `done_criteria`, `eta`, and `createdBy` — all required by the DEFINITION_OF_READY gate. New users would hit a validation error on step 4.

Added the required fields to make the example actually work against a fresh install.

Flagged by @sage on task-1772342446401-x8bvxyllf.