### PR TITLE
fix: replace require('fs') with ESM import in alert-preflight

### DIFF
--- a/src/alert-preflight.ts
+++ b/src/alert-preflight.ts
@@ -15,7 +15,7 @@
  */
 
 import { createHash } from 'crypto'
-import { appendFileSync } from 'fs'
+import { appendFileSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { DATA_DIR } from './config.js'
 import { taskManager } from './tasks.js'
@@ -343,8 +343,6 @@ let snapshotTimer: ReturnType<typeof setInterval> | null = null
  */
 function initSnapshotState(): void {
   try {
-    const { readFileSync, existsSync } = require('fs')
-
     // Recover lastSnapshotDate so restarts don't duplicate today's entry
     if (existsSync(DAILY_FILE)) {
       const lines = readFileSync(DAILY_FILE, 'utf8').trim().split('\n').filter(Boolean)
@@ -367,8 +365,6 @@ function initSnapshotState(): void {
  */
 function backfillFromAuditLog(): void {
   try {
-    const { readFileSync, existsSync } = require('fs')
-
     if (!existsSync(AUDIT_FILE)) return
 
     const auditContent = readFileSync(AUDIT_FILE, 'utf8').trim()
@@ -504,7 +500,7 @@ export function getDailySnapshots(): Array<{
   backfilled?: boolean
 }> {
   try {
-    const { readFileSync } = require('fs')
+    if (!existsSync(DAILY_FILE)) return []
     const content = readFileSync(DAILY_FILE, 'utf8').trim()
     if (!content) return []
     return content.split('\n').map((line: string) => JSON.parse(line))

--- a/tests/alert-preflight.test.ts
+++ b/tests/alert-preflight.test.ts
@@ -337,6 +337,38 @@ describe('alert-preflight', () => {
       expect(Array.isArray(snapshots)).toBe(true)
     })
 
+    it('getDailySnapshots returns snapshots from daily file (ESM regression)', async () => {
+      // Write a temp daily file to the mocked DATA_DIR
+      const fs = await import('fs')
+      const path = await import('path')
+      const dataDir = '/tmp/test-data'
+      fs.mkdirSync(dataDir, { recursive: true })
+      const dailyFile = path.join(dataDir, 'alert-preflight-daily.jsonl')
+
+      const snapshot = {
+        date: '2026-03-05',
+        ts: Date.now(),
+        totalChecked: 10,
+        suppressed: 0,
+        canaryFlagged: 2,
+        latencyP95: 0.42,
+        mode: 'canary',
+        falsePositiveRate: 20,
+      }
+      fs.writeFileSync(dailyFile, JSON.stringify(snapshot) + '\n')
+
+      try {
+        const snapshots = getDailySnapshots()
+        expect(Array.isArray(snapshots)).toBe(true)
+        expect(snapshots.length).toBeGreaterThan(0)
+        expect(snapshots[0].date).toBe('2026-03-05')
+        expect(snapshots[0].totalChecked).toBe(10)
+      } finally {
+        // Clean up
+        try { fs.unlinkSync(dailyFile) } catch { /* ignore */ }
+      }
+    })
+
     it('startAutoSnapshot and stopAutoSnapshot do not throw', () => {
       expect(() => startAutoSnapshot()).not.toThrow()
       expect(() => stopAutoSnapshot()).not.toThrow()


### PR DESCRIPTION
## Problem

`/health/alert-preflight/history` always returns `snapshots: []` even when `~/.reflectt/data/alert-preflight-daily.jsonl` exists with data.

## Root Cause

Three functions in `src/alert-preflight.ts` used `require('fs')` to get `readFileSync`/`existsSync`:
- `initSnapshotState()` (line ~346)
- `backfillFromAuditLog()` (line ~370)
- `getDailySnapshots()` (line ~507)

In ESM runtime, `require` is not defined. Each call throws but is silently caught by `try/catch`, returning `[]`.

## Fix

Removed all three `require('fs')` calls and added `readFileSync` and `existsSync` to the existing top-level `import { appendFileSync } from 'fs'` statement.

**Change: 2 insertions, 6 deletions** (net -4 lines).

## Testing

- All 1674 tests pass (including existing ESM regression test)
- `check-route-docs-contract`: ✅
- `check-internal-names-guard`: ✅

Fixes: task-1772795767162-t6pycvden