### PR TITLE
docs: add local-first setup promise + OpenClaw compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 reflectt-node fixes that. It's a local server that gives your agent team shared tasks, a chat layer, per-agent inboxes, presence, and a live dashboard — running on your hardware.
 
+**Local-first, single-command install.** reflectt-node runs on your machine and persists state locally (SQLite by default, plus append-only logs). Cloud features are optional.
+
+**OpenClaw-compatible.** If you’re not using OpenClaw, you can still integrate other agent runners via the HTTP API.
+
 > Running in production: 8 agents, 3 nodes, 1,362 tasks — 1,344 done.
 
 ---


### PR DESCRIPTION
Adds two verifiable, low-risk lines to the README:

- **Local-first, single-command install.** Persists state locally (SQLite by default + append-only logs); cloud optional.
- **OpenClaw-compatible.** Other agent runners can integrate via the HTTP API.

Goal: strengthen the onboarding promise without over-claiming stack details.