### PR TITLE
fix: mobile 375px overflow — intensity-control flex-wrap

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -988,6 +988,12 @@ export function getDashboardHTML(): string {
     .msg-time { margin-left: 0; }
     .chat-input-bar { padding: 8px 10px; }
     .chat-input-bar select { min-width: 0; width: 100%; }
+    .intensity-control { padding: 8px 12px; gap: 6px; }
+    .intensity-label { font-size: 10px; }
+    .intensity-btn { padding: 4px 8px; font-size: 12px; }
+    .intensity-info { font-size: 10px; margin-left: 4px; }
+    .intensity-sep { display: none; }
+    .pause-toggle-btn { padding: 4px 8px; font-size: 12px; }
   }
 
   @media (min-width: 768px) and (max-width: 1023px) {
@@ -1627,6 +1633,7 @@ export function getDashboardHTML(): string {
   .intensity-control {
     display: flex; align-items: center; gap: 8px; padding: 8px 16px;
     background: var(--surface, #1a1a2e); border-bottom: 1px solid var(--border, #2a2a4a);
+    flex-wrap: wrap; max-width: 100vw; box-sizing: border-box;
   }
   .intensity-label { font-size: var(--text-xs, 11px); color: var(--text-muted, #888); text-transform: uppercase; letter-spacing: 0.05em; margin-right: 4px; }
   .intensity-btn {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7360,7 +7360,6 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
-<<<<<<< HEAD
   // ── File upload/download ──
   app.post('/files', async (request, reply) => {
     try {


### PR DESCRIPTION
## Problem
Dashboard breaks at 375px mobile viewport — the intensity-control bar (label + 3 buttons + info + separator + pause) overflows the viewport by 25px, causing horizontal body scroll.

Root cause: `.intensity-control` was `display: flex` with no `flex-wrap` and no `overflow` handling.

## Fix
- Add `flex-wrap: wrap; max-width: 100vw; box-sizing: border-box` to `.intensity-control`
- Add `@media (max-width: 420px)` rules: tighter padding, smaller font sizes, hide separator
- Remove stale merge conflict marker in server.ts

## Verification
Tested at 375x812 viewport: `body.scrollWidth === body.clientWidth` (no horizontal overflow).

Fixes P1 from pixel audit (2026-03-03-dashboard-polish-audit).