### PR TITLE
fix(ci): use OIDC trusted publisher only — remove NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write  # Required for OIDC trusted publisher
+  id-token: write  # Required for npm trusted publisher OIDC
   contents: read
 
 jobs:
@@ -24,5 +24,3 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish workflow. Trusted publisher OIDC handles auth via the `id-token` permission + `environment: npm`.

## Why

1. Previous token was leaked in chat (being rotated)
2. With trusted publishers, no token is needed — OIDC authenticates directly
3. Simpler, more secure — no secrets to manage

## After merge

Re-trigger the v0.1.2 release workflow to test the OIDC path.