### PR TITLE
feat(cloud): connection lifecycle tracking + /cloud/events

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -493,6 +493,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/cloud/status` | Cloud connection state (registered, heartbeat age, sync status). Only active when `REFLECTT_HOST_TOKEN` is set. |
+| GET | `/cloud/events` | Connection lifecycle events (connect, disconnect, heartbeat failures/recoveries). Query: `?limit=N` (max 100). |
 | POST | `/cloud/reload` | Hot-reload cloud config from `~/.reflectt/config.json` without server restart. Updates env vars and restarts heartbeat/sync loops. Used by CLI after `host connect` enrollment. |
 | GET | `/provisioning/status` | Host provisioning state: phase, enrollment, config/secrets pull status, webhook routes. Dashboard-safe (no credentials). |
 | POST | `/provisioning/provision` | Full provisioning flow: enroll with cloud (join token or API key), pull config + secrets, configure webhooks. Body: `{ cloudUrl, hostName, joinToken?, apiKey?, capabilities? }`. |

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -127,6 +127,60 @@ function isIdle(): boolean {
   return Date.now() - lastActivityAt > IDLE_THRESHOLD_MS
 }
 
+// ── Connection lifecycle tracking ──────────────────────────────────
+interface ConnectionEvent {
+  type: 'connected' | 'disconnected' | 'reconnected' | 'error' | 'heartbeat_failed' | 'heartbeat_recovered'
+  timestamp: number
+  reason?: string
+  errorCount?: number
+}
+
+const MAX_CONNECTION_EVENTS = 100
+const connectionEvents: ConnectionEvent[] = []
+
+function logConnectionEvent(event: ConnectionEvent): void {
+  connectionEvents.push(event)
+  if (connectionEvents.length > MAX_CONNECTION_EVENTS) {
+    connectionEvents.splice(0, connectionEvents.length - MAX_CONNECTION_EVENTS)
+  }
+}
+
+/** Get connection lifecycle events (most recent first) */
+export function getConnectionEvents(limit = 50): ConnectionEvent[] {
+  return connectionEvents.slice(-limit).reverse()
+}
+
+/** Get connection health summary */
+export function getConnectionHealth() {
+  const now = Date.now()
+  const last60m = connectionEvents.filter(e => now - e.timestamp < 60 * 60_000)
+  const disconnects = last60m.filter(e => e.type === 'disconnected')
+  const errors = last60m.filter(e => e.type === 'error' || e.type === 'heartbeat_failed')
+  const reconnects = last60m.filter(e => e.type === 'reconnected' || e.type === 'heartbeat_recovered')
+
+  const lastDisconnect = disconnects[disconnects.length - 1] || null
+  const lastError = errors[errors.length - 1] || null
+  const lastConnect = connectionEvents.filter(e => e.type === 'connected' || e.type === 'reconnected').pop() || null
+
+  return {
+    status: state.running && state.heartbeatCount > 0 ? 'connected' : state.errors > 0 ? 'degraded' : 'disconnected',
+    uptimeMs: state.running ? now - state.startedAt : 0,
+    heartbeatCount: state.heartbeatCount,
+    consecutiveErrors: state.errors,
+    rolling60m: {
+      disconnects: disconnects.length,
+      errors: errors.length,
+      reconnects: reconnects.length,
+    },
+    lastConnect: lastConnect?.timestamp || null,
+    lastDisconnect: lastDisconnect?.timestamp || null,
+    lastDisconnectReason: lastDisconnect?.reason || null,
+    lastError: lastError?.timestamp || null,
+    lastErrorReason: lastError?.reason || null,
+    totalEventsLogged: connectionEvents.length,
+  }
+}
+
 let config: CloudConfig | null = null
 let state: CloudState = {
   hostId: null,
@@ -310,6 +364,7 @@ export async function startCloudIntegration(): Promise<void> {
   // Start loops
   state.running = true
   state.startedAt = Date.now()
+  logConnectionEvent({ type: 'connected', timestamp: Date.now(), reason: `host ${config.hostName} → ${config.cloudUrl}` })
 
   // Immediate first heartbeat
   sendHeartbeat().catch(() => {})
@@ -538,6 +593,7 @@ export function stopCloudIntegration(): void {
     clearInterval(state.contextSyncTimer)
     state.contextSyncTimer = null
   }
+  logConnectionEvent({ type: 'disconnected', timestamp: Date.now(), reason: 'shutdown' })
   console.log('☁️  Cloud integration: stopped')
 }
 
@@ -615,10 +671,12 @@ async function sendHeartbeat(): Promise<void> {
     // Reset consecutive error count on success
     if (state.errors > 0) {
       console.log(`☁️  Heartbeat recovered after ${state.errors} errors`)
+      logConnectionEvent({ type: 'heartbeat_recovered', timestamp: Date.now(), errorCount: state.errors })
       state.errors = 0
     }
   } else {
     state.errors++
+    logConnectionEvent({ type: 'heartbeat_failed', timestamp: Date.now(), reason: result.error || 'unknown', errorCount: state.errors })
     if (state.errors <= 5 || state.errors % 20 === 0) {
       console.warn(`☁️  Heartbeat failed (${state.errors} consecutive): ${result.error}`)
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -11266,8 +11266,18 @@ If your heartbeat shows **no active task** and **no next task**:
   // ============ CLOUD INTEGRATION (see docs/CLOUD_ENDPOINTS.md) ============
 
   app.get('/cloud/status', async () => {
-    const { getCloudStatus } = await import('./cloud.js')
-    return getCloudStatus()
+    const { getCloudStatus, getConnectionHealth, getConnectionEvents } = await import('./cloud.js')
+    return {
+      ...getCloudStatus(),
+      connectionHealth: getConnectionHealth(),
+    }
+  })
+
+  app.get('/cloud/events', async (request) => {
+    const { getConnectionEvents } = await import('./cloud.js')
+    const url = new URL(request.url, 'http://localhost')
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 50, 100)
+    return { events: getConnectionEvents(limit) }
   })
 
   app.post('/cloud/reload', async () => {


### PR DESCRIPTION
## What
Track cloud connection lifecycle events so ops can measure stability.

## New
- `getConnectionEvents(limit)` — rolling buffer of connect/disconnect/heartbeat events
- `getConnectionHealth()` — rolling 60m summary: disconnects, errors, reconnects, reasons
- `GET /cloud/events?limit=N` — lifecycle event log endpoint
- `/cloud/status` now includes `connectionHealth` summary

## Why
@rhythm flagged: we can't quantify host-connect drops from reflectt-node alone. The `/hosts` registry is empty. This adds the instrumentation needed to answer 'are connections stable?' and 'what's the disconnect rate?'

## Tests
1657 pass. Route/docs contract: 409/409.