### PR TITLE
fix: bootstrap command — remove agent-only framing, add cloud URL hint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -914,9 +914,9 @@ dogfood
 // ============ BOOTSTRAP (one-shot install + connect + start) ============
 program
   .command('bootstrap')
-  .description('One-shot setup: init + connect to cloud + start server (for npx/agent use)')
-  .option('--join-token <token>', 'Cloud host join token')
-  .option('--api-key <key>', 'Team API key (agent flow)')
+  .description('One-shot setup: init + connect to cloud + start server. Fastest way to get running.')
+  .option('--join-token <token>', 'Cloud host join token (get one at app.reflectt.ai)')
+  .option('--api-key <key>', 'Team API key')
   .option('--cloud-url <url>', 'Cloud API base URL', 'https://api.reflectt.ai')
   .option('--name <hostName>', 'Host display name', hostname())
   .option('--type <hostType>', 'Host type', 'openclaw')
@@ -925,9 +925,11 @@ program
       if (!options.joinToken && !options.apiKey) {
         console.error('❌ Either --join-token or --api-key is required')
         console.error('')
+        console.error('Get a join token at: https://app.reflectt.ai')
+        console.error('')
         console.error('Usage:')
-        console.error('  npx reflectt-node bootstrap --join-token <token>')
-        console.error('  npx reflectt-node bootstrap --api-key <key>')
+        console.error('  npx reflectt bootstrap --join-token <token>')
+        console.error('  npx reflectt bootstrap --api-key <key>')
         process.exit(1)
       }
 


### PR DESCRIPTION
## What

Fixes Friction #9 from the first-time user experience audit (task-1772426668973).

The `bootstrap` command description read: _"One-shot setup: init + connect to cloud + start server (for npx/agent use)"_

That parenthetical actively misdirects humans away from the command that's best suited to help them get set up. Bootstrap is the right path for both humans and agents.

## Changes

- **Description**: Remove `(for npx/agent use)` — replaced with `Fastest way to get running.`
- **`--join-token` hint**: Adds `(get one at app.reflectt.ai)` so users know where to go
- **Error output**: When `--join-token` and `--api-key` are both missing, now prints `Get a join token at: https://app.reflectt.ai` before the usage lines
- **Usage examples**: `npx reflectt-node` → `npx reflectt` (matches the actual installed command name per audit step 3)

## Before / After

```
# Before
bootstrap  One-shot setup: init + connect to cloud + start server (for npx/agent use)

# After
bootstrap  One-shot setup: init + connect to cloud + start server. Fastest way to get running.
```

## Audit ref

Scout's first-time UX audit — friction map item 9.
Review: @link