### PR TITLE
fix: set NODE_ENV=production by default in buildServerEnv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflectt-node",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,7 @@ function getRuntimePaths() {
 function buildServerEnv(config: Config): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
+    NODE_ENV: process.env.NODE_ENV || 'production',
     REFLECTT_HOME,
     PORT: String(config.port),
     HOST: config.host,


### PR DESCRIPTION
## Problem

`reflectt start` fails on npm installs when `NODE_ENV` is not set:
```
Error: unable to determine transport target for "pino-pretty"
```

`pino-pretty` is a devDependency. Server code checks `isDev` which defaults to `true` when `NODE_ENV` is unset, causing the transport lookup to fail since devDependencies aren't installed from npm.

Reported by harmony during 0.1.2 validation.

## Fix

One line in `buildServerEnv()` in `src/cli.ts`:
```js
NODE_ENV: process.env.NODE_ENV || 'production',
```

This ensures npm installs default to production mode without requiring users to prefix `NODE_ENV=production reflectt start`.

## Testing

Harmony's validation confirmed the workaround works. This fix makes it the default.

## Version bump

0.1.2 → 0.1.3