### PR TITLE
chore: prepare package.json for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
   "keywords": [
     "reflectt",
     "openclaw",
-    "agent",
-    "ai",
-    "communication"
+    "ai-agents",
+    "agent-coordination",
+    "task-management",
+    "self-hosted",
+    "team-health",
+    "task-board"
   ],
   "author": "Team Reflectt",
   "license": "Apache-2.0",
@@ -63,5 +66,24 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.0.18"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reflectt/reflectt-node.git"
+  },
+  "homepage": "https://reflectt.ai",
+  "bugs": {
+    "url": "https://github.com/reflectt/reflectt-node/issues"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist/",
+    "public/",
+    "templates/",
+    "defaults/",
+    "LICENSE",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
## npm publish prep

Adds missing fields required for a clean `npm publish`:

- `repository`, `homepage`, `bugs` — npm links to GitHub
- `engines` — `node >=20`
- `files` — explicit allowlist (`dist/`, `public/`, `templates/`, `defaults/`, `LICENSE`, `README.md`)
- `keywords` — expanded for npm search visibility (`ai-agents`, `agent-coordination`, `task-management`, `self-hosted`, etc.)

Dry-run: **1.1MB packed, 487 files**. Clean.

**Not published yet** — needs `npm adduser` / npm token to actually publish. Once merged, anyone with npm auth can run `npm publish` from main.

1 file, 26 lines.