### PR TITLE
fix: README quickstart + init next steps (scout audit items 4, 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Tell your AI agent to follow the bootstrap: **[reflectt.ai/bootstrap](https://re
 
 ---
 
+## Quickstart (2 minutes)
+
+```bash
+npm install -g reflectt-node   # Install globally
+reflectt init                  # Set up ~/.reflectt/
+reflectt start                 # Start the server
+```
+
+Open [http://localhost:4445/dashboard](http://localhost:4445/dashboard) — a starter team and welcome task are waiting.
+
+**Connect to cloud (optional):** `reflectt host connect --join-token <token>`  
+Get your token at [app.reflectt.ai](https://app.reflectt.ai) → create a team → Settings → Join token.
+
+---
+
 ## Get Started
 
 ### Option 1: Tell your agent
@@ -28,8 +43,8 @@ Your agent reads the instructions, installs reflectt-node, and starts coordinati
 ### Option 2: npm
 
 ```bash
-npm install reflectt-node
-npx reflectt-node
+npm install -g reflectt-node
+reflectt init && reflectt start
 ```
 
 ### Option 3: Docker

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -461,9 +461,14 @@ program
     console.log(`   Home: ${REFLECTT_HOME}`)
     console.log('')
     console.log('Next steps:')
-    console.log('  1. Edit TEAM.md with your team\'s mission and values')
-    console.log('  2. Edit TEAM-ROLES.yaml with your agent roster')
-    console.log('  3. Start the server: reflectt start')
+    console.log('  1. Start the server:   reflectt start')
+    console.log('  2. Open the dashboard: http://localhost:4445/dashboard')
+    console.log('  3. Connect to cloud:   reflectt host connect --join-token <token>')
+    console.log('     Get your token at:  https://app.reflectt.ai')
+    console.log('')
+    console.log('Optional:')
+    console.log('  - Edit TEAM.md with your team\'s mission and values')
+    console.log('  - Edit TEAM-ROLES.yaml to customize your agent roster')
   })
 
 // ============ START COMMAND ============


### PR DESCRIPTION
## What
Two small content fixes from scout's first-time user audit (task-1772426668973-0o44ajopv).

## Changes

### README.md
- Added a 3-command quickstart section before Get Started
- Fixed Option 2 (npm) to use global install + correct CLI commands

### src/cli.ts
- Reordered `reflectt init` next steps: start server first, then dashboard URL, then cloud connect with app.reflectt.ai link
- Team file editing moved to Optional section

## Not in this PR
- package.json description → covered by PR #585
- npm badge → already in #589 (merged)
- doctor fresh-install mode → @link
- host connect hint → @link

## Scout audit items addressed
- #4: init output vague next steps → fixed
- #10: No quickstart in README → fixed