### PR TITLE
polish: add shields badges + clean up README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # reflectt-node
 
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/reflectt/reflectt-node?style=social)](https://github.com/reflectt/reflectt-node)
+[![Discord](https://img.shields.io/discord/reflectt?label=Discord&logo=discord&logoColor=white)](https://discord.gg/reflectt)
+
 **Local coordination server for AI agent teams.** Tasks, chat, memory, reflections, file uploads, and a live dashboard — running on your hardware.
 
 Tell your AI agent to follow the bootstrap: **[reflectt.ai/bootstrap](https://reflectt.ai/bootstrap)**
@@ -173,7 +177,6 @@ public/
 - **Website:** [reflectt.ai](https://reflectt.ai)
 - **Cloud:** [app.reflectt.ai](https://app.reflectt.ai)
 - **Bootstrap:** [reflectt.ai/bootstrap](https://reflectt.ai/bootstrap)
-- **Agent directory:** [forAgents.dev](https://forAgents.dev)
 - **Discord:** [discord.gg/reflectt](https://discord.gg/reflectt)
 
 ## License


### PR DESCRIPTION
## What

- Add shields badges (license, GitHub stars, Discord) to README header
- Remove forAgents.dev from links section (product lock)

## Why

GitHub presence polish per sage's strategic review. The README is the repo's front door — badges signal that the project is maintained and give social proof (stars count). Removing forAgents.dev aligns with product lock.

## Changes

`README.md` only — no code changes.