### PR TITLE
feat: add exclude_from filter to GET /chat/messages

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -545,6 +545,7 @@ class ChatManager {
 
   getMessages(options?: {
     from?: string
+    excludeFrom?: string
     to?: string
     channel?: string
     limit?: number
@@ -559,6 +560,10 @@ class ChatManager {
     if (options?.from) {
       conditions.push('"from" = ?')
       params.push(options.from)
+    }
+    if (options?.excludeFrom) {
+      conditions.push('"from" != ?')
+      params.push(options.excludeFrom)
     }
     if (options?.to) {
       conditions.push('"to" = ?')

--- a/src/server.ts
+++ b/src/server.ts
@@ -510,6 +510,7 @@ const ReviewHandoffSchema = z.object({
 
 const ChatMessagesQuerySchema = z.object({
   from: z.string().optional(),
+  exclude_from: z.string().optional(),
   to: z.string().optional(),
   channel: z.string().optional(),
   limit: z.string().optional(),
@@ -3408,6 +3409,7 @@ export async function createServer(): Promise<FastifyInstance> {
     const query = parsedQuery.data
     const messages = chatManager.getMessages({
       from: query.from,
+      excludeFrom: query.exclude_from,
       to: query.to,
       channel: query.channel,
       limit: boundedLimit(query.limit, DEFAULT_LIMITS.chatMessages, MAX_LIMITS.chatMessages),


### PR DESCRIPTION
## What
Adds `exclude_from` query param to `GET /chat/messages` that filters out messages from a specific sender.

## Why
Scout dogfooding found the cloud dashboard chat page is flooded with system noise. New user sees robot spam instead of team conversation.

## How
- Added `exclude_from` to ChatMessagesQuerySchema in server.ts
- Added `excludeFrom` option to chatManager.getMessages() in chat.ts
- SQL filter: `from != ?` when excludeFrom is set

Usage: `GET /chat/messages?exclude_from=system`

Tests: tsc clean, 218/218 pass.
Task: task-1772383172984-dypvtdpq4