### PR TITLE
fix(dashboard): kanban empty column messages + tablet layout

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -824,8 +824,15 @@ function renderKanban() {
     const isDone = col === 'done';
     const isTodo = col === 'todo';
     const colLimit = isDone ? 3 : isTodo ? 10 : items.length;
+    const emptyMessages = {
+      todo: 'No tasks queued',
+      doing: 'Nothing in progress',
+      blocked: 'Nothing blocked',
+      validating: 'Nothing awaiting review',
+      done: 'No completed tasks yet',
+    };
     const cards = items.length === 0
-      ? '<div class="empty">—</div>'
+      ? '<div class="empty" style="font-size:12px;padding:12px 8px">' + (emptyMessages[col] || '—') + '</div>'
       : items.map((t, idx) => {
         const isHidden = idx >= colLimit;
         const assigneeAgent = t.assignee ? AGENTS.find(a => a.name === t.assignee) : null;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -450,6 +450,13 @@ export function getDashboardHTML(opts: DashboardOptions = {}): string {
   .project-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
   .kanban { display: flex; gap: var(--space-3); padding: 16px 18px; overflow-x: auto; min-height: 180px; align-items: flex-start; }
   .kanban-col { flex: 1; min-width: 160px; max-height: 75vh; overflow-y: auto; scrollbar-width: thin; }
+  @media (max-width: 768px) {
+    .kanban { flex-wrap: wrap; gap: var(--space-2); padding: 12px; }
+    .kanban-col { min-width: 140px; flex-basis: calc(50% - 6px); }
+  }
+  @media (max-width: 480px) {
+    .kanban-col { flex-basis: 100%; }
+  }
   .kanban-col::-webkit-scrollbar { width: 4px; }
   .kanban-col::-webkit-scrollbar-track { background: transparent; }
   .kanban-col::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }


### PR DESCRIPTION
## What
- Empty kanban columns now show contextual messages ('No tasks queued', 'Nothing in progress', etc.) instead of em-dash
- Tablet (≤768px): kanban wraps to 2-column grid
- Mobile (≤480px): single column

## From
Pixel audit (audits/2026-03-03-dashboard-polish-audit.md)

## Tests
1658 pass, 0 fail.

## Task
task-1772558606529-rk3wpk6o7