### PR TITLE
feat: notification dedupe guard (monotonic cursor + stale event suppression)

### DIFF
--- a/src/notificationDedupeGuard.ts
+++ b/src/notificationDedupeGuard.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Notification Dedupe Guard
+ *
+ * Prevents stale/out-of-order task notification events:
+ *   1. Tracks lastSeenUpdatedAt per taskId — drops events with updatedAt <= lastSeen
+ *   2. Checks current task status before emitting — suppresses contradictory transitions
+ *      (e.g., event says →doing but task is already done/cancelled)
+ *   3. Uses strict > (not >=) cursor semantics for poller ordering
+ */
+
+// ── In-memory cursor: taskId → last seen updatedAt ─────────────────────────
+
+const lastSeenByTaskId = new Map<string, number>()
+
+// ── Status ordering (higher = further along the lifecycle) ─────────────────
+
+const STATUS_ORDER: Record<string, number> = {
+  todo: 0,
+  doing: 1,
+  blocked: 1, // lateral to doing
+  validating: 2,
+  done: 3,
+  cancelled: 3,
+  resolved_externally: 3,
+}
+
+function statusRank(s: string): number {
+  return STATUS_ORDER[s] ?? -1
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface DedupeCheckInput {
+  taskId: string
+  eventUpdatedAt: number       // updatedAt from the event payload
+  eventStatus: string          // status the event is announcing (e.g., 'doing')
+  currentTaskStatus?: string   // live task status from DB (if available)
+  currentTaskUpdatedAt?: number // live task updatedAt from DB (if available)
+}
+
+export interface DedupeCheckResult {
+  emit: boolean
+  reason?: string
+}
+
+// ── Core Logic ─────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a task notification should be emitted.
+ * Returns { emit: true } if it should proceed, or { emit: false, reason } if suppressed.
+ */
+export function shouldEmitNotification(input: DedupeCheckInput): DedupeCheckResult {
+  const { taskId, eventUpdatedAt, eventStatus, currentTaskStatus, currentTaskUpdatedAt } = input
+
+  // Guard 1: Monotonic cursor — drop events with updatedAt <= lastSeen
+  const lastSeen = lastSeenByTaskId.get(taskId)
+  if (lastSeen !== undefined && eventUpdatedAt <= lastSeen) {
+    return {
+      emit: false,
+      reason: `Stale event: updatedAt ${eventUpdatedAt} <= lastSeen ${lastSeen} for ${taskId}`,
+    }
+  }
+
+  // Guard 2: Contradictory transition — event status is behind current task status
+  if (currentTaskStatus && currentTaskUpdatedAt !== undefined) {
+    const eventRank = statusRank(eventStatus)
+    const currentRank = statusRank(currentTaskStatus)
+
+    // If current task is further along AND has a newer updatedAt, suppress
+    if (currentRank > eventRank && currentTaskUpdatedAt > eventUpdatedAt) {
+      return {
+        emit: false,
+        reason: `Contradictory: event says →${eventStatus} but task is already ${currentTaskStatus} (updatedAt: ${currentTaskUpdatedAt} > ${eventUpdatedAt})`,
+      }
+    }
+  }
+
+  // Update cursor
+  lastSeenByTaskId.set(taskId, eventUpdatedAt)
+
+  return { emit: true }
+}
+
+/**
+ * Get current dedup state for diagnostics.
+ */
+export function getDedupeState(): { cursors: Record<string, number>; size: number } {
+  const cursors: Record<string, number> = {}
+  for (const [k, v] of lastSeenByTaskId) cursors[k] = v
+  return { cursors, size: lastSeenByTaskId.size }
+}
+
+/**
+ * Clear all cursors (for testing).
+ */
+export function clearDedupeState(): void {
+  lastSeenByTaskId.clear()
+}
+
+/**
+ * Prune old cursors to prevent unbounded memory growth.
+ * Removes entries older than maxAgeMs.
+ */
+export function pruneDedupeState(maxAgeMs: number = 24 * 60 * 60 * 1000): number {
+  const cutoff = Date.now() - maxAgeMs
+  let pruned = 0
+  for (const [taskId, ts] of lastSeenByTaskId) {
+    if (ts < cutoff) {
+      lastSeenByTaskId.delete(taskId)
+      pruned++
+    }
+  }
+  return pruned
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7331,7 +7331,24 @@ export async function createServer(): Promise<FastifyInstance> {
         if (task.reviewer) statusNotifTargets.push({ agent: task.reviewer, type: 'taskCompleted' })
       }
 
+      // Dedupe guard: prevent stale/out-of-order notification events
+      const { shouldEmitNotification } = await import('./notificationDedupeGuard.js')
+
       for (const target of statusNotifTargets) {
+        // Check dedupe guard before emitting
+        const dedupeCheck = shouldEmitNotification({
+          taskId: task.id,
+          eventUpdatedAt: task.updatedAt,
+          eventStatus: parsed.status!,
+          currentTaskStatus: task.status,
+          currentTaskUpdatedAt: task.updatedAt,
+        })
+
+        if (!dedupeCheck.emit) {
+          console.log(`[NotifDedupe] Suppressed: ${dedupeCheck.reason}`)
+          continue
+        }
+
         const routing = notifMgr.shouldNotify({
           type: target.type,
           agent: target.agent,
@@ -7348,6 +7365,7 @@ export async function createServer(): Promise<FastifyInstance> {
               kind: target.type,
               taskId: task.id,
               status: parsed.status,
+              updatedAt: task.updatedAt,
               deliveryMethod: routing.deliveryMethod,
             },
           }).catch(() => {}) // Non-blocking

--- a/tests/notification-dedupe-guard.test.ts
+++ b/tests/notification-dedupe-guard.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  shouldEmitNotification,
+  clearDedupeState,
+  getDedupeState,
+  pruneDedupeState,
+} from '../src/notificationDedupeGuard.js'
+
+describe('notificationDedupeGuard', () => {
+  beforeEach(() => {
+    clearDedupeState()
+  })
+
+  describe('monotonic cursor (Guard 1)', () => {
+    it('emits first event for a task', () => {
+      const result = shouldEmitNotification({
+        taskId: 'task-1',
+        eventUpdatedAt: 1000,
+        eventStatus: 'doing',
+      })
+      expect(result.emit).toBe(true)
+    })
+
+    it('emits when updatedAt is strictly greater than lastSeen', () => {
+      shouldEmitNotification({ taskId: 'task-1', eventUpdatedAt: 1000, eventStatus: 'doing' })
+
+      const result = shouldEmitNotification({
+        taskId: 'task-1',
+        eventUpdatedAt: 2000,
+        eventStatus: 'validating',
+      })
+      expect(result.emit).toBe(true)
+    })
+
+    it('drops event when updatedAt equals lastSeen', () => {
+      shouldEmitNotification({ taskId: 'task-1', eventUpdatedAt: 1000, eventStatus: 'doing' })
+
+      const result = shouldEmitNotification({
+        taskId: 'task-1',
+        eventUpdatedAt: 1000,
+        eventStatus: 'doing',
+      })
+      expect(result.emit).toBe(false)
+      expect(result.reason).toContain('Stale event')
+    })
+
+    it('drops event when updatedAt is less than lastSeen', () => {
+      shouldEmitNotification({ taskId: 'task-1', eventUpdatedAt: 2000, eventStatus: 'validating' })
+
+      const result = shouldEmitNotification({
+        taskId: 'task-1',
+        eventUpdatedAt: 1000,
+        eventStatus: 'doing',
+      })
+      expect(result.emit).toBe(false)
+      expect(result.reason).toContain('Stale event')
+    })
+
+    it('tracks separate cursors per task', () => {
+      shouldEmitNotification({ taskId: 'task-1', eventUpdatedAt: 1000, eventStatus: 'doing' })
+      shouldEmitNotification({ taskId: 'task-2', eventUpdatedAt: 500, eventStatus: 'doing' })
+
+      // task-2 at 600 should emit (> 500)
+      const r1 = shouldEmitNotification({ taskId: 'task-2', eventUpdatedAt: 600, eventStatus: 'validating' })
+      expect(r1.emit).toBe(true)
+
+      // task-1 at 999 should NOT emit (< 1000)
+      const r2 = shouldEmitNotification({ taskId: 'task-1', eventUpdatedAt: 999, eventStatus: 'validating' })
+      expect(r2.emit).toBe(false)
+    })
+  })
+
+  describe('contradictory transition (Guard 2)', () => {
+    it('suppresses event when task is further along in lifecycle', () => {
+      const result = shouldEmitNotification({
+        taskId: 'task-3',
+        eventUpdatedAt: 1000,
+        eventStatus: 'doing',
+        currentTaskStatus: 'done',
+        currentTaskUpdatedAt: 2000,
+      })
+      expect(result.emit).toBe(false)
+      expect(result.reason).toContain('Contradictory')
+    })
+
+    it('allows event when task status matches', () => {
+      const result = shouldEmitNotification({
+        taskId: 'task-4',
+        eventUpdatedAt: 1000,
+        eventStatus: 'doing',
+        currentTaskStatus: 'doing',
+        currentTaskUpdatedAt: 1000,
+      })
+      expect(result.emit).toBe(true)
+    })
+
+    it('allows event when task is behind the event', () => {
+      const result = shouldEmitNotification({
+        taskId: 'task-5',
+        eventUpdatedAt: 2000,
+        eventStatus: 'validating',
+        currentTaskStatus: 'doing',
+        currentTaskUpdatedAt: 1000,
+      })
+      expect(result.emit).toBe(true)
+    })
+  })
+
+  describe('replayed out-of-order events', () => {
+    it('emits only the newest event in a replay sequence', () => {
+      // Simulate out-of-order: doing(1000), done(3000), validating(2000)
+      const r1 = shouldEmitNotification({ taskId: 'task-replay', eventUpdatedAt: 1000, eventStatus: 'doing' })
+      expect(r1.emit).toBe(true)
+
+      const r2 = shouldEmitNotification({ taskId: 'task-replay', eventUpdatedAt: 3000, eventStatus: 'done' })
+      expect(r2.emit).toBe(true)
+
+      // Out of order: validating at 2000 should be dropped (2000 < 3000)
+      const r3 = shouldEmitNotification({ taskId: 'task-replay', eventUpdatedAt: 2000, eventStatus: 'validating' })
+      expect(r3.emit).toBe(false)
+    })
+  })
+
+  describe('cursor management', () => {
+    it('getDedupeState returns current cursors', () => {
+      shouldEmitNotification({ taskId: 'task-a', eventUpdatedAt: 100, eventStatus: 'doing' })
+      shouldEmitNotification({ taskId: 'task-b', eventUpdatedAt: 200, eventStatus: 'todo' })
+
+      const state = getDedupeState()
+      expect(state.size).toBe(2)
+      expect(state.cursors['task-a']).toBe(100)
+      expect(state.cursors['task-b']).toBe(200)
+    })
+
+    it('clearDedupeState resets all cursors', () => {
+      shouldEmitNotification({ taskId: 'task-c', eventUpdatedAt: 100, eventStatus: 'doing' })
+      clearDedupeState()
+
+      const state = getDedupeState()
+      expect(state.size).toBe(0)
+
+      // Should emit again after clear
+      const result = shouldEmitNotification({ taskId: 'task-c', eventUpdatedAt: 100, eventStatus: 'doing' })
+      expect(result.emit).toBe(true)
+    })
+
+    it('pruneDedupeState removes old entries', () => {
+      // Insert an entry with old timestamp
+      shouldEmitNotification({ taskId: 'old-task', eventUpdatedAt: 1, eventStatus: 'doing' })
+      shouldEmitNotification({ taskId: 'new-task', eventUpdatedAt: Date.now(), eventStatus: 'doing' })
+
+      const pruned = pruneDedupeState(1000) // prune entries older than 1s
+      expect(pruned).toBe(1) // old-task pruned
+
+      const state = getDedupeState()
+      expect(state.size).toBe(1)
+      expect(state.cursors['new-task']).toBeDefined()
+    })
+  })
+
+  describe('strict > cursor semantics', () => {
+    it('uses strict > not >= for cursor comparison', () => {
+      // First event at t=1000
+      const r1 = shouldEmitNotification({ taskId: 'strict-test', eventUpdatedAt: 1000, eventStatus: 'doing' })
+      expect(r1.emit).toBe(true)
+
+      // Same timestamp — should NOT emit (uses <=, meaning = is rejected)
+      const r2 = shouldEmitNotification({ taskId: 'strict-test', eventUpdatedAt: 1000, eventStatus: 'doing' })
+      expect(r2.emit).toBe(false)
+
+      // t+1 — should emit (strictly greater)
+      const r3 = shouldEmitNotification({ taskId: 'strict-test', eventUpdatedAt: 1001, eventStatus: 'validating' })
+      expect(r3.emit).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## What
Prevents stale/out-of-order task notification events from being emitted.

### Guard 1 — Monotonic cursor
Tracks `lastSeenUpdatedAt` per taskId. Any event with `updatedAt <= lastSeen` is dropped. Uses strict `>` (not `>=`) cursor semantics.

### Guard 2 — Contradictory transition suppression
Before emitting, checks if the event status is behind the task's current status (e.g., event says →doing but task is already done). Suppresses with a log.

### Integration
- Wired into the task status notification emission path in `server.ts`
- Notifications now include `updatedAt` in metadata for consumers
- Stale events logged and suppressed before delivery
- `pruneDedupeState()` available for memory management

## Tests
1658 pass (13 new), 0 fail

## Task
task-1772743311302-3go45mp59