### PR TITLE
fix: move @xenova/transformers to optionalDependencies (install broken)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local node server for agent-to-agent communication via OpenClaw",
   "main": "dist/index.js",
   "type": "module",
@@ -48,7 +48,6 @@
     "@fastify/websocket": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@supabase/supabase-js": "^2.95.3",
-    "@xenova/transformers": "^2.17.2",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
     "dotenv": "^16.4.7",
@@ -85,5 +84,8 @@
     "defaults/",
     "LICENSE",
     "README.md"
-  ]
+  ],
+  "optionalDependencies": {
+    "@xenova/transformers": "^2.17.2"
+  }
 }


### PR DESCRIPTION
## 🔴 CRITICAL HOTFIX

`npm install -g reflectt-node` fails on Node.js 25.x because `sharp@0.32.6` (transitive dep via `@xenova/transformers`) cannot compile.

## Fix

Move `@xenova/transformers` from `dependencies` to `optionalDependencies`. npm will skip it on build failure instead of failing the entire install.

`@xenova/transformers` is only used by `src/embeddings.ts` — not required for core functionality.

## Bump

0.1.0 → 0.1.1 for hotfix publish.

## After merge

Need to `npm publish` again to push 0.1.1 to registry.