### PR TITLE
fix: add <your-key> placeholder to gitleaks allowlist regex

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,6 +37,7 @@ regexes = [
   '''xxxxx''',
   '''YOUR_\w+''',
   '''REPLACE_WITH_''',
+  '''<your-\w+>''',
 ]
 
 # Block common env dump patterns even if not caught by default rules


### PR DESCRIPTION
Fixes gitleaks CI false positive on `src/doctor.ts` setup guidance text.

The custom `env-dump` rule matches `ANTHROPIC_API_KEY=<your-key>` because `<your-key>` is 10+ non-whitespace chars. Add `<your-\w+>` to the allowlist regexes since angle-bracket placeholders are clearly not real secrets.

Verified locally: `npx gitleaks detect` passes clean.

Closes task-1772468710481-f2vyaemma