### PR TITLE
fix: lane-based routing for backlog health + sweeper

### DIFF
--- a/src/boardHealthWorker.ts
+++ b/src/boardHealthWorker.ts
@@ -651,7 +651,13 @@ export class BoardHealthWorker {
         if (now - lastReplenish < cooldownMs) continue
 
         // Count unblocked todo tasks for this agent
-        const todoTasks = taskManager.listTasks({ status: 'todo', assignee: agent })
+        // Use metadata.lane if present, fall back to assignee match
+        const allTodo = taskManager.listTasks({ status: 'todo' })
+        const todoTasks = allTodo.filter(t => {
+          const taskLane = (t.metadata?.lane as string | undefined)
+          if (taskLane) return taskLane === lane.name && t.assignee === agent
+          return t.assignee === agent
+        })
         const unblockedTodo = todoTasks.filter(t => {
           const blocked = t.metadata?.blocked_by
           if (!blocked) return true

--- a/src/server.ts
+++ b/src/server.ts
@@ -2607,9 +2607,17 @@ export async function createServer(): Promise<FastifyInstance> {
       return hasTitle && hasPriority && hasReviewer && hasDoneCriteria
     }
 
+    // Count tasks missing metadata.lane for visibility
+    const missingLaneCount = allTasks.filter(t => !t.metadata?.lane && t.status !== 'done').length
+
     // Build per-lane health
+    // Task belongs to a lane if: (1) metadata.lane matches, OR (2) assignee is in lane agents (fallback)
     const laneHealth = Object.entries(lanes).map(([laneName, config]) => {
-      const laneTasks = allTasks.filter(t => config.agents.includes(t.assignee || ''))
+      const laneTasks = allTasks.filter(t => {
+        const taskLane = t.metadata?.lane as string | undefined
+        if (taskLane) return taskLane === laneName
+        return config.agents.includes(t.assignee || '')
+      })
 
       const todo = laneTasks.filter(t => t.status === 'todo')
       const doing = laneTasks.filter(t => t.status === 'doing')
@@ -2711,6 +2719,7 @@ export async function createServer(): Promise<FastifyInstance> {
         breachedLaneCount: breachedLanes.length,
         overallStatus: breachedLanes.length > 0 ? 'breach' : totalReady === 0 ? 'critical' : 'healthy',
         staleValidatingCount: staleValidating.length,
+        missingLaneMetadata: missingLaneCount,
       },
       lanes: laneHealth,
       staleValidating,


### PR DESCRIPTION
Backlog health and sweeper now use metadata.lane for lane routing instead of only assignee. Falls back to assignee when lane is missing. Adds missingLaneMetadata count to summary.

1600 tests pass.

Closes task-1772719664951-eteblgkpy