### PR TITLE
feat: email ingest endpoint for Cloudflare Email Worker

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -365,6 +365,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | GET | `/inbox/:agent/subscriptions` | List subscriptions |
 | GET | `/inbox/:agent/unread` | Unread count |
 | GET | `/inbox/:agent/mentions` | Get @mentions |
+| POST | `/email/inbound` | Email ingest — receives forwarded emails from Cloudflare Email Worker. Body: `{ agent, from, subject, body }`. Posts to chat as system message with @mention. |
 
 ## Presence
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4065,6 +4065,44 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
+  // ─── Email ingest — receives forwarded emails from Cloudflare Email Worker ───
+  app.post('/email/inbound', async (request, reply) => {
+    const body = request.body as Record<string, unknown>
+    const agent = typeof body.agent === 'string' ? body.agent.trim() : null
+    const from = typeof body.from === 'string' ? body.from : 'unknown'
+    const subject = typeof body.subject === 'string' ? body.subject : '(no subject)'
+    const emailBody = typeof body.body === 'string' ? body.body : ''
+    const channel = 'email'
+
+    if (!agent) {
+      return reply.status(400).send({ error: 'Missing agent field' })
+    }
+
+    // Post as a chat message in the agent's general channel
+    const content = `📧 **Email from ${from}**\n**Subject:** ${subject}\n\n${emailBody.slice(0, 4000)}`
+
+    const msg = chatManager.addMessage({
+      room: 'general',
+      author: 'system',
+      content,
+      mentions: [agent],
+      metadata: {
+        channel,
+        email_from: from,
+        email_subject: subject,
+        email_to: typeof body.to === 'string' ? body.to : undefined,
+        email_message_id: typeof body.messageId === 'string' ? body.messageId : undefined,
+      },
+    })
+
+    return {
+      success: true,
+      agent,
+      messageId: msg.id,
+      channel,
+    }
+  })
+
   // List rooms
   app.get('/chat/rooms', async () => {
     const rooms = chatManager.listRooms()


### PR DESCRIPTION
## What

`POST /email/inbound` — receives forwarded emails and posts them to the agent's chat as a system message with @mention.

Pairs with the new `reflectt-email-worker` (Cloudflare Email Routing) to give every agent a real email address (`link@reflectt.ai`, `kai@reflectt.ai`, etc.) with zero SMTP infrastructure.

## How it works

```
sender → link@reflectt.ai → Cloudflare Email Routing → Email Worker → POST /email/inbound → agent inbox
```

## Endpoint

```
POST /email/inbound
Body: { agent, from, subject, body, to?, messageId? }
```

Posts a formatted email message to the general chat channel, mentioning the target agent so it shows up in their inbox.

## Cost

Free. Cloudflare Email Routing is included with any zone. No SMTP server needed.

## Tests

1596 pass. Route-docs contract pass (406 routes).