### PR TITLE
feat: chat drop counters + /health/chat + heartbeat drops

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -103,6 +103,7 @@ Remote hosts (multi-host installs) phone-home via a lightweight heartbeat so the
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/health/chat` | Chat subsystem health: message counts, drop counters per agent (total + rolling 1h + reasons). Returns `{ totalMessages, rooms, subscribers, drops }`. |
 | GET | `/health/errors` | Request error metrics: total errors, total requests, error rate, and last 20 errors for debugging. Returns `{ total_errors, total_requests, error_rate, recent[], timestamp }`. |
 | GET | `/health/keepalive` | Self-keepalive status for CF/serverless: warm boot detection, ping state, cold start count, environment info. |
 | GET | `/health/ping` | Ultra-lightweight keepalive — no DB access. Returns `{ status, uptime_seconds, ts }`. Use for cron triggers, load balancers, uptime monitors. |

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -111,10 +111,25 @@ function rowToMessage(row: ChatMessageRow): AgentMessage {
   }
 }
 
+interface DropCounter {
+  total: number
+  rolling: { ts: number }[]
+  reasons: Record<string, number>
+}
+
+const DROP_WINDOW_MS = 60 * 60 * 1000  // 1 hour rolling window
+const DROP_ALERT_THRESHOLD = 10
+const DROP_ALERT_WINDOW_MS = 10 * 60 * 1000
+const DROP_ALERT_DEDUP_MS = 30 * 60 * 1000
+
 class ChatManager {
   private rooms = new Map<string, ChatRoom>()
   private subscribers = new Set<(message: AgentMessage) => void>()
   private initialized = false
+
+  // Drop tracking per agent
+  private dropCounters = new Map<string, DropCounter>()
+  private lastAlertAt = 0
 
   // Monotonic timestamp guard: ensure message timestamps (and ids) are strictly increasing.
   // This prevents conditional-caching + since-polling clients from missing messages when
@@ -402,6 +417,7 @@ class ChatManager {
       const dedupKey = (message.metadata as any)?.dedup_key as string | undefined
       if (this.checkDuplicate(message.from, channel, message.content, dedupKey)) {
         console.log(`[Chat/NoiseBudget] Suppressed duplicate from ${message.from} in #${channel}`)
