### PR TITLE
feat: add cancelled status to task state machine

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -779,7 +779,7 @@ function renderKanban() {
   const filtered = currentProject === 'all' ? visible : visible.filter(t => classifyProject(t) === currentProject);
   const cols = currentStatusFilter === 'open'
     ? ['todo', 'doing', 'blocked', 'validating']
-    : ['todo', 'doing', 'blocked', 'validating', 'done'];
+    : ['todo', 'doing', 'blocked', 'validating', 'done', 'cancelled'];
   const grouped = {}; cols.forEach(c => grouped[c] = []);
   filtered.forEach(t => { const s = t.status || 'todo'; if (grouped[s]) grouped[s].push(t); else grouped['todo'].push(t); });
   const pOrder = { P0: 0, P1: 1, P2: 2, P3: 3 };

--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -563,7 +563,7 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
   // ── Orphan PR detection ──────────────────────────────────────────────
   // Scan all tasks with PR URLs where the task is done/cancelled but the PR
   // was linked — these represent potential orphan open PRs
-  const cancelledTasks = taskManager.listTasks({ status: 'cancelled' as any })
+  const cancelledTasks = taskManager.listTasks({ status: 'cancelled' })
   const doneAndCancelled = [...doneTasks, ...cancelledTasks]
   for (const task of doneAndCancelled) {
     const meta = (task.metadata || {}) as Record<string, unknown>

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -117,7 +117,7 @@ tool(
   {
     title: z.string().describe("Task title"),
     description: z.string().optional().describe("Detailed description"),
-    status: z.enum(["todo", "doing", "blocked", "validating", "done"]).optional().describe("Task status (default: todo)"),
+    status: z.enum(["todo", "doing", "blocked", "validating", "done", "cancelled"]).optional().describe("Task status (default: todo)"),
     assignee: z.string().min(1).describe("Task owner/assignee"),
     reviewer: z.string().min(1).describe("Task reviewer"),
     done_criteria: z.array(z.string().min(1)).min(1).describe("Explicit done criteria"),
@@ -160,7 +160,7 @@ tool(
   "list_tasks",
   "List tasks, optionally filtered by status, assignee, priority, or tags.",
   {
-    status: z.enum(["todo", "doing", "blocked", "validating", "done"]).optional().describe("Filter by status"),
+    status: z.enum(["todo", "doing", "blocked", "validating", "done", "cancelled"]).optional().describe("Filter by status"),
     assignee: z.string().optional().describe("Filter by assignee"),
     createdBy: z.string().optional().describe("Filter by creator"),
     priority: z.enum(["P0", "P1", "P2", "P3"]).optional().describe("Filter by priority"),
@@ -209,7 +209,7 @@ tool(
     id: z.string().describe("Task ID"),
     title: z.string().optional().describe("New title"),
     description: z.string().optional().describe("New description"),
-    status: z.enum(["todo", "doing", "blocked", "validating", "done"]).optional().describe("New status"),
+    status: z.enum(["todo", "doing", "blocked", "validating", "done", "cancelled"]).optional().describe("New status"),
     assignee: z.string().optional().describe("New assignee"),
     priority: z.enum(["P0", "P1", "P2", "P3"]).optional().describe("New priority"),
     blocked_by: z.array(z.string()).optional().describe("Task IDs blocking this task"),
@@ -450,7 +450,7 @@ function initToolHandlers() {
         properties: {
           title: { type: "string", description: "Task title" },
           description: { type: "string", description: "Task description" },
-          status: { type: "string", enum: ["todo", "doing", "blocked", "validating", "done"] },
+          status: { type: "string", enum: ["todo", "doing", "blocked", "validating", "done", "cancelled"] },
           assignee: { type: "string", description: "Assignee" },
           createdBy: { type: "string", description: "Creator" },
           priority: { type: "string", enum: ["P0", "P1", "P2", "P3"] },
@@ -474,7 +474,7 @@ function initToolHandlers() {
       inputSchema: {
         type: "object",
         properties: {
-          status: { type: "string", enum: ["todo", "doing", "blocked", "validating", "done"] },
+          status: { type: "string", enum: ["todo", "doing", "blocked", "validating", "done", "cancelled"] },
           assignee: { type: "string" },
           createdBy: { type: "string" },
           priority: { type: "string", enum: ["P0", "P1", "P2", "P3"] },
@@ -517,7 +517,7 @@ function initToolHandlers() {
           id: { type: "string", description: "Task ID" },
           title: { type: "string" },
           description: { type: "string" },
-          status: { type: "string", enum: ["todo", "doing", "blocked", "validating", "done"] },
+          status: { type: "string", enum: ["todo", "doing", "blocked", "validating", "done", "cancelled"] },
           assignee: { type: "string" },
           priority: { type: "string", enum: ["P0", "P1", "P2", "P3"] },
           blocked_by: { type: "array", items: { type: "string" } },

--- a/src/server.ts
+++ b/src/server.ts
@@ -186,7 +186,7 @@ const CreateTaskSchema = z.object({
   title: z.string().min(1),
   type: z.enum(TASK_TYPES).optional(), // optional for backward compat, validated when present
   description: z.string().optional(),
-  status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done']).default('todo'),
+  status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done', 'cancelled']).default('todo'),
   assignee: z.string().trim().min(1).optional().default('unassigned'),
   reviewer: z.string().trim().min(1).or(z.literal('auto')).default('auto'), // 'auto' triggers load-balanced assignment
   done_criteria: z.array(z.string().trim().min(1)).optional().default([]),
@@ -334,7 +334,7 @@ function normalizeConfiguredModel(value: unknown): { ok: boolean; value?: string
 const UpdateTaskSchema = z.object({
   title: z.string().min(1).optional(),
   description: z.string().optional(),
-  status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done']).optional(),
+  status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done', 'cancelled']).optional(),
   assignee: z.string().optional(),
   reviewer: z.string().optional(),
   done_criteria: z.array(z.string().min(1)).optional(),
@@ -401,7 +401,7 @@ const CreateRecurringTaskSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
   schedule: RecurringTaskScheduleSchema,
   enabled: z.boolean().optional(),
-  status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done']).optional(),
+  status: z.enum(['todo', 'doing', 'blocked', 'validating', 'done', 'cancelled']).optional(),
 })
 
 const UpdateRecurringTaskSchema = z.object({

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1174,7 +1174,7 @@ class TaskManager {
       
       return task.blocked_by.some(blockerId => {
         const blocker = queryTask(blockerId)
-        return blocker && blocker.status !== 'done'
+        return blocker && blocker.status !== 'done' && blocker.status !== 'cancelled'
       })
     }
 
@@ -1516,7 +1516,7 @@ class TaskManager {
       if (task.blocked_by && task.blocked_by.includes(completedTaskId)) {
         const stillBlocked = task.blocked_by.some(blockerId => {
           const blocker = queryTask(blockerId)
-          return blocker && blocker.status !== 'done'
+          return blocker && blocker.status !== 'done' && blocker.status !== 'cancelled'
         })
         if (!stillBlocked) {
           unblockedTasks.push(task)
@@ -1565,7 +1565,7 @@ class TaskManager {
       
       return task.blocked_by.some(blockerId => {
         const blocker = queryTask(blockerId)
-        return blocker && blocker.status !== 'done'
+        return blocker && blocker.status !== 'done' && blocker.status !== 'cancelled'
       })
     }
 
@@ -1621,7 +1621,7 @@ class TaskManager {
   getLifecycleInstrumentation() {
     const db = getDb()
     const activeRows = db.prepare(
-      `SELECT * FROM tasks WHERE status NOT IN ('todo', 'done')`
+      `SELECT * FROM tasks WHERE status NOT IN ('todo', 'done', 'cancelled')`
     ).all() as TaskRow[]
     const active = activeRows.map(rowToTask)
     const missingReviewer = active.filter(t => !t.reviewer || t.reviewer.trim().length === 0)
@@ -1665,7 +1665,7 @@ class TaskManager {
       `SELECT status, COUNT(*) as count FROM tasks ${whereClause} GROUP BY status`
     ).all() as Array<{ status: string; count: number }>
     const byStatus: Record<string, number> = {
-      todo: 0, doing: 0, blocked: 0, validating: 0, done: 0, 'in-progress': 0,
+      todo: 0, doing: 0, blocked: 0, validating: 0, done: 0, cancelled: 0, 'in-progress': 0,
     }
     for (const row of byStatusRows) {
       byStatus[row.status] = row.count

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface Task {
   id: string
   title: string
   description?: string
-  status: 'todo' | 'doing' | 'blocked' | 'validating' | 'done'
+  status: 'todo' | 'doing' | 'blocked' | 'validating' | 'done' | 'cancelled'
   assignee?: string
   reviewer?: string
   done_criteria?: string[]


### PR DESCRIPTION
Adds 'cancelled' as a valid task status. Cancelled tasks resolve blockers (like done), are excluded from active task queries, and show in the dashboard kanban.

Closes task-1772576212839-ocik8aje1