### PR TITLE
fix: move @xenova/transformers to optionalDependencies (P0 install blocker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local node server for agent-to-agent communication via OpenClaw",
   "main": "dist/index.js",
   "type": "module",
@@ -48,7 +48,6 @@
     "@fastify/websocket": "^11.0.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@supabase/supabase-js": "^2.95.3",
-    "@xenova/transformers": "^2.17.2",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
     "dotenv": "^16.4.7",
@@ -85,5 +84,8 @@
     "defaults/",
     "LICENSE",
     "README.md"
-  ]
+  ],
+  "optionalDependencies": {
+    "@xenova/transformers": "^2.17.2"
+  }
 }

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) Reflectt AI
 
-import { pipeline } from '@xenova/transformers'
+// @xenova/transformers is an optional dependency — may not be installed
+// if sharp fails to build (e.g. Node 25+). Embeddings gracefully degrade.
+let pipeline: any
+try {
+  pipeline = (await import('@xenova/transformers')).pipeline
+} catch {
+  pipeline = null
+}
 
 const DEFAULT_MODEL = process.env.REFLECTT_EMBED_MODEL || 'Xenova/all-MiniLM-L6-v2'
 
@@ -14,6 +21,9 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 async function getExtractor(): Promise<FeatureExtractor> {
+  if (!pipeline) {
+    throw new Error('Embeddings unavailable: @xenova/transformers is not installed. Install it with: npm install @xenova/transformers')
+  }
   if (!extractorPromise) {
     extractorPromise = pipeline('feature-extraction', DEFAULT_MODEL) as Promise<FeatureExtractor>
   }


### PR DESCRIPTION
## 🚨 Critical

`npm install -g reflectt-node` is broken. `sharp@0.32.6` (pulled by `@xenova/transformers`) fails to build on Node 25+.

## Fix

- Move `@xenova/transformers` from `dependencies` to `optionalDependencies`
- Gracefully handle missing import in `embeddings.ts` (clear error message if someone tries to use embeddings without the dep)
- Bump to 0.1.1

## Impact

Embeddings (semantic search) are a power feature. Core functionality (tasks, chat, dashboard, presence, health) works perfectly without it. Users who want embeddings can `npm install @xenova/transformers` separately.

## After merge

Ryan needs to `npm publish` to push 0.1.1.