### PR TITLE
docs(readme): add npx quick try path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Runs locally (no cloud required). If you’re using OpenClaw, it works well with
 
 ## Install
 
+### Quick try (no global install)
+
+```bash
+npx reflectt-node
+```
+
+Then open http://127.0.0.1:4445/dashboard (or the URL printed in your terminal).
+
+### Install globally
+
+
 ```bash
 npm install -g reflectt-node
 reflectt init


### PR DESCRIPTION
Adds a zero-friction quick try path for GitHub-first users:

- 
- open /dashboard

Keeps existing global install + first-5-min + 60s demo sections intact.