### PR TITLE
fix: surface fix text in doctor CLI output

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -247,14 +247,26 @@ export function formatDoctorHuman(report: DoctorReport): string {
     const overall = d?.overall
     const OPTIONAL = new Set(['github-identity', 'openclaw_bootstrap'])
     const checks: any[] = Array.isArray(d?.checks) ? d.checks : []
-    const fails = checks.filter((c: any) => c?.status === 'fail').map((c: any) => c?.name).filter(Boolean)
-    const warns = checks.filter((c: any) => c?.status === 'warn').map((c: any) => c?.name).filter(Boolean)
-    const requiredFails = fails.filter(n => !OPTIONAL.has(n))
-    const optionalFails = fails.filter(n => OPTIONAL.has(n))
+    const fails = checks.filter((c: any) => c?.status === 'fail')
+    const warns = checks.filter((c: any) => c?.status === 'warn')
+    const failNames = fails.map((c: any) => c?.name).filter(Boolean)
+    const warnNames = warns.map((c: any) => c?.name).filter(Boolean)
+    const requiredFails = failNames.filter(n => !OPTIONAL.has(n))
+    const optionalFails = failNames.filter(n => OPTIONAL.has(n))
     const parts = [`overall=${overall ?? 'n/a'}`]
     if (requiredFails.length) parts.push(`fails=${requiredFails.join(',')}`)
     if (optionalFails.length) parts.push(`optional=${optionalFails.join(',')}`)
-    if (warns.length) parts.push(`warns=${warns.join(',')}`)
+    if (warnNames.length) parts.push(`warns=${warnNames.join(',')}`)
+
+    // Surface fix text for failing/warning checks so users know what to do
+    const actionable = [...fails, ...warns].filter((c: any) => c?.fix)
+    if (actionable.length) {
+      parts.push('\n')
+      for (const c of actionable) {
+        const status = c.status === 'fail' ? 'FAIL' : 'WARN'
+        parts.push(`    ${c.name}: ${status} — ${c.fix}`)
+      }
+    }
     return parts.join(' ')
   })
   section('preflight', '/preflight', (d) => {


### PR DESCRIPTION
## Problem

The `/health/team/doctor` API returns a `fix` field on failing/warning checks, but the CLI output never displayed it. Users saw `FAIL` with a check name but not what to do.

## Fix

Surface the `fix` field for all failing and warning checks:

```
teamDoctor: overall=fail fails=model_auth
    model_auth: FAIL — Add at least one LLM API key to your .env file (e.g. ANTHROPIC_API_KEY=sk-...)
    openclaw_bootstrap: WARN — Delete one of MEMORY.md/memory.md...
```

Small change, big UX improvement for first-run users hitting doctor failures.

All 1598 tests pass.