### PR TITLE
fix: cloud-url default from api.reflectt.ai → app.reflectt.ai

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -812,7 +812,7 @@ dogfood
   .description('Run end-to-end cloud enrollment chain verification')
   .requiredOption('--team-id <id>', 'Cloud team id to target')
   .requiredOption('--token <jwt>', 'Bearer token for cloud API auth (team admin/owner)')
-  .option('--cloud-url <url>', 'Cloud API base URL', process.env.REFLECTT_CLOUD_URL || 'https://api.reflectt.ai')
+  .option('--cloud-url <url>', 'Cloud API base URL', process.env.REFLECTT_CLOUD_URL || 'https://app.reflectt.ai')
   .option('--dashboard-url <url>', 'Dashboard base URL', process.env.REFLECTT_APP_URL || 'https://app.reflectt.ai')
   .option('--host-name <name>', 'Host name to register', `dogfood-${process.pid}`)
   .option('--capability <value...>', 'Host capabilities', ['openclaw', 'dogfood-smoke'])
@@ -923,7 +923,7 @@ program
   .description('One-shot setup: init + connect to cloud + start server. Fastest way to get running.')
   .option('--join-token <token>', 'Cloud host join token (get one at app.reflectt.ai)')
   .option('--api-key <key>', 'Team API key')
-  .option('--cloud-url <url>', 'Cloud API base URL', 'https://api.reflectt.ai')
+  .option('--cloud-url <url>', 'Cloud API base URL', 'https://app.reflectt.ai')
   .option('--name <hostName>', 'Host display name', hostname())
   .option('--type <hostType>', 'Host type', 'openclaw')
   .action(async (options) => {
@@ -970,7 +970,7 @@ program
 
       // Step 2: Connect
       console.log('☁️  Step 2/3: Connecting to Reflectt Cloud...')
-      const cloudUrl = String(options.cloudUrl || 'https://api.reflectt.ai').replace(/\/+$/, '')
+      const cloudUrl = String(options.cloudUrl || 'https://app.reflectt.ai').replace(/\/+$/, '')
 
       const registered = options.apiKey
         ? await enrollHostWithApiKey({
@@ -1053,7 +1053,7 @@ host
   .description('Enroll this reflectt-node host with Reflectt Cloud')
   .option('--join-token <token>', 'Cloud host join token (from dashboard)')
   .option('--api-key <key>', 'Team API key for agent-friendly enrollment (no browser needed)')
-  .option('--cloud-url <url>', 'Cloud API base URL', 'https://api.reflectt.ai')
+  .option('--cloud-url <url>', 'Cloud API base URL', 'https://app.reflectt.ai')
   .option('--name <hostName>', 'Host display name', hostname())
   .option('--type <hostType>', 'Host type', 'openclaw')
   .option('--auth-token <jwt>', 'Temporary user JWT for environments where claim endpoint is JWT-gated')
@@ -1073,7 +1073,7 @@ host
 
       ensureReflecttHome()
       const config = loadConfig()
-      const cloudUrl = String(options.cloudUrl || 'https://api.reflectt.ai').replace(/\/+$/, '')
+      const cloudUrl = String(options.cloudUrl || 'https://app.reflectt.ai').replace(/\/+$/, '')
 
       console.log('☁️  Enrolling host with Reflectt Cloud...')
       console.log(`   Cloud: ${cloudUrl}`)

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -259,7 +259,7 @@ export async function startCloudIntegration(): Promise<void> {
   }
 
   config = {
-    cloudUrl: (process.env.REFLECTT_CLOUD_URL || fileConfig?.cloudUrl || 'https://api.reflectt.ai').replace(/\/+$/, ''),
+    cloudUrl: (process.env.REFLECTT_CLOUD_URL || fileConfig?.cloudUrl || 'https://app.reflectt.ai').replace(/\/+$/, ''),
     token: process.env.REFLECTT_HOST_TOKEN || '',
     hostName: process.env.REFLECTT_HOST_NAME || fileConfig?.hostName || 'unnamed-host',
     hostType: process.env.REFLECTT_HOST_TYPE || fileConfig?.hostType || 'openclaw',


### PR DESCRIPTION
api.reflectt.ai is 404. Cloud API is served from app.reflectt.ai. Updated all CLI defaults.

Refs task-1772730345434-e6j0u9kb7