### PR TITLE
fix: context page staleness — proactive sync, autosummary on by default, wider agent_persistent budget

### DIFF
--- a/src/context-budget.ts
+++ b/src/context-budget.ts
@@ -73,10 +73,10 @@ export interface ContextInjectionResult {
 }
 
 const DEFAULT_BUDGETS: ContextBudgets = {
-  totalTokens: 10_000,
+  totalTokens: 12_000,
   layers: {
     session_local: 6_000,
-    agent_persistent: 2_000,
+    agent_persistent: 4_000, // Increased from 2k: workspace files (SOUL/TOOLS/AGENTS/HEARTBEAT/MEMORY) typically exceed 2k
     team_shared: 2_000,
   },
 }
@@ -105,7 +105,10 @@ export function getContextBudgets(): ContextBudgets {
 
 export function isAutoSummaryEnabled(): boolean {
   const v = String(process.env.REFLECTT_CONTEXT_AUTOSUMMARY || '').trim().toLowerCase()
-  return v === '1' || v === 'true' || v === 'yes'
+  // Autosummary uses a local heuristic summarizer (no LLM), so it is safe to enable by default.
+  // Opt-out explicitly with REFLECTT_CONTEXT_AUTOSUMMARY=false (or 0/no).
+  if (v === '0' || v === 'false' || v === 'no') return false
+  return true // enabled by default
 }
 
 /**

--- a/tests/context-budget-defaults.test.ts
+++ b/tests/context-budget-defaults.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for context-budget default changes:
+//   - agent_persistent budget increased from 2k → 4k (prevents token suppression for typical workspaces)
+//   - autosummary defaults to ON (heuristic-only, no LLM cost; opt-out via REFLECTT_CONTEXT_AUTOSUMMARY=false)
+//   - proactive context sync added (cloud.ts timer — not testable here, covered by integration)
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { getContextBudgets, isAutoSummaryEnabled } from '../src/context-budget.js'
+
+describe('context-budget defaults', () => {
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    savedEnv = {
+      REFLECTT_CONTEXT_AUTOSUMMARY: process.env.REFLECTT_CONTEXT_AUTOSUMMARY,
+      REFLECTT_CONTEXT_BUDGET_AGENT_PERSISTENT_TOKENS: process.env.REFLECTT_CONTEXT_BUDGET_AGENT_PERSISTENT_TOKENS,
+      REFLECTT_CONTEXT_BUDGET_SESSION_LOCAL_TOKENS: process.env.REFLECTT_CONTEXT_BUDGET_SESSION_LOCAL_TOKENS,
+      REFLECTT_CONTEXT_BUDGET_TOTAL_TOKENS: process.env.REFLECTT_CONTEXT_BUDGET_TOTAL_TOKENS,
+    }
+    // Clear all overrides so we test the actual defaults
+    for (const key of Object.keys(savedEnv)) delete process.env[key]
+  })
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key]
+      else process.env[key] = val
+    }
+  })
+
+  describe('isAutoSummaryEnabled', () => {
+    it('defaults to true when env var is unset', () => {
+      expect(isAutoSummaryEnabled()).toBe(true)
+    })
+
+    it('returns false when explicitly disabled with "false"', () => {
+      process.env.REFLECTT_CONTEXT_AUTOSUMMARY = 'false'
+      expect(isAutoSummaryEnabled()).toBe(false)
+    })
+
+    it('returns false when explicitly disabled with "0"', () => {
+      process.env.REFLECTT_CONTEXT_AUTOSUMMARY = '0'
+      expect(isAutoSummaryEnabled()).toBe(false)
+    })
+
+    it('returns false when explicitly disabled with "no"', () => {
+      process.env.REFLECTT_CONTEXT_AUTOSUMMARY = 'no'
+      expect(isAutoSummaryEnabled()).toBe(false)
+    })
+
+    it('returns true when set to "true"', () => {
+      process.env.REFLECTT_CONTEXT_AUTOSUMMARY = 'true'
+      expect(isAutoSummaryEnabled()).toBe(true)
+    })
+
+    it('returns true when set to "1"', () => {
+      process.env.REFLECTT_CONTEXT_AUTOSUMMARY = '1'
+      expect(isAutoSummaryEnabled()).toBe(true)
+    })
+  })
+
+  describe('getContextBudgets defaults', () => {
+    it('agent_persistent default is 4000 tokens', () => {
+      const budgets = getContextBudgets()
+      expect(budgets.layers.agent_persistent).toBe(4_000)
+    })
+
+    it('session_local default is 6000 tokens', () => {
+      const budgets = getContextBudgets()
+      expect(budgets.layers.session_local).toBe(6_000)
+    })
+
+    it('team_shared default is 2000 tokens', () => {
+      const budgets = getContextBudgets()
+      expect(budgets.layers.team_shared).toBe(2_000)
+    })
+
+    it('total default is 12000 tokens', () => {
+      const budgets = getContextBudgets()
+      expect(budgets.totalTokens).toBe(12_000)
+    })
+
+    it('env override still works for agent_persistent', () => {
+      process.env.REFLECTT_CONTEXT_BUDGET_AGENT_PERSISTENT_TOKENS = '8000'
+      const budgets = getContextBudgets()
+      expect(budgets.layers.agent_persistent).toBe(8_000)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Three separate root causes all making the context page useless:

**1. Context data stale 3+ days**
Context sync is command-driven only — the cloud sends a `context_sync` command and the node responds. But if the cloud stops dispatching commands (new agent, post-restart, cloud lag), context stays stale indefinitely with no fallback.

**2. Autosummary OFF by default**
`isAutoSummaryEnabled()` required an explicit opt-in env var. The heuristic summarizer is purely local (no LLM, no cost), so defaulting off causes silent truncation instead of smart summarization.

**3. `agent_persistent` budget too tight**
Default 2000 tokens for a layer that holds SOUL.md + TOOLS.md + AGENTS.md + HEARTBEAT.md + MEMORY.md + memory files. Typical workspace exceeds this by ~4000 tokens → 3849+ tokens suppressed, truncated without warning.

## Fixes

- **Proactive sync**: Added `proactiveContextSync()` + periodic timer (30 min active, 60 min idle) in `startCloudIntegration()`. Pushes context for all presence agents without waiting for a cloud command. Cloud-issued `context_sync` still works and takes precedence.
- **Autosummary default on**: Changed `isAutoSummaryEnabled()` from opt-in to opt-out. Disabled only when `REFLECTT_CONTEXT_AUTOSUMMARY=false/0/no`.
- **Budget 2k → 4k**: Increased `agent_persistent` default from 2000 to 4000. Total bumped from 10k to 12k to preserve session_local headroom.

## Tests

11 new unit tests (`context-budget-defaults.test.ts`) covering autosummary default, opt-out variants, budget defaults, and env override. Full suite: **1589 passed** (123 files).

## Changes

- `src/context-budget.ts` — autosummary default on, budget increases
- `src/cloud.ts` — `proactiveContextSync()` + `contextSyncTimer`
- `tests/context-budget-defaults.test.ts` — 11 new tests

Fixes: task-1772415416169-n0eiyptdo