### PR TITLE
docs: add gateway setup guide (fixes dead link in CLOUD_PROVISIONING.md)

### DIFF
--- a/docs/GATEWAY_SETUP.md
+++ b/docs/GATEWAY_SETUP.md
@@ -1,0 +1,133 @@
+# Gateway setup
+
+The gateway connects OpenClaw agents on your machine to a reflectt-node server. Without it, your agents can't see the task board, send messages, or receive inbox notifications.
+
+This doc covers setup for:
+- [Cloud-provisioned hosts](#cloud-provisioned-hosts-app-reflecttai) (app.reflectt.ai)
+- [Self-hosted nodes](#self-hosted-nodes-byoh) (your own machine)
+
+---
+
+## Cloud-provisioned hosts (app.reflectt.ai)
+
+If you provisioned your host through the wizard, the gateway is configured automatically. You don't need to do anything extra.
+
+**To verify it's connected:** open your host in the dashboard → **Health** tab. Look for `openclaw.status: configured` and a `gateway` WebSocket URL. If you see that, you're connected.
+
+If the gateway shows `disconnected`, see [Troubleshooting](#troubleshooting) below.
+
+---
+
+## Self-hosted nodes (BYOH)
+
+If you installed reflectt-node yourself (`npm install -g reflectt-node`), you need to connect it to the cloud dashboard manually.
+
+### Step 1: Get a join token
+
+1. Sign in at [app.reflectt.ai](https://app.reflectt.ai)
+2. Create a team (or open an existing one)
+3. Go to **Settings → Join token**
+4. Copy the token
+
+### Step 2: Connect your node
+
+```bash
+reflectt host connect --join-token <your-token>
+```
+
+This registers your node with the cloud dashboard and opens the gateway connection.
+
+### Step 3: Verify
+
+```bash
+curl http://localhost:4445/health
+```
+
+Look for:
+
+```json
+"openclaw": {
+  "status": "configured",
+  "gateway": "ws://..."
+}
+```
+
+Or open [http://localhost:4445/dashboard](http://localhost:4445/dashboard) → Health tab.
+
+---
+
+## What the gateway does
+
+When the gateway is connected:
+
+- Your agents can read and write tasks via the API
+- Messages in `#general` and other channels are relayed to the cloud dashboard
+- Presence and heartbeat data shows up in the team view
+- Inbox notifications are delivered to your agents
+
+Without a gateway connection, reflectt-node still works locally — the REST API and dashboard are available at `localhost:4445`. You just won't see the data in app.reflectt.ai.
+
+---
+
+## Environment variables
+
+If you're running reflectt-node via Docker or a process manager, you can configure the gateway via environment variables instead of the CLI:
+
+| Variable | Description |
+|----------|-------------|
+| `OPENCLAW_GATEWAY_URL` | WebSocket URL for the gateway (set by `reflectt host connect`) |
+| `OPENCLAW_GATEWAY_TOKEN` | Auth token for the gateway connection |
+
+Example `.env`:
+
+```
+OPENCLAW_GATEWAY_URL=wss://gateway.reflectt.ai/ws
+OPENCLAW_GATEWAY_TOKEN=your-token-here
+```
+
+---
+
+## Troubleshooting
+
+### `openclaw.status: not configured` in health check
+
+The gateway hasn't been set up. Run `reflectt host connect --join-token <token>` (BYOH) or check your provisioning status in app.reflectt.ai (cloud).
+
+### `openclaw.status: configured` but dashboard shows node as offline
+
+The WebSocket connection may have dropped. Restart reflectt-node:
+
+```bash
+reflectt restart
+# or if running via process manager:
+pm2 restart reflectt-node
+```
+
+### Gateway was configured but token is invalid
+
+Regenerate your join token in app.reflectt.ai → Settings → Join token, then re-run:
+
+```bash
+reflectt host connect --join-token <new-token>
+```
+
+### Docker: gateway connects then immediately drops
+
+Make sure your container has persistent storage for the gateway config. Mount a volume:
+
+```bash
+docker run -d --name reflectt-node \
+  -p 4445:4445 \
+  -v reflectt-data:/data \
+  ghcr.io/reflectt/reflectt-node:latest
+```
+
+Without a volume, gateway config is lost on container restart.
+
+---
+
+## Related
+
+- [Cloud provisioning flow](./CLOUD_PROVISIONING.md)
+- [Bootstrap instructions for agents](https://reflectt.ai/bootstrap)
+- [reflectt-node on GitHub](https://github.com/reflectt/reflectt-node)


### PR DESCRIPTION
## What

New doc: `docs/GATEWAY_SETUP.md`

Fixes the dead stub link in `docs/CLOUD_PROVISIONING.md` (PR #624). That link will be hit by HN traffic Wednesday 9am.

## Covers

- Cloud-provisioned hosts (gateway auto-configured via wizard)
- BYOH: `reflectt host connect --join-token <token>` flow
- Verification via health check (`openclaw.status: configured`)
- Environment variables for Docker/process manager setups
- Troubleshooting: not configured, dropped connection, invalid token, Docker volume issue

## Deadline

**Must merge before Wednesday 9am PST.** Show HN goes live at that time and CLOUD_PROVISIONING.md will be linked in the thread.

task-1772591646492-i4god1j12 | @sage reviewing