### PR TITLE
fix(chat-approval): prevent false-positive auto-close from casual messages

### DIFF
--- a/src/chat-approval-detector.ts
+++ b/src/chat-approval-detector.ts
@@ -26,18 +26,25 @@ import { getDuplicateClosureCanonicalRefError } from './duplicateClosureGuard.js
 
 // ── Approval signal patterns ──
 
+/**
+ * Approval patterns — intentionally strict to avoid false positives.
+ * "approved" in a longer sentence (e.g. "you're unblocked to approve") must NOT trigger.
+ * Patterns require either: start-of-message, standalone statement, or explicit task reference context.
+ */
 const APPROVAL_PATTERNS: RegExp[] = [
-  /\blgtm\b/i,
-  /\bapproved?\b/i,
-  /\bship\s*it\b/i,
-  /\blooks\s+good\s+to\s+me\b/i,
-  /\blooks\s+great\b/i,
-  /\b(?:good\s+to\s+(?:go|merge|ship))\b/i,
-  /\b(?:all\s+good|looks\s+solid|nice\s+work|well\s+done)\b/i,
-  /\b(?:✅|👍)\s*(?:approved?|lgtm|merge|ship)?\b/i,
-  /(?:✅|👍)\s*$/,  // standalone emoji at end of message
-  /^\s*(?:✅|👍)\s*$/,  // standalone emoji as entire message
+  /^\s*lgtm\b/i,                                  // "LGTM" at start
+  /^\s*approved?\b/i,                              // "Approved" at start
+  /^\s*ship\s*it\b/i,                              // "Ship it" at start
+  /^\s*looks\s+good\s+to\s+me\b/i,                // "Looks good to me" at start
+  /^\s*looks\s+great\b/i,                          // "Looks great" at start
+  /^\s*(?:good\s+to\s+(?:go|merge|ship))\b/i,     // "Good to go/merge/ship" at start
+  /^\s*(?:all\s+good|looks\s+solid)\b/i,           // "All good" / "Looks solid" at start
+  /\[review\]\s*approved?\b/i,                     // "[review] approved" anywhere (formal pattern)
+  /^\s*(?:✅|👍)\s*(?:approved?|lgtm|merge|ship)?\s*$/i,  // standalone emoji (entire message)
 ]
+
+/** Maximum message length for approval detection — long messages are unlikely to be simple approvals */
+const MAX_APPROVAL_MESSAGE_LENGTH = 300
 
 // Negative patterns — if these match, don't treat as approval
 const REJECTION_PATTERNS: RegExp[] = [
@@ -46,9 +53,17 @@ const REJECTION_PATTERNS: RegExp[] = [
   /\bneeds?\s+(?:work|changes?|fixes?|rework)\b/i,
   /\breject(?:ed|ing)?\b/i,
   /\bblock(?:ed|ing|er)?\b/i,
-  /\bnit(?:s|pick)?\b/i,   // nit alone is not rejection but…
+  /\bnit(?:s|pick)?\b/i,
   /\bfix\s+before\s+merge\b/i,
   /\brequested?\s+changes?\b/i,
+  /\bplease\s+(?:approve|review)\b/i,       // asking someone else to approve
+  /\b(?:to|can|should|will|could)\s+approve\b/i, // "unblocked to approve", "can approve"
+  /\bapprove\s+(?:or|and|it|this|the)\b/i,  // "approve or close", "approve this task"
+  /\b(?:auto|self)[- ]?approv/i,             // discussing auto-approval mechanism
+  /\b(?:harden|fix|tighten).*approv/i,       // discussing approval logic itself
+  /\bapproved?\s*\+\s*closed\b/i,           // "Approved + closed already" (status update)
+  /\bapproved?\s+(?:already|earlier|before|previously)\b/i, // past-tense status report
+  /\bnot\s+approved?\b/i,                   // "Not approved"
 ]
 
 // ── Task ID extraction ──
@@ -88,6 +103,11 @@ export function detectApproval(
   from: string,
   content: string,
 ): DetectionResult {
+  // Step 0: Skip long messages — unlikely to be simple approvals
+  if (content.length > MAX_APPROVAL_MESSAGE_LENGTH) {
+    return { detected: false, skipped: { reason: 'no_approval_signal', details: 'message too long for approval signal' } }
+  }
+
   // Step 1: Check for approval signal in content
   const approvalMatch = APPROVAL_PATTERNS.find(p => p.test(content))
   if (!approvalMatch) {

--- a/tests/chat-approval-detector.test.ts
+++ b/tests/chat-approval-detector.test.ts
@@ -51,7 +51,7 @@ describe('Chat Approval Detector', () => {
         'LGTM',
         'lgtm!',
         'Approved',
-        'This is approved.',
+        'Approved.',
         'Ship it',
         'ship it!',
         'Looks good to me',
@@ -60,7 +60,7 @@ describe('Chat Approval Detector', () => {
         'Good to merge',
         'All good',
         'Looks solid',
-        'Nice work',
+        '[review] approved',
         '✅',
         '👍',
         '✅ approved',
@@ -79,19 +79,19 @@ describe('Chat Approval Detector', () => {
     describe('rejection signal overrides', () => {
       const validatingTask = makeTask({ reviewer: 'sage', status: 'validating' })
 
-      // Messages that contain approval patterns BUT also rejection patterns → rejection_signal
+      // Messages that contain approval-ish words BUT also rejection patterns or don't match approval start
       const approvalWithRejection = [
-        'Not approved — needs changes',
-        'LGTM but needs work on X',
-        'Approved but fix before merge',
+        { msg: 'Not approved — needs changes', reason: 'no_approval_signal' },  // "Not" at start, no approval pattern match
+        { msg: 'LGTM but needs work on X', reason: 'rejection_signal' },        // LGTM at start, but rejection overrides
+        { msg: 'Approved but fix before merge', reason: 'rejection_signal' },    // Approved at start, but rejection overrides
       ]
 
-      for (const msg of approvalWithRejection) {
+      for (const { msg, reason } of approvalWithRejection) {
         it(`detects rejection override in "${msg}"`, () => {
           listTasksSpy.mockReturnValue([validatingTask])
           const result = detectApproval('sage', msg)
           expect(result.detected).toBe(false)
-          expect(result.skipped?.reason).toBe('rejection_signal')
+          expect(result.skipped?.reason).toBe(reason)
         })
       }
 
@@ -102,6 +102,12 @@ describe('Chat Approval Detector', () => {
         'Requested changes',
         'Don\'t ship this yet',
         'Looks good but needs fixes',
+        'you\'re unblocked to approve',
+        'please approve this when ready',
+        'templates are now attached and the task is actually closable',
+        'Approved + closed already (review decision submitted). You\'re unblocked to mint the small eng implementation task.',
+        'this auto-approval trigger looks too eager and can close tasks incorrectly; please harden the rule',
+        'can approve or close it',
       ]
 
       for (const msg of noApprovalSignal) {


### PR DESCRIPTION
## Problem
'approved' or 'approve' anywhere in a chat message triggered auto-close on tasks. Example: '@sage you're unblocked to approve' would close sage's validating task. Reported by @spark.

## Fix
- Approval patterns anchored to start-of-message (no mid-sentence triggers)
- Max message length guard (300 chars)
- 8 new rejection patterns for common false positives
- 6 new test cases covering the exact scenarios that caused false closures

## Tests
1657 pass, 47 approval-detector tests pass.