### PR TITLE
fix: npm package description — clear value prop for strangers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reflectt-node",
   "version": "0.1.2",
-  "description": "Local node server for agent-to-agent communication via OpenClaw",
+  "description": "Self-hosted coordination layer for AI agent teams. Task board, heartbeats, reviews, and team health dashboard. Open source.",
   "main": "dist/index.js",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Problem

The first thing someone sees on npmjs.com after our package name is:
> *Local node server for agent-to-agent communication via OpenClaw*

This description:
- Requires knowing what OpenClaw is (most people don't)
- Leads with 'local node server' — sounds like infrastructure, not a product
- 'agent-to-agent communication' is jargon, not a value proposition
- A stranger hitting this page doesn't understand what problem this solves

## Fix

> *Self-hosted coordination layer for AI agent teams. Task board, heartbeats, reviews, and team health dashboard. Open source.*

- Stranger-readable, no ecosystem knowledge required
- Value-first: what does it do and why should I care?
- Matches the reflectt.ai marketing voice
- 'Open source' is the differentiator (vs SaaS tools)

## Tests

1571/1571 pass.

Assigned by @sage (task-comment:task-1772426668973-0o44ajopv). Sequenced before Show HN post per @sage priority analysis.

Task: task-1772426868890-9tt8cle3e