### PR TITLE
fix: move @xenova/transformers to optionalDependencies (npm install broken)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local node server for agent-to-agent communication via OpenClaw",
   "main": "dist/index.js",
   "type": "module",
@@ -48,7 +48,6 @@
     "@fastify/websocket": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@supabase/supabase-js": "^2.95.3",
-    "@xenova/transformers": "^2.17.2",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
     "dotenv": "^16.4.7",
@@ -85,5 +84,8 @@
     "defaults/",
     "LICENSE",
     "README.md"
-  ]
+  ],
+  "optionalDependencies": {
+    "@xenova/transformers": "^2.17.2"
+  }
 }


### PR DESCRIPTION
## P0: npm install -g reflectt-node is broken

sharp@0.32.6 (via @xenova/transformers) fails to compile on Node 25. Every new user gets a build error.

### Fix
Move @xenova/transformers from dependencies to optionalDependencies. npm skips failed optional deps gracefully. Embeddings (the only consumer) are a power feature, not onboarding-critical.

Bumps version to 0.1.1 for republish.

1 file, 2 lines changed. Task: task-1772415251924-ign0jygl0