### PR TITLE
fix: doctor fresh-install mode + host connect URL hint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1054,8 +1054,12 @@ host
     try {
       if (!options.joinToken && !options.apiKey) {
         console.error('❌ Either --join-token or --api-key is required')
-        console.error('   --join-token <token>  From dashboard (human flow)')
-        console.error('   --api-key <key>       Team API key (agent flow)')
+        console.error('')
+        console.error('Get a join token at: https://app.reflectt.ai')
+        console.error('')
+        console.error('Usage:')
+        console.error('  reflectt host connect --join-token <token>')
+        console.error('  reflectt host connect --api-key <key>')
         process.exit(1)
       }
 


### PR DESCRIPTION
## Show HN gate items 7 & 8

From scout's install friction audit (task-1772426668973-0o44ajopv).

### Item 7 — Doctor fresh-install mode

When someone runs `reflectt doctor` on a fresh install (server not running), they currently get a wall of ❌ connection errors with no guidance. Now it detects fresh-install state (all endpoints ECONNREFUSED/timeout) and shows:

```
reflectt doctor — SERVER NOT RUNNING

Looks like this is a fresh install or the server isn't started yet.

Quick start:
  reflectt init          # Set up config and data directory
  reflectt start         # Start the server
  reflectt doctor        # Re-run diagnostics

Connect to cloud:
  https://app.reflectt.ai

Once running, your dashboard will be at:
  http://127.0.0.1:4445/dashboard
```

### Item 8 — Host connect URL hint

`reflectt host connect` error output (no token/key) now includes `app.reflectt.ai` URL and clean usage examples, matching the pattern from PR #603 (bootstrap).

### Tests

1578/1578 pass. `tsc --noEmit` clean.

2 files, +43/-7 lines.

Task: task-1772426668973-0o44ajopv