### PR TITLE
fix: alert-preflight snapshot persistence across restarts

### DIFF
--- a/src/alert-preflight.ts
+++ b/src/alert-preflight.ts
@@ -335,6 +335,103 @@ export function resetPreflightMetrics(): void {
 
 const DAILY_FILE = join(DATA_DIR, 'alert-preflight-daily.jsonl')
 let lastSnapshotDate = ''
+let snapshotTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * Initialize snapshot state from existing daily file and backfill
+ * missing days from the audit log.  Called once on module load.
+ */
+function initSnapshotState(): void {
+  try {
+    const { readFileSync, existsSync } = require('fs')
+
+    // Recover lastSnapshotDate so restarts don't duplicate today's entry
+    if (existsSync(DAILY_FILE)) {
+      const lines = readFileSync(DAILY_FILE, 'utf8').trim().split('\n').filter(Boolean)
+      if (lines.length > 0) {
+        const last = JSON.parse(lines[lines.length - 1]!)
+        if (last.date) lastSnapshotDate = last.date
+      }
+    }
+
+    // Backfill missing days from audit log
+    backfillFromAuditLog()
+  } catch {
+    // Non-fatal — best-effort initialization
+  }
+}
+
+/**
+ * Scan the audit log and generate daily snapshots for any dates
+ * that don't already have an entry in the daily file.
+ */
+function backfillFromAuditLog(): void {
+  try {
+    const { readFileSync, existsSync } = require('fs')
+
+    if (!existsSync(AUDIT_FILE)) return
+
+    const auditContent = readFileSync(AUDIT_FILE, 'utf8').trim()
+    if (!auditContent) return
+
+    // Collect existing snapshot dates
+    const existingDates = new Set<string>()
+    if (existsSync(DAILY_FILE)) {
+      const dailyContent = readFileSync(DAILY_FILE, 'utf8').trim()
+      if (dailyContent) {
+        for (const line of dailyContent.split('\n')) {
+          try {
+            const entry = JSON.parse(line)
+            if (entry.date) existingDates.add(entry.date)
+          } catch { /* skip malformed */ }
+        }
+      }
+    }
+
+    // Aggregate audit entries by date
+    const byDate = new Map<string, { total: number; flagged: number; suppressed: number }>()
+    for (const line of auditContent.split('\n')) {
+      try {
+        const entry = JSON.parse(line)
+        const date = new Date(entry.ts).toISOString().slice(0, 10)
+        if (existingDates.has(date)) continue // already have a snapshot
+
+        let day = byDate.get(date)
+        if (!day) { day = { total: 0, flagged: 0, suppressed: 0 }; byDate.set(date, day) }
+        day.total++
+        if (entry.mode === 'canary' && !entry.proceed) day.flagged++ // shouldn't happen, canary always proceeds
+        if (entry.category) day.flagged++ // any categorized entry = would-be suppression
+        if (entry.mode === 'enforce' && !entry.proceed) day.suppressed++
+      } catch { /* skip malformed */ }
+    }
+
+    // Write backfilled snapshots (sorted by date)
+    const dates = [...byDate.keys()].sort()
+    for (const date of dates) {
+      const day = byDate.get(date)!
+      const snapshot = {
+        date,
+        ts: new Date(date + 'T23:59:59Z').getTime(),
+        totalChecked: day.total,
+        suppressed: day.suppressed,
+        canaryFlagged: day.flagged,
+        latencyP95: 0, // not available from audit log
+        mode: 'canary',
+        falsePositiveRate: day.total > 0
+          ? Math.round((day.flagged / day.total) * 10000) / 100
+          : 0,
+        backfilled: true,
+      }
+      try {
+        appendFileSync(DAILY_FILE, JSON.stringify(snapshot) + '\n')
+        existingDates.add(date)
+        lastSnapshotDate = date > lastSnapshotDate ? date : lastSnapshotDate
+      } catch { /* non-fatal */ }
+    }
+  } catch {
+    // Non-fatal — best-effort backfill
+  }
+}
 
 /**
  * Append a daily metrics snapshot if the date has changed.
@@ -372,6 +469,28 @@ export function snapshotDailyMetrics(): void {
 }
 
 /**
+ * Start periodic auto-snapshot (hourly).
+ * Ensures daily snapshots happen even if no health endpoint is accessed.
+ */
+export function startAutoSnapshot(): void {
+  if (snapshotTimer) return
+  snapshotTimer = setInterval(() => {
+    snapshotDailyMetrics()
+  }, 60 * 60 * 1000) // 1 hour
+  snapshotTimer.unref() // Don't prevent process exit
+}
+
+/**
+ * Stop the auto-snapshot timer (for testing/cleanup).
+ */
+export function stopAutoSnapshot(): void {
+  if (snapshotTimer) {
+    clearInterval(snapshotTimer)
+    snapshotTimer = null
+  }
+}
+
+/**
  * Read all daily snapshots for the observation window report.
  */
 export function getDailySnapshots(): Array<{
@@ -382,6 +501,7 @@ export function getDailySnapshots(): Array<{
   latencyP95: number
   mode: string
   falsePositiveRate: number
+  backfilled?: boolean
 }> {
   try {
     const { readFileSync } = require('fs')
@@ -392,3 +512,6 @@ export function getDailySnapshots(): Array<{
     return []
   }
 }
+
+// Initialize on module load
+initSnapshotState()

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import type { WebSocket } from 'ws'
 import { execSync } from 'child_process'
 import { serverConfig, openclawConfig, isDev, REFLECTT_HOME } from './config.js'
 import { trackRequest, getRequestMetrics } from './request-tracker.js'
-import { getPreflightMetrics, snapshotDailyMetrics, getDailySnapshots } from './alert-preflight.js'
+import { getPreflightMetrics, snapshotDailyMetrics, getDailySnapshots, startAutoSnapshot } from './alert-preflight.js'
 
 // ── Build info (read once at startup) ──────────────────────────────────────
 const BUILD_VERSION = (() => {
@@ -12342,6 +12342,9 @@ If your heartbeat shows **no active task** and **no next task**:
     const result = calendarEvents.getAgentNextEvent(query.agent)
     return { agent: query.agent, next_event: result?.event || null, starts_at: result?.starts_at || null }
   })
+
+  // Start hourly auto-snapshot for alert-preflight daily metrics
+  startAutoSnapshot()
 
   return app
 }

--- a/tests/alert-preflight.test.ts
+++ b/tests/alert-preflight.test.ts
@@ -38,6 +38,10 @@ import {
   getPreflightMetrics,
   resetPreflightMetrics,
   getPreflightMode,
+  snapshotDailyMetrics,
+  getDailySnapshots,
+  startAutoSnapshot,
+  stopAutoSnapshot,
   type PreflightInput,
 } from '../src/alert-preflight.js'
 
@@ -318,6 +322,24 @@ describe('alert-preflight', () => {
     it('falls back to canary for invalid', () => {
       process.env.ALERT_PREFLIGHT_MODE = 'garbage'
       expect(getPreflightMode()).toBe('canary')
+    })
+  })
+
+  describe('daily snapshots', () => {
+    it('snapshotDailyMetrics does not throw', () => {
+      preflightCheck({ taskId: 'task-snap-1', alertType: 'test' })
+      // Should not throw even with mocked fs
+      expect(() => snapshotDailyMetrics()).not.toThrow()
+    })
+
+    it('getDailySnapshots returns empty array when no file', () => {
+      const snapshots = getDailySnapshots()
+      expect(Array.isArray(snapshots)).toBe(true)
+    })
+
+    it('startAutoSnapshot and stopAutoSnapshot do not throw', () => {
+      expect(() => startAutoSnapshot()).not.toThrow()
+      expect(() => stopAutoSnapshot()).not.toThrow()
     })
   })
 })


### PR DESCRIPTION
## What

Fixes the gap where daily preflight metrics were lost on server restart, breaking the 7-day observation window needed for canary→enforce transition.

## Changes

- **Startup recovery**: Load `lastSnapshotDate` from existing daily file so restarts don't duplicate entries
- **Audit log backfill**: Scan audit JSONL and generate daily snapshots for any missing dates
- **Auto-snapshot timer**: Hourly interval (unref'd) ensures snapshots happen even without health endpoint access
- **Server integration**: `startAutoSnapshot()` called in `createServer()`
- **Tests**: 3 new tests for snapshot functions

## Task

`task-1771849175579-apuqqi0fd` — P0-2: Alert-integrity guard

## Context

Canary mode has been running since March 1. Audit log shows 29 entries of correctly-caught false positives (alerts for done tasks). The daily snapshot file only had 1 entry because `snapshotDailyMetrics()` depended on health endpoint access and `lastSnapshotDate` reset on restart.

This fix ensures reliable metrics collection for the remaining observation window (through March 8).