### PR TITLE
feat: session compliance detector — state-read-before-assertion

### DIFF
--- a/src/compliance-detector.ts
+++ b/src/compliance-detector.ts
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Session Compliance Detector
+ *
+ * Implements the state-read-before-assertion rule:
+ * Every triggering action (task create, status transition, review, reflection)
+ * must be preceded by at least one qualifying state read within the session window.
+ *
+ * Based on: docs/compliance-spec-state-reads.md
+ * Task: task-1772609696194-1i9s775yl
+ *
+ * Phase 1: API-layer triggers only.
+ * Phase 2 (future): chat assertion detection.
+ *
+ * Flag, do not block. Observability-first.
+ */
+
+import { getDb } from './db.js'
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** Normal session window (ms) */
+const WINDOW_NORMAL_MS = 10 * 60 * 1000
+
+/** Long-running task session window (ms) */
+const WINDOW_LONG_MS = 30 * 60 * 1000
+
+/** Heartbeat-triggered session window (ms) */
+const WINDOW_HEARTBEAT_MS = 5 * 60 * 1000
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type ViolationSeverity = 'high' | 'medium' | 'low'
+export type ViolationType =
+  | 'no_state_read_before_action'   // zero reads in session
+  | 'stale_state_read'              // reads exist but window expired
+
+export interface ComplianceViolation {
+  id: string
+  agent: string
+  session_id: string
+  violation_type: ViolationType
+  severity: ViolationSeverity
+  triggering_call: string
+  last_state_read_at: number | null
+  window_elapsed_ms: number | null
+  window_used_ms: number
+  detected_at: number
+}
+
+// ── In-memory session state ────────────────────────────────────────────────
+
+interface SessionState {
+  lastStateReadAt: number | null
+  /** true if the most recent state read was a heartbeat call */
+  lastReadWasHeartbeat: boolean
+  /** true if the session has any active doing task (use long window) */
+  hasActiveTask: boolean
+}
+
+// Sessions keyed by: `${agent}:${bucketId}` where bucketId is 30-min bucket
+const sessions = new Map<string, SessionState>()
+
+function getBucketId(now: number): string {
+  // 30-minute buckets
+  return String(Math.floor(now / WINDOW_LONG_MS))
+}
+
+function getSessionKey(agent: string, now: number): string {
+  return `${agent.toLowerCase()}:${getBucketId(now)}`
+}
+
+function getOrCreateSession(agent: string, now: number): SessionState {
+  const key = getSessionKey(agent, now)
+  if (!sessions.has(key)) {
+    // Carry forward the most recent state read from the previous bucket,
+    // so reads near a bucket boundary don't lose their validity window.
+    const prevKey = `${agent.toLowerCase()}:${String(Number(getBucketId(now)) - 1)}`
+    const prev = sessions.get(prevKey)
+    sessions.set(key, {
+      lastStateReadAt: prev?.lastStateReadAt ?? null,
+      lastReadWasHeartbeat: prev?.lastReadWasHeartbeat ?? false,
+      hasActiveTask: prev?.hasActiveTask ?? false,
+    })
+  }
+  // Clean stale sessions (older than 2 buckets)
+  cleanStaleSessions(now)
+  return sessions.get(key)!
+}
+
+function cleanStaleSessions(now: number): void {
+  const currentBucket = getBucketId(now)
+  const prevBucket = String(Number(currentBucket) - 1)
+  for (const key of sessions.keys()) {
+    const bucket = key.split(':')[1]
+    if (bucket !== currentBucket && bucket !== prevBucket) {
+      sessions.delete(key)
+    }
+  }
+}
+
+// ── State read registry ────────────────────────────────────────────────────
+
+/** URL patterns that count as qualifying state reads */
+const STATE_READ_PATTERNS: Array<{
+  pattern: RegExp
+  isHeartbeat: boolean
+}> = [
+  { pattern: /^GET \/heartbeat\/[^/]+$/, isHeartbeat: true },
+  { pattern: /^GET \/tasks\/active($|\?)/, isHeartbeat: false },
+  { pattern: /^GET \/tasks\/next($|\?)/, isHeartbeat: false },
+  { pattern: /^GET \/tasks($|\?)/, isHeartbeat: false },
+  { pattern: /^GET \/tasks\/[^/]+($|\?)/, isHeartbeat: false },
+  { pattern: /^GET \/chat\/messages($|\?)/, isHeartbeat: false },
+  { pattern: /^GET \/inbox\/[^/]+($|\?)/, isHeartbeat: false },
+  { pattern: /^GET \/me\/[^/]+($|\?)/, isHeartbeat: false },
+]
+
+/** URL + method patterns that count as triggering actions */
+const TRIGGERING_PATTERNS: Array<{
+  pattern: RegExp
+  label: string
+}> = [
+  { pattern: /^POST \/tasks($|\?)/, label: 'POST /tasks' },
+  { pattern: /^PATCH \/tasks\/[^/]+($|\?)/, label: 'PATCH /tasks/:id' },
+  { pattern: /^POST \/tasks\/[^/]+\/review($|\?)/, label: 'POST /tasks/:id/review' },
+  { pattern: /^POST \/reflections($|\?)/, label: 'POST /reflections' },
+  // Note: POST /tasks/:id/comments is NOT a Phase 1 trigger.
+  // Phase 2 will add chat assertion detection for comments with status claims.
+]
+
+function isStateRead(method: string, path: string): { isRead: boolean; isHeartbeat: boolean } {
+  const key = `${method.toUpperCase()} ${path.split('?')[0]}`
+  for (const { pattern, isHeartbeat } of STATE_READ_PATTERNS) {
+    if (pattern.test(key)) return { isRead: true, isHeartbeat }
+  }
+  return { isRead: false, isHeartbeat: false }
+}
+
+function isTriggeringAction(method: string, path: string): string | null {
+  const key = `${method.toUpperCase()} ${path.split('?')[0]}`
+  for (const { pattern, label } of TRIGGERING_PATTERNS) {
+    if (pattern.test(key)) return label
+  }
+  return null
+}
+
+// ── Agent extraction ───────────────────────────────────────────────────────
+
+/**
+ * Extract agent name from request context.
+ * Tries: URL params, query params, body, from header.
+ */
+export function extractAgent(
+  method: string,
+  url: string,
+  query: Record<string, unknown>,
+  body: unknown,
+  headers: Record<string, string | string[] | undefined>,
+): string | null {
+  // URL param patterns: /heartbeat/:agent, /inbox/:agent, /me/:agent
+  const urlMatch = url.match(/\/(?:heartbeat|inbox|me)\/([a-z][a-z0-9_-]*)(?:\/|\?|$)/i)
+  if (urlMatch) return urlMatch[1].toLowerCase()
+
+  // Query param: agent=
+  if (query.agent && typeof query.agent === 'string') return query.agent.toLowerCase()
+
+  // Body: from, agent, assignee
+  if (body && typeof body === 'object') {
+    const b = body as Record<string, unknown>
+    const candidate = b.from ?? b.agent ?? b.assignee
+    if (typeof candidate === 'string' && candidate.length > 0) return candidate.toLowerCase()
+  }
+
+  // Header: x-agent-id
+  const agentHeader = headers['x-agent-id']
+  if (typeof agentHeader === 'string') return agentHeader.toLowerCase()
+
+  return null
+}
+
+// ── DB setup ───────────────────────────────────────────────────────────────
+
+let dbReady = false
+
+function ensureTable(): void {
+  if (dbReady) return
+  try {
+    const db = getDb()
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS compliance_violations (
+        id TEXT PRIMARY KEY,
+        agent TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        violation_type TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        triggering_call TEXT NOT NULL,
+        last_state_read_at INTEGER,
+        window_elapsed_ms INTEGER,
+        window_used_ms INTEGER NOT NULL,
+        detected_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_compliance_violations_agent ON compliance_violations(agent);
+      CREATE INDEX IF NOT EXISTS idx_compliance_violations_detected_at ON compliance_violations(detected_at);
+    `)
+    dbReady = true
+  } catch {
+    // DB not available (e.g. test env) — run in degraded mode
+  }
+}
+
+function persistViolation(v: ComplianceViolation): void {
+  try {
+    const db = getDb()
+    db.prepare(`
+      INSERT OR REPLACE INTO compliance_violations
+        (id, agent, session_id, violation_type, severity, triggering_call,
+         last_state_read_at, window_elapsed_ms, window_used_ms, detected_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      v.id,
+      v.agent,
+      v.session_id,
+      v.violation_type,
+      v.severity,
+      v.triggering_call,
+      v.last_state_read_at,
+      v.window_elapsed_ms,
+      v.window_used_ms,
+      v.detected_at,
+    )
+  } catch {
+    // Silent — never block a request due to compliance logging failure
+  }
+}
+
+// ── Core detector ──────────────────────────────────────────────────────────
+
+/**
+ * Called for every request that completes successfully (statusCode < 400).
+ * Records state reads and checks triggering actions for compliance.
+ */
+export function processRequest(
+  method: string,
+  url: string,
+  statusCode: number,
+  query: Record<string, unknown>,
+  body: unknown,
+  headers: Record<string, string | string[] | undefined>,
+  now = Date.now(),
+): ComplianceViolation | null {
+  // Only track successful requests
+  if (statusCode >= 400) return null
+
+  const agent = extractAgent(method, url, query, body, headers)
+  if (!agent) return null
+
+  // Skip system/watchdog agents
+  if (['system', 'watchdog', 'openai'].includes(agent)) return null
+
+  ensureTable()
+
+  const path = url.split('?')[0]
+  const session = getOrCreateSession(agent, now)
+  const sessionId = getSessionKey(agent, now)
+
+  // Record state read
+  const { isRead, isHeartbeat } = isStateRead(method, path)
+  if (isRead) {
+    session.lastStateReadAt = now
+    session.lastReadWasHeartbeat = isHeartbeat
+    return null
+  }
+
+  // Check triggering action
+  const triggerLabel = isTriggeringAction(method, path)
+  if (!triggerLabel) return null
+
+  // Determine window
+  const windowMs = session.lastReadWasHeartbeat
+    ? WINDOW_HEARTBEAT_MS
+    : session.hasActiveTask
+      ? WINDOW_LONG_MS
+      : WINDOW_NORMAL_MS
+
+  const lastReadAt = session.lastStateReadAt
+  const windowElapsedMs = lastReadAt !== null ? now - lastReadAt : null
+
+  // Evaluate violation
+  let violationType: ViolationType | null = null
+  let severity: ViolationSeverity = 'medium'
+
+  if (lastReadAt === null) {
+    // No state read at all this session
+    violationType = 'no_state_read_before_action'
+    severity = 'high'
+  } else if (windowElapsedMs !== null && windowElapsedMs > windowMs) {
+    // State read exists but window expired
+    violationType = 'stale_state_read'
+    severity = 'medium'
+  }
+
+  if (!violationType) return null
+
+  const violation: ComplianceViolation = {
+    id: `cv-${now}-${Math.random().toString(36).slice(2, 9)}`,
+    agent,
+    session_id: sessionId,
+    violation_type: violationType,
+    severity,
+    triggering_call: triggerLabel,
+    last_state_read_at: lastReadAt,
+    window_elapsed_ms: windowElapsedMs,
+    window_used_ms: windowMs,
+    detected_at: now,
+  }
+
+  persistViolation(violation)
+  return violation
+}
+
+/**
+ * Mark a session as having an active doing task (extends window to 30 min).
+ */
+export function setSessionHasActiveTask(agent: string, hasTask: boolean, now = Date.now()): void {
+  const session = getOrCreateSession(agent, now)
+  session.hasActiveTask = hasTask
+}
+
+// ── Query API ──────────────────────────────────────────────────────────────
+
+export interface ViolationQueryOptions {
+  agent?: string
+  severity?: ViolationSeverity
+  limit?: number
+  since?: number
+}
+
+export function queryViolations(opts: ViolationQueryOptions = {}): ComplianceViolation[] {
+  try {
+    const db = getDb()
+    ensureTable()
+
+    const { agent, severity, limit = 100, since } = opts
+
+    const conditions: string[] = []
+    const params: unknown[] = []
+
+    if (agent) {
+      conditions.push('agent = ?')
+      params.push(agent.toLowerCase())
+    }
+    if (severity) {
+      conditions.push('severity = ?')
+      params.push(severity)
+    }
+    if (since) {
+      conditions.push('detected_at >= ?')
+      params.push(since)
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+    const rows = db.prepare(
+      `SELECT * FROM compliance_violations ${where} ORDER BY detected_at DESC LIMIT ?`,
+    ).all(...params, limit) as ComplianceViolation[]
+
+    return rows
+  } catch {
+    return []
+  }
+}
+
+export function getViolationSummary(since?: number): {
+  total: number
+  byAgent: Record<string, number>
+  bySeverity: Record<string, number>
+  sinceMs: number
+} {
+  const cutoff = since ?? (Date.now() - 24 * 60 * 60 * 1000) // default 24h
+  const violations = queryViolations({ since: cutoff, limit: 10_000 })
+
+  const byAgent: Record<string, number> = {}
+  const bySeverity: Record<string, number> = {}
+
+  for (const v of violations) {
+    byAgent[v.agent] = (byAgent[v.agent] ?? 0) + 1
+    bySeverity[v.severity] = (bySeverity[v.severity] ?? 0) + 1
+  }
+
+  return {
+    total: violations.length,
+    byAgent,
+    bySeverity,
+    sinceMs: cutoff,
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,6 +68,7 @@ import { alertUnauthorizedApproval, alertFlipAttempt, getMutationAlertStatus, pr
 import { mentionAckTracker } from './mention-ack.js'
 import type { PresenceStatus, FocusLevel } from './presence.js'
 import { analyticsManager } from './analytics.js'
+import { processRequest as complianceProcessRequest, queryViolations, getViolationSummary } from './compliance-detector.js'
 import { getDashboardHTML } from './dashboard.js'
 import { healthMonitor, computeActiveLane } from './health.js'
 import { getSystemLoopTicks, recordSystemLoopTick } from './system-loop-state.js'
@@ -1820,6 +1821,18 @@ export async function createServer(): Promise<FastifyInstance> {
     healthMonitor.trackRequest(duration)
     trackTelemetryRequest(request.method, request.url, reply.statusCode, duration)
     trackRequest(request.method, request.url, reply.statusCode, request.headers['user-agent'])
+
+    // Compliance detector: flag state-read-before-assertion violations
+    try {
+      complianceProcessRequest(
+        request.method,
+        request.url,
+        reply.statusCode,
+        (request.query as Record<string, unknown>) ?? {},
+        request.body,
+        request.headers as Record<string, string | string[] | undefined>,
+      )
+    } catch { /* never let compliance logging break a request */ }
     
     if (reply.statusCode >= 400) {
       healthMonitor.trackError()
@@ -11804,6 +11817,25 @@ export async function createServer(): Promise<FastifyInstance> {
   // Prune old mutation alert tracking every 30 minutes
   const pruneTimer = setInterval(pruneOldAttempts, 30 * 60 * 1000)
   pruneTimer.unref()
+
+  // GET /compliance/violations — state-read-before-assertion compliance violations
+  app.get('/compliance/violations', async (request, reply) => {
+    const query = request.query as Record<string, string>
+    const agent = query.agent || undefined
+    const severity = (query.severity as any) || undefined
+    const limit = Math.min(parseInt(query.limit || '100', 10) || 100, 1000)
+    const since = query.since ? parseInt(query.since, 10) : undefined
+
+    const violations = queryViolations({ agent, severity, limit, since })
+    const summary = getViolationSummary(since)
+
+    reply.send({
+      violations,
+      count: violations.length,
+      summary,
+      query: { agent: agent ?? null, severity: severity ?? null, limit, since: since ?? null },
+    })
+  })
 
   // GET /audit/reviews — review-field mutation audit ledger
   app.get('/audit/reviews', async (request, reply) => {

--- a/tests/compliance-detector.test.ts
+++ b/tests/compliance-detector.test.ts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Tests for session compliance detector
+// Task: task-1772609696194-1i9s775yl
+// Spec: docs/compliance-spec-state-reads.md
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { processRequest, extractAgent } from '../src/compliance-detector.js'
+
+// Reset module-level session state between tests by advancing time
+// (sessions are bucketed by 30-min windows; using different base times isolates tests)
+
+const BASE = 1_700_000_000_000 // arbitrary fixed timestamp
+const AGENT_HEADERS = {}
+const NO_BODY = null
+
+// Helper: simulate a GET request (state read)
+function read(path: string, agent: string, now: number) {
+  return processRequest('GET', path, 200, { agent }, NO_BODY, AGENT_HEADERS, now)
+}
+
+// Helper: simulate a POST/PATCH (triggering action)
+function act(method: string, path: string, agent: string, now: number, body: unknown = null) {
+  return processRequest(method, path, 200, {}, body, AGENT_HEADERS, now)
+}
+
+// Isolate session buckets by using different base times per describe block
+function iso(offset: number) {
+  // Each test gets a unique 30-min bucket by using large offsets
+  return BASE + offset * 60 * 60 * 1000
+}
+
+describe('extractAgent', () => {
+  it('extracts from URL param for heartbeat', () => {
+    expect(extractAgent('GET', '/heartbeat/kai', {}, null, {})).toBe('kai')
+  })
+
+  it('extracts from URL param for inbox', () => {
+    expect(extractAgent('GET', '/inbox/link', {}, null, {})).toBe('link')
+  })
+
+  it('extracts from query param', () => {
+    expect(extractAgent('GET', '/tasks/next', { agent: 'rhythm' }, null, {})).toBe('rhythm')
+  })
+
+  it('extracts from body.from', () => {
+    expect(extractAgent('POST', '/tasks', {}, { from: 'pixel' }, {})).toBe('pixel')
+  })
+
+  it('extracts from body.assignee', () => {
+    expect(extractAgent('PATCH', '/tasks/task-001', {}, { assignee: 'echo' }, {})).toBe('echo')
+  })
+
+  it('returns null when no agent found', () => {
+    expect(extractAgent('GET', '/tasks', {}, null, {})).toBeNull()
+  })
+
+  it('lowercases agent name', () => {
+    expect(extractAgent('GET', '/heartbeat/KAI', {}, null, {})).toBe('kai')
+  })
+})
+
+describe('state reads suppress violations', () => {
+  it('no violation when heartbeat precedes POST /tasks', () => {
+    const t = iso(100)
+    read('/heartbeat/kai', 'kai', t)
+    const violation = act('POST', '/tasks', 'kai', t + 60_000, { from: 'kai' })
+    expect(violation).toBeNull()
+  })
+
+  it('no violation when GET /tasks/next precedes PATCH', () => {
+    const t = iso(101)
+    read('/tasks/next?agent=link', 'link', t)
+    const violation = act('PATCH', '/tasks/task-001', 'link', t + 60_000, { assignee: 'link' })
+    expect(violation).toBeNull()
+  })
+
+  it('no violation when GET /tasks precedes POST /reflections', () => {
+    const t = iso(102)
+    read('/tasks?assignee=pixel', 'pixel', t)
+    const violation = act('POST', '/reflections', 'pixel', t + 30_000, { agent: 'pixel' })
+    expect(violation).toBeNull()
+  })
+})
+
+describe('no_state_read_before_action violations', () => {
+  it('flags POST /tasks with no prior state read as high severity', () => {
+    const t = iso(200)
+    const violation = act('POST', '/tasks', 'sage', t, { from: 'sage' })
+    expect(violation).not.toBeNull()
+    expect(violation!.violation_type).toBe('no_state_read_before_action')
+    expect(violation!.severity).toBe('high')
+    expect(violation!.agent).toBe('sage')
+    expect(violation!.triggering_call).toBe('POST /tasks')
+  })
+
+  it('flags PATCH /tasks/:id with no prior state read', () => {
+    const t = iso(201)
+    const violation = act('PATCH', '/tasks/task-abc', 'harmony', t, { assignee: 'harmony' })
+    expect(violation).not.toBeNull()
+    expect(violation!.violation_type).toBe('no_state_read_before_action')
+    expect(violation!.severity).toBe('high')
+  })
+
+  it('flags POST /tasks/:id/review with no prior state read', () => {
+    const t = iso(202)
+    const violation = act('POST', '/tasks/task-abc/review', 'scout', t, { agent: 'scout' })
+    expect(violation).not.toBeNull()
+    expect(violation!.violation_type).toBe('no_state_read_before_action')
+  })
+
+  it('flags POST /reflections with no prior state read', () => {
+    const t = iso(203)
+    const violation = act('POST', '/reflections', 'echo', t, { agent: 'echo' })
+    expect(violation).not.toBeNull()
+    expect(violation!.violation_type).toBe('no_state_read_before_action')
+  })
+})
+
+describe('stale_state_read violations', () => {
+  const NORMAL_WINDOW = 10 * 60 * 1000
+  const LONG_WINDOW = 30 * 60 * 1000
+
+  it('flags POST /tasks when normal window (10 min) has expired', () => {
+    const t = iso(300)
+    // State read, then act 11 minutes later
+    read('/tasks', 'kai', t)
+    const violation = act('POST', '/tasks', 'kai', t + NORMAL_WINDOW + 60_000, { from: 'kai' })
+    expect(violation).not.toBeNull()
+    expect(violation!.violation_type).toBe('stale_state_read')
+    expect(violation!.severity).toBe('medium')
+    expect(violation!.last_state_read_at).toBe(t)
+  })
+
+  it('no violation when acting within normal window (9 min)', () => {
+    const t = iso(301)
+    read('/tasks', 'link', t)
+    const violation = act('POST', '/tasks', 'link', t + 9 * 60_000, { from: 'link' })
+    expect(violation).toBeNull()
+  })
+
+  it('no violation when acting within long window after heartbeat (4 min)', () => {
+    const t = iso(302)
+    read('/heartbeat/pixel', 'pixel', t)
+    // Heartbeat window is 5 min
+    const violation = act('POST', '/tasks', 'pixel', t + 4 * 60_000, { from: 'pixel' })
+    expect(violation).toBeNull()
+  })
+
+  it('flags POST /tasks after heartbeat window expires (6 min)', () => {
+    const t = iso(303)
+    read('/heartbeat/harmony', 'harmony', t)
+    // Heartbeat window is 5 min
+    const violation = act('POST', '/tasks', 'harmony', t + 6 * 60_000, { from: 'harmony' })
+    expect(violation).not.toBeNull()
+    expect(violation!.violation_type).toBe('stale_state_read')
+  })
+})
+
+describe('non-triggering actions are ignored', () => {
+  it('GET /tasks does not produce a violation', () => {
+    const t = iso(400)
+    const violation = processRequest('GET', '/tasks', 200, { agent: 'kai' }, null, {}, t)
+    expect(violation).toBeNull()
+  })
+
+  it('POST /tasks/:id/comments does not trigger (Phase 2)', () => {
+    const t = iso(401)
+    const violation = act('POST', '/tasks/task-001/comments', 'kai', t, { agent: 'kai' })
+    expect(violation).toBeNull()
+  })
+
+  it('failed requests (4xx) are ignored', () => {
+    const t = iso(402)
+    const violation = processRequest('POST', '/tasks', 400, { agent: 'kai' }, { from: 'kai' }, {}, t)
+    expect(violation).toBeNull()
+  })
+
+  it('system agent is ignored', () => {
+    const t = iso(403)
+    const violation = act('POST', '/tasks', 'system', t, { from: 'system' })
+    expect(violation).toBeNull()
+  })
+})
+
+describe('state read resets the window', () => {
+  it('second state read extends window and clears violation risk', () => {
+    const t = iso(500)
+    const NORMAL = 10 * 60 * 1000
+
+    // Initial read
+    read('/tasks', 'scout', t)
+    // Wait 9 min (still valid) — no violation
+    expect(act('POST', '/tasks', 'scout', t + 9 * 60_000, { from: 'scout' })).toBeNull()
+
+    // Second read at 9 min mark
+    read('/tasks/next', 'scout', t + 9 * 60_000)
+
+    // Now wait 9 more min from second read — should still be valid
+    expect(act('PATCH', '/tasks/task-x', 'scout', t + 18 * 60_000, { assignee: 'scout' })).toBeNull()
+  })
+})
+
+describe('violation record format', () => {
+  it('violation has required fields', () => {
+    const t = iso(600)
+    const violation = act('POST', '/tasks', 'kai', t, { from: 'kai' })
+    expect(violation).not.toBeNull()
+    expect(violation!.id).toMatch(/^cv-/)
+    expect(violation!.agent).toBe('kai')
+    expect(violation!.session_id).toContain('kai')
+    expect(typeof violation!.detected_at).toBe('number')
+    expect(violation!.window_used_ms).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What

Implements the state-read-before-assertion compliance rule from spec PR #636.

Detects when agents take triggering actions without a qualifying state read within the session window. **Flag, do not block.**

## Implementation

### New module: `src/compliance-detector.ts`

**Triggering actions (Phase 1 — API-layer only):**
- `POST /tasks` — creates shared task
- `PATCH /tasks/:id` — status transitions
- `POST /tasks/:id/review` — review decision
- `POST /reflections` — team state assertion

**Phase 2 (not in this PR):** `POST /tasks/:id/comments` chat assertion detection — deferred to avoid false positives.

**Qualifying state reads:**
- `GET /heartbeat/:agent` → 5-min window
- `GET /tasks/active`, `GET /tasks/next`, `GET /tasks` → 10-min window  
- `GET /chat/messages`, `GET /inbox/:agent`, `GET /me/:agent` → 10-min window

**Sessions:** keyed by `agent:30-min-bucket` with carry-forward across bucket boundaries.

### Server wiring
- Hooked into existing `onResponse` — zero latency impact, never throws
- New endpoint: `GET /compliance/violations?agent=&severity=&since=&limit=`

### Tests
24 unit tests: agent extraction, read suppression, no-read violations, stale-read violations, window reset, non-triggering actions, record format.

## Open questions from spec resolved

1. `GET /tasks/:id` — scoped to that task, not a general board read
2. Repeated reads — extend window
3. Retroactive detection — deploy-forward only

Closes task-1772609696194-1i9s775yl