### PR TITLE
fix: default NODE_ENV=production in CLI spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,7 @@ function getRuntimePaths() {
 function buildServerEnv(config: Config): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
+    NODE_ENV: process.env.NODE_ENV || 'production',
     REFLECTT_HOME,
     PORT: String(config.port),
     HOST: config.host,


### PR DESCRIPTION
## Problem
`reflectt start` fails after `npm install -g reflectt-node` with:
```
unable to determine transport target for "pino-pretty"
```

`pino-pretty` is a devDependency excluded from production installs. When `NODE_ENV` is unset, `isDev` defaults to `true` and tries to load it.

## Fix
One line in `buildServerEnv()`: default `NODE_ENV` to `'production'` when not set.

## Version bump
0.1.2 → 0.1.3. Should publish before Show HN.

## Tests
1578/1578 pass.

Task: task-1772431496399-kad3ek1ed