+        this.recordDrop(message.from, 'duplicate')
         // Return a synthetic message so callers don't break
         return {
           ...message,
@@ -453,6 +469,7 @@ class ChatManager {
 
       if (check.isDuplicate) {
         console.log(`[Chat/SuppressionLedger] Suppressed duplicate (key=${dedupKey}) from ${message.from} in #${channel}`)
+        this.recordDrop(message.from, 'ledger-suppressed')
         return {
           ...message,
           id: `msg-${Date.now()}-ledger-suppressed`,
@@ -816,6 +833,51 @@ class ChatManager {
     return rows.map(rowToMessage).reverse()
   }
 
+  recordDrop(agent: string, reason: string) {
+    const now = Date.now()
+    let counter = this.dropCounters.get(agent)
+    if (!counter) {
+      counter = { total: 0, rolling: [], reasons: {} }
+      this.dropCounters.set(agent, counter)
+    }
+    counter.total++
+    counter.rolling.push({ ts: now })
+    counter.reasons[reason] = (counter.reasons[reason] || 0) + 1
+
+    // Prune rolling window
+    const cutoff = now - DROP_WINDOW_MS
+    counter.rolling = counter.rolling.filter(e => e.ts > cutoff)
+
+    // Alert check
+    const alertCutoff = now - DROP_ALERT_WINDOW_MS
+    const recentDrops = counter.rolling.filter(e => e.ts > alertCutoff).length
+    if (recentDrops >= DROP_ALERT_THRESHOLD && (now - this.lastAlertAt) > DROP_ALERT_DEDUP_MS) {
+      this.lastAlertAt = now
+      console.warn(`[Chat/DropAlert] Agent ${agent} dropped ${recentDrops} messages in ${DROP_ALERT_WINDOW_MS / 60000}m`)
+      void this.sendMessage({
+        from: 'system',
+        channel: 'ops',
+        content: `⚠️ **Chat Drop Alert**: Agent \`${agent}\` dropped ${recentDrops} messages in the last ${DROP_ALERT_WINDOW_MS / 60000} minutes. Check /health/chat for details.`,
+        metadata: { category: 'chat-drop-alert', bypass_budget: true },
+      })
+    }
+  }
+
+  getDropStats(): Record<string, { total: number; rolling_1h: number; reasons: Record<string, number> }> {
+    const now = Date.now()
+    const cutoff = now - DROP_WINDOW_MS
+    const result: Record<string, { total: number; rolling_1h: number; reasons: Record<string, number> }> = {}
+    for (const [agent, counter] of this.dropCounters) {
+      counter.rolling = counter.rolling.filter(e => e.ts > cutoff)
+      result[agent] = {
+        total: counter.total,
+        rolling_1h: counter.rolling.length,
+        reasons: { ...counter.reasons },
+      }
+    }
+    return result
+  }
+
   getStats() {
     const db = getDb()
     const totalRow = db.prepare('SELECT COUNT(*) as count FROM chat_messages').get() as { count: number } | undefined
@@ -825,6 +887,7 @@ class ChatManager {
       rooms: this.rooms.size,
       subscribers: this.subscribers.size,
       initialized: this.initialized,
+      drops: this.getDropStats(),
     }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2237,6 +2237,16 @@ export async function createServer(): Promise<FastifyInstance> {
   })
 
   // ─── Request errors — last N errors for launch-day debugging ───
+  app.get('/health/chat', async () => {
+    const stats = chatManager.getStats()
+    return {
+      totalMessages: stats.totalMessages,
+      rooms: stats.rooms,
+      subscribers: stats.subscribers,
+      drops: stats.drops,
+    }
+  })
+
   app.get('/health/errors', async () => {
     const m = getRequestMetrics()
     return {
@@ -9648,12 +9658,17 @@ export async function createServer(): Promise<FastifyInstance> {
     const intensity = getIntensity()
     const pullBudget = checkPullBudget(agent)
 
+    // Drop stats for this agent
+    const allDrops = chatManager.getDropStats()
+    const agentDrops = allDrops[agent]
+
     return {
       agent, ts: Date.now(),
       active: slim(activeTask), next: pauseStatus.paused ? null : slim(nextTask),
       inbox: slimInbox, inboxCount: inbox.length,
       queue: { todo: todoTasks.length, doing: doingTasks.length, validating: validatingTasks.length },
       intensity: { preset: intensity.preset, pullsRemaining: pullBudget.remaining, wipLimit: intensity.limits.wipLimit },
+      ...(agentDrops ? { drops: { total: agentDrops.total, rolling_1h: agentDrops.rolling_1h } } : {}),
       ...(pauseStatus.paused ? { paused: true, pauseMessage: pauseStatus.message, resumesAt: pauseStatus.entry?.pausedUntil ?? null } : {}),
       action: pauseStatus.paused ? `PAUSED: ${pauseStatus.message}`
         : activeTask ? `Continue ${activeTask.id}`

--- a/tests/chat-drop-counters.test.ts
+++ b/tests/chat-drop-counters.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+})
+
+describe('Chat drop counters', () => {
+  it('GET /health/chat returns drops object with per-agent counters', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health/chat' })
+    expect(res.statusCode).toBe(200)
+
+    const body = JSON.parse(res.body)
+    expect(typeof body.totalMessages).toBe('number')
+    expect(typeof body.drops).toBe('object')
+    // drops is a Record<string, { total, rolling_1h, reasons }>
+    // May be empty if no drops yet — that's valid
+    for (const [agent, stats] of Object.entries(body.drops as Record<string, any>)) {
+      expect(typeof agent).toBe('string')
+      expect(typeof stats.total).toBe('number')
+      expect(typeof stats.rolling_1h).toBe('number')
+      expect(typeof stats.reasons).toBe('object')
+    }
+  })
+
+  it('posting duplicate messages increments drop counter', async () => {
+    const testAgent = `test-drop-agent-${Date.now()}`
+    const testContent = `duplicate test message ${Date.now()}`
+
+    // Post first message — should succeed
+    const res1 = await app.inject({
+      method: 'POST',
+      url: '/chat/messages',
+      payload: { from: testAgent, content: testContent, channel: 'ops' },
+    })
+    expect(res1.statusCode).toBe(200)
+
+    // Post same message again — should be suppressed as duplicate
+    const res2 = await app.inject({
+      method: 'POST',
+      url: '/chat/messages',
+      payload: { from: testAgent, content: testContent, channel: 'ops' },
+    })
+    expect(res2.statusCode).toBe(200) // Returns 200 with synthetic suppressed msg
+
+    // Check drop stats
+    const healthRes = await app.inject({ method: 'GET', url: '/health/chat' })
+    const health = JSON.parse(healthRes.body)
+
+    const agentDrops = health.drops[testAgent]
+    expect(agentDrops).toBeDefined()
+    expect(agentDrops.total).toBeGreaterThanOrEqual(1)
+    expect(agentDrops.rolling_1h).toBeGreaterThanOrEqual(1)
+    expect(agentDrops.reasons).toBeDefined()
+    // Should have 'duplicate' as a reason
+    expect(agentDrops.reasons['duplicate']).toBeGreaterThanOrEqual(1)
+  })
+
+  it('heartbeat includes drop stats for agent with drops', async () => {
+    const testAgent = `test-hb-drop-${Date.now()}`
+    const testContent = `heartbeat drop test ${Date.now()}`
+
+    // Create a drop
+    await app.inject({
+      method: 'POST',
+      url: '/chat/messages',
+      payload: { from: testAgent, content: testContent, channel: 'ops' },
+    })
+    await app.inject({
+      method: 'POST',
+      url: '/chat/messages',
+      payload: { from: testAgent, content: testContent, channel: 'ops' },
+    })
+
+    // Check heartbeat for this agent
+    const hbRes = await app.inject({ method: 'GET', url: `/heartbeat/${testAgent}` })
+    expect(hbRes.statusCode).toBe(200)
+
+    const hb = JSON.parse(hbRes.body)
+    // Heartbeat should include drops if present
+    if (hb.drops) {
+      expect(typeof hb.drops.total).toBe('number')
+      expect(typeof hb.drops.rolling_1h).toBe('number')
+    }
+  })
+})


### PR DESCRIPTION
Track dropped/suppressed messages per agent. Expose via `/health/chat` and `/heartbeat/:agent`.

- Per-agent counters: total, rolling_1h, reasons (duplicate vs ledger-suppressed)
- Alert to #ops when >10 drops in 10min (deduped 30min)
- `/health/chat` endpoint with full chat subsystem stats + drop counters
- Heartbeat includes drop stats when present

Tests: 1667 pass (3 new). Route-docs: 411/411.

For task-1772779963794-6tjzt8j4p