### PR TITLE
docs: release notes (2026-03-05) + changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - **First-run banner shows on real first boots** (seeded tasks no longer suppress it) and CTAs no longer 404. (#656)
 - **Avatars: default response instead of 404s** (reduces error-rate pollution). (#657)
+- **Host connect cloud-url default** — points at app.reflectt.ai (avoids 404 trap) + clearer help text. (#660)
 - **Host connect guard** — prevents overwriting an existing enrollment unless `--force` is passed. (#662)
 
 ### Docs / UX

--- a/docs/release-notes/2026-03-05.md
+++ b/docs/release-notes/2026-03-05.md
@@ -11,6 +11,9 @@ Objective: make a new GitHub user’s path clearer and more trustworthy (install
 - **Avatars no longer pollute error rate**: relaxed filename guard + serve a default avatar instead of 404s.
   - PR #657: https://github.com/reflectt/reflectt-node/pull/657
 
+- **Cloud-url default + help text**: host connect points at app.reflectt.ai (avoids 404 trap) and guidance is clearer.
+  - PR #660: https://github.com/reflectt/reflectt-node/pull/660
+
 - **Host connect safety**: prevents overwriting an existing enrollment unless `--force` is passed.
   - PR #662: https://github.com/reflectt/reflectt-node/pull/662
 


### PR DESCRIPTION
Adds user-facing release notes for the GitHub-new-user usability push and updates CHANGELOG [Unreleased] with today’s key fixes.

- docs/release-notes/2026-03-05.md
- CHANGELOG.md (Unreleased)

Includes: #656 first-run banner, #657 avatar fallback, #662 host connect guard, #659 60-second demo section.

Note: release notes also reference cloud proof surfaces (demo workspace) for distribution context.