### PR TITLE
fix(ci): use Node 24 for publish — OIDC requires npm v11+

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 24+ required: ships npm v11 which supports OIDC trusted publishing.
+      # Node 22 ships npm v10 which fails the OIDC handshake (misleading 404/expired token).
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - run: npm ci


### PR DESCRIPTION
## Root Cause
Node 22 ships npm v10 which doesn't support the OIDC handshake for npm trusted publishing. The misleading 'Access token expired' + 404 errors were npm v10 failing the OIDC token exchange silently, then trying to publish as anonymous.

## Fix
Node 22 → Node 24 in publish.yml. Node 24 ships npm v11 which handles OIDC correctly.

## References
- [NPM Trusted Publishing: The 'Weird' 404 Error and the Node.js 24 Fix](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd)
- [GitHub Community Discussion #188194](https://github.com/orgs/community/discussions/188194)

## Impact
Once merged, future releases auto-publish to npm via OIDC. No manual OTP needed. Ryan is no longer a blocker for publishes.