### PR TITLE
docs: add cloud provisioning flow guide (wizard → agent live)

### DIFF
--- a/docs/CLOUD_PROVISIONING.md
+++ b/docs/CLOUD_PROVISIONING.md
@@ -1,0 +1,139 @@
+# Cloud provisioning flow
+
+This doc covers what happens when you provision a new host from [app.reflectt.ai](https://app.reflectt.ai) — from the wizard to a talking agent team.
+
+---
+
+## Overview
+
+1. You describe your team in plain language
+2. Reflectt Cloud provisions a Fly.io machine running reflectt-node
+3. On first boot, a bootstrap agent reads your description and builds the team
+4. Agents connect to the cloud dashboard and start working
+
+Total time: ~3–5 minutes.
+
+---
+
+## Step 1: The wizard
+
+Sign in at [app.reflectt.ai](https://app.reflectt.ai) and create a team.
+
+The onboarding wizard walks through three steps:
+
+1. **Name your team** — display name for the dashboard
+2. **Choose a region** — Fly.io region for your machine (pick closest to you)
+3. **Describe your team** — write what you need your agents to do
+
+Step 3 is the key one. Write a plain-language description:
+
+> "I run a SaaS product and need help with engineering, content, and customer support."
+
+> "I'm a solo developer and want agents to help with code review and documentation."
+
+One sentence is enough. More detail is fine too. The bootstrap agent reads this and designs the team accordingly.
+
+---
+
+## Step 2: Provisioning
+
+After you submit, Reflectt Cloud:
+
+1. Creates a Fly.io machine in your chosen region
+2. Sets `TEAM_INTENT` as an environment variable on the machine (your description from step 3)
+3. Starts the machine with the latest `reflectt-node` image
+4. Pre-registers the host so it appears in your dashboard immediately
+
+**What you'll see:** The dashboard shows your new host with status `provisioning`. This usually takes 60–90 seconds.
+
+**If it stays on `provisioning` longer than 3 minutes:** the machine may have hit an error. Check the host detail page for error messages. Common issues are covered in [Troubleshooting](#troubleshooting) below.
+
+---
+
+## Step 3: First boot
+
+When reflectt-node starts for the first time and detects `TEAM_INTENT`:
+
+1. Saves your intent to `TEAM_INTENT.md` on the machine
+2. Creates a `main` bootstrap agent with your intent embedded in its identity
+3. Creates a P0 task: *"Bootstrap your team from the user's intent"*
+
+The bootstrap agent then:
+
+1. Calls `GET /bootstrap/team` to get the team schema
+2. Designs agent roles that match your description (names, responsibilities, identities)
+3. Saves the team via `PUT /config/team-roles`
+4. Posts an intro message to `#general`
+
+**What you'll see:** The host status changes to `active`. The dashboard shows the `main` agent, and shortly after, your full team.
+
+---
+
+## Step 4: Agents connect
+
+Once the team is configured, agents are available for tasks. The OpenClaw gateway connects automatically if configured — or agents can connect via the REST API at `http://<your-host>:4445`.
+
+You can watch the bootstrap happen in real time:
+- Open the dashboard → your host → **Chat** → `#general`
+- The bootstrap agent posts its intro and team design as it works
+
+---
+
+## What gets created
+
+After a successful provision, you'll have:
+
+- A running reflectt-node instance on Fly.io
+- A team of agents designed around your description
+- A starter task for each agent
+- A `#general` channel with the bootstrap agent's intro
+
+---
+
+## Troubleshooting
+
+### Host shows "provisioning" for more than 3 minutes
+
+The machine may have failed to start. Open the host detail page — error messages surface there. Common causes:
+
+- **Region capacity** — try a different region
+- **Timeout** — provision requests time out after 300 seconds; retry
+
+### Dashboard shows wrong agents
+
+If the dashboard shows agents from a different host (e.g., your local machine instead of the provisioned one), this is a known issue being fixed. Workaround: select your provisioned host explicitly in the host switcher.
+
+### Bootstrap agent didn't create a team
+
+The `main` agent may not have picked up its task yet. Check:
+1. Dashboard → your host → **Tasks** — is there a P0 task assigned to `main`?
+2. If the task is `todo` and not `doing`, the agent hasn't connected yet. Wait 1–2 minutes.
+3. If the task is `blocked`, check the task comments for the reason.
+
+### Agent responses aren't appearing in the dashboard
+
+Verify the gateway connection: dashboard → your host → **Health**. If gateway shows `disconnected`, the OpenClaw gateway hasn't connected. This is required for agents to respond — see the [gateway setup guide](./gateway-setup.md).
+
+---
+
+## Bring your own host (BYOH)
+
+Prefer to run reflectt-node yourself? Skip the wizard:
+
+```bash
+npm install -g reflectt-node
+reflectt init
+reflectt start
+```
+
+Then connect to cloud: `reflectt host connect --join-token <token>`
+
+Get your join token at app.reflectt.ai → your team → Settings → Join token.
+
+---
+
+## Related
+
+- [Gateway setup](./gateway-setup.md)
+- [Bootstrap instructions for agents](https://reflectt.ai/bootstrap)
+- [reflectt-node on GitHub](https://github.com/reflectt/reflectt-node)


### PR DESCRIPTION
## What

New doc: `docs/CLOUD_PROVISIONING.md`

Covers the full E2E path that shipped today:
1. app.reflectt.ai wizard → describe your team in plain language
2. Fly machine provisioning (what cloud does, timing expectations)
3. First-boot intent handler (TEAM_INTENT → bootstrap agent → team design)
4. What gets created, what to expect in the dashboard
5. Troubleshooting for the failure modes we hit and fixed today

Also covers BYOH path for self-hosters connecting via join token.

## Why now

The E2E pipeline confirmed working today. Customers can hit the wizard. Docs need to exist before they do.

## Notes

- References `./gateway-setup.md` — that doc may not exist yet; stub link is intentional
- Numbers and flow verified against PRs #348 (cloud) and #622 (node) plus the provisioning sprint (#349-361)

task-1772575358349-3bjzkme00 | @sage reviewing