### PR TITLE
fix: request tracker — rolling window + granular route groups

### DIFF
--- a/src/request-tracker.ts
+++ b/src/request-tracker.ts
@@ -4,6 +4,7 @@
 /**
  * Lightweight request tracking for launch-day visibility.
  * Tracks request counts per endpoint group and last N errors.
+ * Includes rolling-window metrics to distinguish historical from ongoing errors.
  * No external dependencies — pure in-memory counters.
  */
 
@@ -23,9 +24,21 @@ interface EndpointGroup {
   name: string
 }
 
+interface RollingBucket {
+  requests: number
+  errors: number
+  /** Start of this bucket (ms since epoch) */
+  startedAt: number
+}
+
 // ── Configuration ──────────────────────────────────────────────────────────
 
 const MAX_ERRORS = 20
+
+/** Rolling window: 5-minute buckets, keep last 1 hour */
+const BUCKET_DURATION_MS = 5 * 60 * 1000
+const MAX_BUCKETS = 12 // 12 × 5 min = 1 hour
+
 const TRACKED_GROUPS: EndpointGroup[] = [
   { pattern: /^\/health/, name: 'health' },
   { pattern: /^\/bootstrap/, name: 'bootstrap' },
@@ -34,6 +47,19 @@ const TRACKED_GROUPS: EndpointGroup[] = [
   { pattern: /^\/openclaw/, name: 'openclaw' },
   { pattern: /^\/chat/, name: 'chat' },
   { pattern: /^\/mcp/, name: 'mcp' },
+  // Additional groups to reduce "other" noise
+  { pattern: /^\/heartbeat/, name: 'heartbeat' },
+  { pattern: /^\/inbox/, name: 'inbox' },
+  { pattern: /^\/reflections/, name: 'reflections' },
+  { pattern: /^\/insights/, name: 'insights' },
+  { pattern: /^\/hosts/, name: 'hosts' },
+  { pattern: /^\/presence/, name: 'presence' },
+  { pattern: /^\/shared/, name: 'shared' },
+  { pattern: /^\/avatars/, name: 'avatars' },
+  { pattern: /^\/dashboard/, name: 'dashboard' },
+  { pattern: /^\/memory/, name: 'memory' },
+  { pattern: /^\/preflight/, name: 'preflight' },
+  { pattern: /^\/policy/, name: 'policy' },
 ]
 
 // ── State ──────────────────────────────────────────────────────────────────
@@ -45,6 +71,10 @@ let totalRequests = 0
 let totalErrors = 0
 const startedAt = Date.now()
 
+// Rolling window state
+const rollingBuckets: RollingBucket[] = []
+let currentBucket: RollingBucket = { requests: 0, errors: 0, startedAt: Date.now() }
+
 // ── Core ───────────────────────────────────────────────────────────────────
 
 function classifyUrl(url: string): string {
@@ -54,22 +84,39 @@ function classifyUrl(url: string): string {
   return 'other'
 }
 
+/** Rotate rolling buckets if the current one has expired */
+function rotateBuckets(now: number): void {
+  if (now - currentBucket.startedAt >= BUCKET_DURATION_MS) {
+    rollingBuckets.push(currentBucket)
+    if (rollingBuckets.length > MAX_BUCKETS) {
+      rollingBuckets.shift()
+    }
+    currentBucket = { requests: 0, errors: 0, startedAt: now }
+  }
+}
+
 /**
  * Record a request. Call from Fastify onResponse hook.
  */
 export function trackRequest(method: string, url: string, statusCode: number, userAgent?: string): void {
+  const now = Date.now()
   totalRequests++
   const group = classifyUrl(url)
   requestCounts[group] = (requestCounts[group] || 0) + 1
 
+  // Rolling window
+  rotateBuckets(now)
+  currentBucket.requests++
+
   if (statusCode >= 400) {
     totalErrors++
     errorCounts[group] = (errorCounts[group] || 0) + 1
+    currentBucket.errors++
   }
 
   if (statusCode >= 500) {
     recentErrors.push({
-      ts: Date.now(),
+      ts: now,
       method,
       url: url.length > 200 ? url.slice(0, 200) + '…' : url,
       status: statusCode,
@@ -102,6 +149,31 @@ export function trackError(context: string, error: unknown): void {
 
 // ── Metrics ────────────────────────────────────────────────────────────────
 
+/** Compute rolling-window stats from recent buckets */
+function getRollingMetrics(): { requests: number; errors: number; errorRate: number; windowMinutes: number } {
+  const now = Date.now()
+  rotateBuckets(now)
+
+  let requests = currentBucket.requests
+  let errors = currentBucket.errors
+  const windowStart = now - (MAX_BUCKETS * BUCKET_DURATION_MS)
+
+  for (const bucket of rollingBuckets) {
+    if (bucket.startedAt >= windowStart) {
+      requests += bucket.requests
+      errors += bucket.errors
+    }
+  }
+
+  const errorRate = requests > 0 ? Math.round((errors / requests) * 10000) / 100 : 0
+  return {
+    requests,
+    errors,
+    errorRate,
+    windowMinutes: MAX_BUCKETS * (BUCKET_DURATION_MS / 60000),
+  }
+}
+
 export function getRequestMetrics(): {
   total: number
   errors: number
@@ -109,6 +181,7 @@ export function getRequestMetrics(): {
   byGroup: Record<string, { requests: number; errors: number }>
   recentErrors: ErrorEntry[]
   rps: number
+  rolling: { requests: number; errors: number; errorRate: number; windowMinutes: number }
 } {
   const uptimeMs = Date.now() - startedAt
   const uptimeSec = uptimeMs / 1000
@@ -117,9 +190,11 @@ export function getRequestMetrics(): {
   const byGroup: Record<string, { requests: number; errors: number }> = {}
   for (const group of TRACKED_GROUPS) {
     const name = group.name
-    byGroup[name] = {
-      requests: requestCounts[name] || 0,
-      errors: errorCounts[name] || 0,
+    const reqs = requestCounts[name] || 0
+    const errs = errorCounts[name] || 0
+    // Only include groups that have traffic
+    if (reqs > 0 || errs > 0) {
+      byGroup[name] = { requests: reqs, errors: errs }
     }
   }
   if (requestCounts['other']) {
@@ -136,6 +211,7 @@ export function getRequestMetrics(): {
     byGroup,
     recentErrors: [...recentErrors].reverse(), // Most recent first
     rps,
+    rolling: getRollingMetrics(),
   }
 }
 
@@ -146,4 +222,6 @@ export function resetRequestMetrics(): void {
   for (const key of Object.keys(requestCounts)) delete requestCounts[key]
   for (const key of Object.keys(errorCounts)) delete errorCounts[key]
   recentErrors.length = 0
+  rollingBuckets.length = 0
+  currentBucket = { requests: 0, errors: 0, startedAt: Date.now() }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2202,7 +2202,7 @@ export async function createServer(): Promise<FastifyInstance> {
       inbox: inboxManager.getStats(),
       request_counts: (() => {
         const m = getRequestMetrics()
-        return { total: m.total, errors: m.errors, rps: m.rps, byGroup: m.byGroup }
+        return { total: m.total, errors: m.errors, rps: m.rps, byGroup: m.byGroup, rolling: m.rolling }
       })(),
       timestamp: Date.now(),
     }
@@ -2215,6 +2215,7 @@ export async function createServer(): Promise<FastifyInstance> {
       total_errors: m.errors,
       total_requests: m.total,
       error_rate: m.total > 0 ? Math.round((m.errors / m.total) * 10000) / 100 : 0,
+      rolling: m.rolling,
       recent: m.recentErrors.slice(0, 20),
       timestamp: Date.now(),
     }

--- a/tests/request-tracker.test.ts
+++ b/tests/request-tracker.test.ts
@@ -23,10 +23,42 @@ describe('request-tracker', () => {
     trackRequest('GET', '/tasks/next', 200)
     trackRequest('POST', '/chat/send', 200)
     const m = getRequestMetrics()
-    expect(m.byGroup.health.requests).toBe(2)
-    expect(m.byGroup.bootstrap.requests).toBe(1)
-    expect(m.byGroup.tasks.requests).toBe(1)
-    expect(m.byGroup.chat.requests).toBe(1)
+    expect(m.byGroup.health!.requests).toBe(2)
+    expect(m.byGroup.bootstrap!.requests).toBe(1)
+    expect(m.byGroup.tasks!.requests).toBe(1)
+    expect(m.byGroup.chat!.requests).toBe(1)
+  })
+
+  it('classifies new route groups correctly', () => {
+    trackRequest('GET', '/heartbeat/link', 200)
+    trackRequest('GET', '/inbox/link', 200)
+    trackRequest('GET', '/reflections', 200)
+    trackRequest('GET', '/insights', 200)
+    trackRequest('GET', '/hosts', 200)
+    trackRequest('POST', '/presence/link', 200)
+    trackRequest('GET', '/shared/list', 404)
+    trackRequest('GET', '/avatars/link.png', 404)
+    trackRequest('GET', '/dashboard', 200)
+    trackRequest('GET', '/memory/link', 200)
+    trackRequest('GET', '/preflight', 200)
+    trackRequest('GET', '/policy', 200)
+    const m = getRequestMetrics()
+    expect(m.byGroup.heartbeat!.requests).toBe(1)
+    expect(m.byGroup.inbox!.requests).toBe(1)
+    expect(m.byGroup.reflections!.requests).toBe(1)
+    expect(m.byGroup.insights!.requests).toBe(1)
+    expect(m.byGroup.hosts!.requests).toBe(1)
+    expect(m.byGroup.presence!.requests).toBe(1)
+    expect(m.byGroup.shared!.requests).toBe(1)
+    expect(m.byGroup.shared!.errors).toBe(1)
+    expect(m.byGroup.avatars!.requests).toBe(1)
+    expect(m.byGroup.avatars!.errors).toBe(1)
+    expect(m.byGroup.dashboard!.requests).toBe(1)
+    expect(m.byGroup.memory!.requests).toBe(1)
+    expect(m.byGroup.preflight!.requests).toBe(1)
+    expect(m.byGroup.policy!.requests).toBe(1)
+    // None should land in "other"
+    expect(m.byGroup.other).toBeUndefined()
   })
 
   it('tracks 4xx as errors in counts', () => {
@@ -34,8 +66,8 @@ describe('request-tracker', () => {
     trackRequest('GET', '/health', 200)
     const m = getRequestMetrics()
     expect(m.errors).toBe(1)
-    expect(m.byGroup.tasks.errors).toBe(1)
-    expect(m.byGroup.health.errors).toBe(0)
+    expect(m.byGroup.tasks!.errors).toBe(1)
+    expect(m.byGroup.health!.errors).toBe(0)
   })
 
   it('stores 5xx errors in recentErrors', () => {
@@ -89,6 +121,8 @@ describe('request-tracker', () => {
     expect(m.total).toBe(0)
     expect(m.errors).toBe(0)
     expect(m.recentErrors).toHaveLength(0)
+    expect(m.rolling.requests).toBe(0)
+    expect(m.rolling.errors).toBe(0)
   })
 
   it('truncates long URLs', () => {
@@ -96,5 +130,42 @@ describe('request-tracker', () => {
     trackRequest('GET', longUrl, 500)
     const m = getRequestMetrics()
     expect(m.recentErrors[0]!.url.length).toBeLessThanOrEqual(201) // 200 + ellipsis
+  })
+
+  describe('rolling window', () => {
+    it('includes rolling metrics in output', () => {
+      trackRequest('GET', '/health', 200)
+      trackRequest('GET', '/tasks', 400)
+      const m = getRequestMetrics()
+      expect(m.rolling).toBeDefined()
+      expect(m.rolling.requests).toBe(2)
+      expect(m.rolling.errors).toBe(1)
+      expect(m.rolling.errorRate).toBe(50)
+      expect(m.rolling.windowMinutes).toBe(60)
+    })
+
+    it('shows 0% error rate when all requests succeed', () => {
+      trackRequest('GET', '/health', 200)
+      trackRequest('GET', '/health', 200)
+      trackRequest('GET', '/health', 200)
+      const m = getRequestMetrics()
+      expect(m.rolling.errorRate).toBe(0)
+    })
+
+    it('shows 0 for empty window', () => {
+      const m = getRequestMetrics()
+      expect(m.rolling.requests).toBe(0)
+      expect(m.rolling.errors).toBe(0)
+      expect(m.rolling.errorRate).toBe(0)
+    })
+
+    it('only includes groups with traffic', () => {
+      trackRequest('GET', '/health', 200)
+      const m = getRequestMetrics()
+      // health should be present
+      expect(m.byGroup.health).toBeDefined()
+      // mcp with no traffic should not be present
+      expect(m.byGroup.mcp).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
## Problem
EVI shows 22% cumulative error rate, but all errors are historical 4xx from before config fix. No new errors are occurring — cumulative metrics mask this.

## Changes
- **Rolling 1-hour window** (5-minute buckets): `/health` and `/health/errors` now surface `rolling.errorRate` — shows the *current* error rate separate from cumulative
- **12 new route groups**: heartbeat, inbox, reflections, insights, hosts, presence, shared, avatars, dashboard, memory, preflight, policy — reduces uncategorized `other` traffic from ~12k to only truly unknown routes
- **Sparse output**: Only groups with traffic appear in `/health` (less noise)
- **Tests**: 15 pass (added rolling window + new group coverage)

## Result
After deploy, `/health` will show:
- `request_counts.rolling.errorRate` → current 1h error rate (should be ~0%)
- `request_counts.rolling.requests/errors` → raw counts
- Better per-group visibility into what was previously all lumped in `other`

The cumulative 22% will naturally dilute, but rolling rate immediately shows the system is healthy.

Closes task-1772384674122-x33ygszdg