### PR TITLE
fix: hide internal deploy jargon from new users

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1564,6 +1564,7 @@ async function loadReleaseStatus(force = false) {
     badge.classList.toggle('stale', stale);
     badge.classList.toggle('fresh', !stale);
     badge.textContent = stale ? 'deploy: stale' : 'deploy: in sync';
+    badge.style.display = '';
 
     const reasons = Array.isArray(status.reasons) ? status.reasons : [];
     const startupCommit = status.startup && status.startup.commit ? status.startup.commit.slice(0, 8) : 'unknown';
@@ -1599,6 +1600,7 @@ async function loadBuildInfo() {
     badge.classList.toggle('stale', branch !== 'main');
     badge.textContent = `${sha} • ${uptimeStr}`;
     badge.title = `SHA: ${info.gitSha}\nBranch: ${branch}\nCommit: ${info.gitMessage}\nAuthor: ${info.gitAuthor}\nPID: ${info.pid}\nNode: ${info.nodeVersion}\nStarted: ${info.startedAt}`;
+    badge.style.display = '';
   } catch (err) {
     badge.textContent = 'build: error';
     badge.title = 'Failed to load build info';
@@ -2757,6 +2759,11 @@ function toggleFocusMode() {
 
   // Persist preference
   try { localStorage.setItem('reflectt-focus-mode', focusModeActive ? '1' : '0'); } catch {}
+
+  // Show/hide dev-only panels
+  document.querySelectorAll('.panel.focus-only').forEach(panel => {
+    panel.style.display = focusModeActive ? '' : 'none';
+  });
 
   // Re-render kanban to add/remove QA contract details
   renderKanban();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2043,8 +2043,8 @@ export function getDashboardHTML(opts: DashboardOptions = {}): string {
     <button class="focus-toggle" id="focus-toggle" onclick="toggleFocusMode()" title="Focus Mode: highlight active work, collapse noise">
       <span class="focus-icon">🎯</span> Focus
     </button>
-    <span id="release-badge" class="release-badge" title="Deploy status">deploy: checking…</span>
-    <span id="build-badge" class="release-badge" title="Build info">build: loading…</span>
+    <span id="release-badge" class="release-badge" title="Deploy status" style="display:none">deploy: checking…</span>
+    <span id="build-badge" class="release-badge" title="Build info" style="display:none">build: loading…</span>
     <span id="clock"></span>
   </div>
 </div>
@@ -2158,7 +2158,7 @@ ${internalMode ? `<div id="pause-banner" class="pause-banner" style="display:non
     </div>
   </div>
 
-  <div class="panel">
+  <div class="panel focus-only" style="display:none">
     <div class="panel-header">🧭 Runtime Truth Card <span class="count" id="truth-count">loading…</span></div>
     <div class="panel-body" id="truth-body"></div>
   </div>


### PR DESCRIPTION
Deploy/build badges and runtime truth card are dev-ops info irrelevant to new users. Hidden by default; badges appear on successful load, truth card appears in Focus Mode.

1633 tests pass.

Refs task-1772729936962-t4mqegnqn