### PR TITLE
Suppress task-comment fanout for test-harness tasks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { detectApproval, applyApproval } from './chat-approval-detector.js'
 import { inboxManager } from './inbox.js'
 import { getDb } from './db.js'
 import type { AgentMessage, Task } from './types.js'
+import { isTestHarnessTask } from './test-task-filter.js'
 import { handleMCPRequest, handleSSERequest, handleMessagesRequest } from './mcp.js'
 import { memoryManager } from './memory.js'
 import { buildContextInjection, getContextBudgets, getContextMemo, upsertContextMemo, type ContextLayer } from './context-budget.js'
@@ -5467,7 +5468,15 @@ export async function createServer(): Promise<FastifyInstance> {
       // fan out inbox-visible notifications to assignee/reviewer + explicit @mentions.
       // Notification routing respects per-agent preferences (quiet hours, mute, filters).
       const task = taskManager.getTask(resolved.resolvedId)
-      if (task && !comment.suppressed) {
+
+      // Never fan out notifications for test-harness tasks.
+      // Our repo contains a few "LIVE server" tests (BASE=127.0.0.1:4445) that create
+      // tasks/comments with metadata.is_test=true. Without this guard, running `npm test`
+      // on a machine with a live node will spam real chat channels and look like a human
+      // (e.g. @link) posted the comment.
+      const shouldFanOut = task ? !isTestHarnessTask(task) : false
+
+      if (task && !comment.suppressed && shouldFanOut) {
         const targets = new Set<string>()
 
         if (task.assignee) targets.add(task.assignee)

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -4517,6 +4517,45 @@ describe('task comment notification - no truncation', () => {
 
     await req('DELETE', `/tasks/${taskId}`)
   })
+
+  it('does not fan out notifications for test-harness tasks (metadata.is_test)', async () => {
+    const unique = Date.now()
+
+    // Baseline: ensure no existing message contains our marker
+    const marker = `TEST_NO_FANOUT_${unique}`
+    const { body: beforeChat } = await req('GET', '/chat/messages?channel=task-comments&limit=200')
+    expect((beforeChat.messages || []).some((m: any) => m.content.includes(marker))).toBe(false)
+
+    // Create a test-harness task (is_test=true)
+    const { status: createStatus, body: taskBody } = await req('POST', '/tasks', {
+      title: `TEST: test-harness fanout suppression ${unique}`,
+      createdBy: 'test-runner',
+      assignee: 'kai',
+      reviewer: 'sage',
+      done_criteria: ['No fanout for is_test tasks'],
+      eta: '~15m',
+      metadata: {
+        is_test: true,
+        source_reflection: 'ref-test-harness-fanout',
+      },
+    })
+    expect(createStatus).toBe(200)
+    const taskId = taskBody.task.id
+
+    // Post a comment that would normally notify assignee+reviewer
+    const { status: commentStatus } = await req('POST', `/tasks/${taskId}/comments`, {
+      author: 'link',
+      content: `Starting work on this ${marker}`,
+    })
+    expect(commentStatus).toBe(200)
+
+    // Verify: no relay message emitted to task-comments channel
+    const { body: afterChat } = await req('GET', '/chat/messages?channel=task-comments&limit=200')
+    const hit = (afterChat.messages || []).find((m: any) => m.content.includes(marker) && m.content.includes('[task-comment:'))
+    expect(hit).toBeUndefined()
+
+    await req('DELETE', `/tasks/${taskId}`)
+  })
 })
 
 // ── Regression: task updatedAt advances on comment ────────────────────────


### PR DESCRIPTION
Fixes coordination thrash where running LIVE-server tests (metadata.is_test=true) can spam real task-comments chat and appear as a human author (e.g. @link) posted "Starting work on this" on phantom/cleanup tasks.

Change:
- In POST /tasks/:id/comments, skip chat fanout when task isTestHarnessTask (metadata.is_test).
- Adds regression test in tests/api.test.ts asserting no task-comments relay message is emitted for is_test tasks.

Related: task-1772692029568-7rsrr7nk8