### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump for npm publish. Includes all fixes since 0.1.4 (PRs #660, #662, #674-#681).

Blocked on npm auth — do NOT merge until ready to publish. Ryan to run `npm publish` or set NPM_TOKEN.

For task-1772771238701-tzbzapm59