### PR TITLE
feat(reflectt-channel): auto-discover agents from /team/roles

### DIFF
--- a/plugins/reflectt-channel/src/channel.ts
+++ b/plugins/reflectt-channel/src/channel.ts
@@ -4,8 +4,12 @@ import type { ResolvedReflecttAccount, ReflecttConfig } from "./types.js";
 
 const DEFAULT_REFLECTT_URL = "http://localhost:4445";
 
-const WATCHED_AGENTS = ["kai", "link", "pixel", "echo", "harmony", "rhythm", "sage", "scout", "spark"] as const;
-const WATCHED_SET = new Set<string>(WATCHED_AGENTS);
+// NOTE: This file is a legacy standalone implementation and is NOT imported by ../index.ts.
+// Agent discovery is handled dynamically in index.ts via refreshAgentRoster() which queries
+// /team/roles on connect and refreshes every 5 minutes. The hardcoded roster has been removed;
+// if this file is ever wired up it should import the shared roster from index.ts instead.
+let WATCHED_AGENTS: string[] = [];
+let WATCHED_SET = new Set<string>();
 
 const IDLE_NUDGE_WINDOW_MS = 15 * 60 * 1000; // 15m
 const WATCHDOG_INTERVAL_MS = 60 * 1000; // 1m poll


### PR DESCRIPTION
## What

Auto-discover the agent roster from `/team/roles` instead of relying on a hardcoded list.

### Changes to `index.ts`:
- **`/team/roles` added as the first endpoint** in `refreshAgentRoster()` — extracts `data.agents[].name`
- **Periodic refresh every 5 minutes** via `startRosterRefresh()` / `stopRosterRefresh()` — called in `startAccount`, cleaned up in `stop`
- **`FALLBACK_AGENTS` emptied** — no more placeholder names; warns clearly when roster can't be loaded
- Legacy endpoints (`/health/agents`, `/capabilities`) kept as fallbacks

### Changes to `src/channel.ts`:
- Hardcoded `WATCHED_AGENTS` list removed, replaced with empty mutable bindings
- Comment added noting this file is legacy and not imported by `index.ts`

### Done criteria:
- [x] Plugin fetches /team/roles on connect and periodically refreshes
- [x] Spawned sub-agents are automatically dispatchable without config changes
- [x] WATCHED_AGENTS hardcoded list removed or used only as fallback
- [ ] Tested: spawn a new agent, @mention it, verify dispatch works without restart (needs runtime test)

Closes task-1772386004861-ugzzq8gak