### PR TITLE
fix: insight-task-bridge dedup by source reflection

### DIFF
--- a/incidents/watchdog-incidents.jsonl
+++ b/incidents/watchdog-incidents.jsonl
@@ -103,3 +103,4 @@
 {"type":"stale_working","at":1771700486971,"agent":"kai","taskId":"task-1771695803638-4habgloi3","thresholdMs":2700000,"lastUpdateAt":null,"workingSinceAt":1771698968542}
 {"type":"stale_working","at":1772389640982,"agent":"pixel","taskId":"task-1772383147598-2xofiqz13","thresholdMs":2700000,"lastUpdateAt":1772386415894,"workingSinceAt":1772386537876}
 {"type":"stale_working","at":1772397203011,"agent":"link","taskId":"task-1771849175579-apuqqi0fd","thresholdMs":2700000,"lastUpdateAt":1772394472185,"workingSinceAt":1772394368602}
+{"type":"stale_working","at":1772412027791,"agent":"link","taskId":"task-1771849175579-apuqqi0fd","thresholdMs":2700000,"lastUpdateAt":1772409304819,"workingSinceAt":1772409304817}

--- a/src/insight-task-bridge.ts
+++ b/src/insight-task-bridge.ts
@@ -149,7 +149,7 @@ export function reflectionOverlap(a: string[], b: string[]): number {
  * 1. Direct insight_id match (exact)
  * 2. Exact title match (case-insensitive)
  * 3. Same cluster_key via insight-bridge source (same stage::family::unit)
- * 4. Reflection overlap: source insight shares ≥50% of reflection_ids (same evidence, different cluster)
+ * 4. Same source reflection (two insights from one reflection = duplicate)
  *
  * Returns match with status so callers can decide (done = already addressed,
  * active = in progress, null = no coverage).
@@ -161,7 +161,7 @@ interface ExistingTaskMatch {
   alreadyAddressed: boolean  // true if done or validating
 }
 
-function findExistingTaskForInsight(insight: Insight): ExistingTaskMatch | null {
+export function findExistingTaskForInsight(insight: Insight): ExistingTaskMatch | null {
   const allTasks = taskManager.listTasks({})
   const targetTitle = `[Insight] ${insight.title}`.toLowerCase()
 
@@ -260,6 +260,19 @@ function findExistingTaskForInsight(insight: Insight): ExistingTaskMatch | null 
           }
         }
       } catch { /* ignore lookup failures */ }
+    }
+
+    // 4. Same source reflection — two insights from the same reflection are duplicates
+    if (meta.source === 'insight-task-bridge' && typeof meta.source_reflection === 'string') {
+      const insightReflectionIds = insight.reflection_ids || []
+      if (insightReflectionIds.includes(meta.source_reflection as string)) {
+        return {
+          id: task.id,
+          title: task.title,
+          status: task.status,
+          alreadyAddressed: task.status === 'done' || task.status === 'validating',
+        }
+      }
     }
   }
 

--- a/tests/insight-dedup-reflection.test.ts
+++ b/tests/insight-dedup-reflection.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests: insight dedup by source reflection
+// Proves: two insights from the same reflection are detected as duplicates.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { taskManager } from '../src/tasks.js'
+import { findExistingTaskForInsight } from '../src/insight-task-bridge.js'
+import type { Insight } from '../src/insights.js'
+
+function makeInsight(overrides: Partial<Insight> = {}): Insight {
+  return {
+    id: 'ins-test-1',
+    cluster_key: 'unknown::uncategorized::product-bugs',
+    workflow_stage: 'unknown',
+    failure_family: 'uncategorized',
+    impacted_unit: 'product-bugs',
+    title: 'uncategorized: Multiple product bugs hiding behind process noise',
+    status: 'promoted',
+    score: 10,
+    priority: 'P0',
+    reflection_ids: ['ref-shared-reflection-123'],
+    independent_count: 1,
+    evidence_refs: ['PR #572', 'PR #574'],
+    authors: ['rhythm'],
+    promotion_readiness: 'override',
+    recurring_candidate: false,
+    cooldown_until: null,
+    cooldown_reason: null,
+    severity_max: 'high',
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('Insight dedup by source reflection', () => {
+  const createdTaskIds: string[] = []
+
+  afterEach(() => {
+    for (const id of createdTaskIds) {
+      try { taskManager.deleteTask(id) } catch { /* ok */ }
+    }
+    createdTaskIds.length = 0
+  })
+
+  it('detects duplicate when existing task shares the same source_reflection', async () => {
+    // Create a task from the first insight (same source reflection)
+    const task = await taskManager.createTask({
+      title: '[Insight] First insight from shared reflection',
+      status: 'done',
+      assignee: 'sage',
+      reviewer: 'rhythm',
+      createdBy: 'insight-bridge',
+      done_criteria: ['done'],
+      metadata: {
+        source: 'insight-task-bridge',
+        insight_id: 'ins-first-insight',
+        source_reflection: 'ref-shared-reflection-123',
+      },
+    })
+    createdTaskIds.push(task.id)
+
+    // Second insight from the same reflection but different cluster
+    const secondInsight = makeInsight({
+      id: 'ins-test-2',
+      cluster_key: 'unknown::uncategorized::topic-process-automation-sweeper',
+      title: 'uncategorized: Process automation generating noise',
+      reflection_ids: ['ref-shared-reflection-123'],
+    })
+
+    const match = findExistingTaskForInsight(secondInsight)
+    expect(match).not.toBeNull()
+    expect(match!.id).toBe(task.id)
+    expect(match!.alreadyAddressed).toBe(true)
+  })
+
+  it('does not flag as duplicate when reflections are different', async () => {
+    const task = await taskManager.createTask({
+      title: '[Insight] Unrelated insight',
+      status: 'todo',
+      assignee: 'sage',
+      reviewer: 'rhythm',
+      createdBy: 'insight-bridge',
+      done_criteria: ['done'],
+      metadata: {
+        source: 'insight-task-bridge',
+        insight_id: 'ins-unrelated',
+        source_reflection: 'ref-different-reflection-456',
+      },
+    })
+    createdTaskIds.push(task.id)
+
+    const newInsight = makeInsight({
+      id: 'ins-test-3',
+      reflection_ids: ['ref-shared-reflection-123'],
+    })
+
+    // Should NOT match — different source_reflection
+    const match = findExistingTaskForInsight(newInsight)
+    // Could match on other criteria depending on test state, but not on reflection
+    // The key assertion: if it matches, it shouldn't be because of reflection dedup
+    if (match && match.id === task.id) {
+      // This would be wrong — different reflections shouldn't match
+      expect(true).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Two insights from the same reflection created duplicate tasks because they had different cluster_keys (`product-bugs` vs `topic-process-automation-sweeper`) despite identical evidence. The existing dedup checks by insight_id, title, and cluster_key all missed this.

## Fix

Added dedup check #4: if an existing insight-bridge task shares the same `source_reflection` as the new insight, treat it as a duplicate. Two insights from one reflection are duplicates by definition.

## Tests
2 new in `insight-dedup-reflection.test.ts`. Full suite: 1573/1573 pass. Build clean.

Closes task-yowl2xutn