### PR TITLE
feat: alert-preflight persistent daily snapshots + history endpoint

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -112,6 +112,7 @@ Remote hosts (multi-host installs) phone-home via a lightweight heartbeat so the
 | GET | `/health/reflection-pipeline` | Reflection→Insight→Promotion health signal. Returns recent reflection/insight/promotion counts, status (`healthy`\|`at_risk`\|`broken`), and alert timestamps. Triggers alert when reflections flow but insights remain zero past threshold. |
 | GET | `/health/backlog` | Backlog readiness snapshot by lane/agent with ready-floor breach detection and stale-validating summary. Query: `include_test=1` to include test-harness tasks. |
 | GET | `/health/alert-preflight` | Alert-preflight guard metrics: total checked, canary-flagged, suppressed, false-positive rate, mode (canary/enforce/off). |
+| GET | `/health/alert-preflight/history` | Daily alert-preflight snapshots for observation window tracking. Returns per-day metrics + current session. |
 | GET | `/health/mention-ack` | Mention-ack lifecycle metrics (pending, timeout, latency counters) |
 | GET | `/health/mention-ack/recent` | Recent mention-ack entries for debugging. Query: `limit` (max 100) |
 | GET | `/health/mention-ack/:agent` | Pending mention-ack entries for one agent |

--- a/src/alert-preflight.ts
+++ b/src/alert-preflight.ts
@@ -330,3 +330,65 @@ export function resetPreflightMetrics(): void {
   metrics.latencies = []
   recentKeys.clear()
 }
+
+// ── Persistent daily snapshots ─────────────────────────────────────────────
+
+const DAILY_FILE = join(DATA_DIR, 'alert-preflight-daily.jsonl')
+let lastSnapshotDate = ''
+
+/**
+ * Append a daily metrics snapshot if the date has changed.
+ * Called from getPreflightMetrics() and also from the health endpoint.
+ * Idempotent per calendar day.
+ */
+export function snapshotDailyMetrics(): void {
+  const today = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+  if (today === lastSnapshotDate) return
+  if (metrics.totalChecked === 0) return // nothing to snapshot
+
+  const sorted = [...metrics.latencies].sort((a, b) => a - b)
+  const p95Index = Math.floor(sorted.length * 0.95)
+  const latencyP95 = sorted.length > 0 ? sorted[p95Index] ?? 0 : 0
+
+  const snapshot = {
+    date: today,
+    ts: Date.now(),
+    totalChecked: metrics.totalChecked,
+    suppressed: metrics.suppressed,
+    canaryFlagged: metrics.canaryFlagged,
+    latencyP95: Math.round(latencyP95 * 100) / 100,
+    mode: getPreflightMode(),
+    falsePositiveRate: metrics.totalChecked > 0
+      ? Math.round((metrics.canaryFlagged / metrics.totalChecked) * 10000) / 100
+      : 0,
+  }
+
+  try {
+    appendFileSync(DAILY_FILE, JSON.stringify(snapshot) + '\n')
+    lastSnapshotDate = today
+  } catch {
+    // Non-fatal — best-effort persistence
+  }
+}
+
+/**
+ * Read all daily snapshots for the observation window report.
+ */
+export function getDailySnapshots(): Array<{
+  date: string
+  totalChecked: number
+  suppressed: number
+  canaryFlagged: number
+  latencyP95: number
+  mode: string
+  falsePositiveRate: number
+}> {
+  try {
+    const { readFileSync } = require('fs')
+    const content = readFileSync(DAILY_FILE, 'utf8').trim()
+    if (!content) return []
+    return content.split('\n').map((line: string) => JSON.parse(line))
+  } catch {
+    return []
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import type { WebSocket } from 'ws'
 import { execSync } from 'child_process'
 import { serverConfig, openclawConfig, isDev, REFLECTT_HOME } from './config.js'
 import { trackRequest, getRequestMetrics } from './request-tracker.js'
-import { getPreflightMetrics } from './alert-preflight.js'
+import { getPreflightMetrics, snapshotDailyMetrics, getDailySnapshots } from './alert-preflight.js'
 
 // ── Build info (read once at startup) ──────────────────────────────────────
 const BUILD_VERSION = (() => {
@@ -2538,7 +2538,13 @@ export async function createServer(): Promise<FastifyInstance> {
 
   // ─── Alert preflight metrics ───
   app.get('/health/alert-preflight', async () => {
+    snapshotDailyMetrics() // Persist daily checkpoint on health check
     return { ...getPreflightMetrics(), timestamp: Date.now() }
+  })
+
+  app.get('/health/alert-preflight/history', async () => {
+    snapshotDailyMetrics()
+    return { snapshots: getDailySnapshots(), currentSession: getPreflightMetrics() }
   })
 
   // ─── Backlog health: ready counts per lane, breach status, floor compliance ───


### PR DESCRIPTION
Adds persistent daily metric snapshots for the alert-preflight canary observation window.

Without this, metrics were in-memory only and reset on every server restart — making it impossible to prove the 7-day sustained rate required by the done criteria.

- `snapshotDailyMetrics()`: appends to `data/alert-preflight-daily.jsonl` (idempotent per day)
- `GET /health/alert-preflight/history`: returns all daily snapshots + current session
- Health endpoint auto-triggers daily snapshot on check

Task: task-1771849175579-apuqqi0fd