### PR TITLE
fix(ci): remove registry-url from setup-node to unblock OIDC publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+          # Note: registry-url intentionally omitted — it injects NODE_AUTH_TOKEN
+          # from GITHUB_TOKEN which breaks npm OIDC trusted publisher auth
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Root cause

Every publish attempt has failed with E404 despite correct trusted publisher config on npmjs.com.

**Why:** `setup-node` with `registry-url` automatically injects `NODE_AUTH_TOKEN` into the job environment — even when not explicitly set in `env:`. It sources this from the GitHub Actions default token (`GITHUB_TOKEN`), which is **not** an npm auth token. This gets written to `.npmrc` and npm uses it, overriding the OIDC trusted publisher exchange.

Evidence from run `22562664132` (after PR #597 removed `NPM_TOKEN`):
```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX  ← still present, from setup-node
```

## Fix

Remove `registry-url` from `setup-node`. Without it, no `.npmrc` auth entry is written. npm defaults to `https://registry.npmjs.org` for publish and uses the OIDC trusted publisher exchange for auth.

## Testing

After merge: re-trigger `workflow_dispatch` and verify publish succeeds. If it does, tag `v0.1.3` to publish the NODE_ENV fix from PR #606.