### PR TITLE
Improve /tasks/next empty response diagnostics

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -129,7 +129,15 @@ curl "http://localhost:4445/tasks/next?agent=builder"
 curl -X POST http://localhost:4445/chat/messages \
   -H 'Content-Type: application/json' \
   -d '{"from": "builder", "channel": "general", "content": "Hello team"}'
+```
 
+Notes on `GET /tasks/next`:
+
+- **Selection logic:** returns (1) your highest-priority `doing` task (resume in-progress work), else (2) the highest-priority `todo` task that is either **unassigned** or **assigned to you**. Blocked tasks are skipped.
+- If it returns `{ "task": null }`, it means there is no **ready** task available under those rules (or you are paused / rate-limited / WIP-blocked).
+- **Shell gotcha (zsh):** keep the URL quoted so `?agent=...` doesn’t get treated like a glob.
+
+```bash
 # Create a task
 curl -X POST http://localhost:4445/tasks \
   -H 'Content-Type: application/json' \

--- a/src/server.ts
+++ b/src/server.ts
@@ -9544,7 +9544,31 @@ export async function createServer(): Promise<FastifyInstance> {
 
     const task = taskManager.getNextTask(agent, { includeTest })
     if (!task) {
-      return { task: null, message: 'No available tasks' }
+      const aliases = agent ? getAgentAliases(agent) : []
+
+      // "Ready" counts: match /tasks/next selection semantics (blocked excluded)
+      const readyTodo = taskManager.listTasks({ status: 'todo', includeBlocked: false, includeTest })
+      const ready_todo_unassigned = readyTodo.filter(t => !t.assignee || String(t.assignee).trim().length === 0).length
+      const ready_todo_assigned = agent
+        ? taskManager.listTasks({ status: 'todo', assigneeIn: aliases, includeBlocked: false, includeTest }).length
+        : 0
+      const ready_doing_assigned = agent
+        ? taskManager.listTasks({ status: 'doing', assigneeIn: aliases, includeBlocked: false, includeTest }).length
+        : 0
+      const ready_validating_assigned = agent
+        ? taskManager.listTasks({ status: 'validating', assigneeIn: aliases, includeBlocked: false, includeTest }).length
+        : 0
+
+      const { formatTasksNextEmptyResponse } = await import('./tasks-next-diagnostics.js')
+      const payload = formatTasksNextEmptyResponse({
+        agent,
+        ready_doing_assigned,
+        ready_todo_unassigned,
+        ready_todo_assigned,
+        ready_validating_assigned,
+      })
+
+      return { task: null, ...payload }
     }
 
     // Rule C: auto-claim (todo→doing) when ?claim=1

--- a/src/tasks-next-diagnostics.ts
+++ b/src/tasks-next-diagnostics.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+export type TasksNextEmptyDiagnostics = {
+  agent?: string
+  /** Counts are "ready" counts: blocked tasks are excluded */
+  ready_doing_assigned: number
+  ready_todo_unassigned: number
+  ready_todo_assigned: number
+  ready_validating_assigned: number
+}
+
+export function formatTasksNextEmptyResponse(
+  diagnostics: TasksNextEmptyDiagnostics,
+): { message: string; hint?: string; code: 'NO_AVAILABLE_TASKS'; diagnostics: TasksNextEmptyDiagnostics } {
+  const a = diagnostics.agent
+  const msgCounts = `ready(todo_unassigned=${diagnostics.ready_todo_unassigned}, todo_assigned_to_you=${diagnostics.ready_todo_assigned}, doing=${diagnostics.ready_doing_assigned}, validating=${diagnostics.ready_validating_assigned})`
+
+  // Base message stays stable for clients; extra info is appended for humans.
+  const message = `No available tasks (${msgCounts})`
+
+  let hint: string | undefined
+
+  if (a) {
+    // Common confusion: agent is in validating-only state with an empty ready todo queue.
+    if (
+      diagnostics.ready_doing_assigned === 0 &&
+      diagnostics.ready_todo_unassigned === 0 &&
+      diagnostics.ready_todo_assigned === 0 &&
+      diagnostics.ready_validating_assigned > 0
+    ) {
+      hint = `@${a} has only validating work right now. Either (1) wait for reviews, (2) unpause/adjust WIP if blocked elsewhere, or (3) mint an unassigned todo to keep the lane moving.`
+    } else if (diagnostics.ready_todo_unassigned === 0 && diagnostics.ready_todo_assigned === 0) {
+      hint = `No ready todo tasks are available for @${a}. /tasks/next only returns: your doing task, unassigned todo tasks, or todo tasks assigned to you.`
+    }
+  } else {
+    if (diagnostics.ready_todo_unassigned === 0) {
+      hint = 'No unassigned todo tasks exist. Create a todo with no assignee (assignee=null) to enable pull-based routing.'
+    }
+  }
+
+  return {
+    code: 'NO_AVAILABLE_TASKS',
+    message,
+    ...(hint ? { hint } : {}),
+    diagnostics,
+  }
+}

--- a/tests/tasks-next-diagnostics.test.ts
+++ b/tests/tasks-next-diagnostics.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest'
+import { formatTasksNextEmptyResponse } from '../src/tasks-next-diagnostics.js'
+
+describe('tasks-next diagnostics formatting', () => {
+  it('adds a validating-only hint', () => {
+    const res = formatTasksNextEmptyResponse({
+      agent: 'sage',
+      ready_doing_assigned: 0,
+      ready_todo_unassigned: 0,
+      ready_todo_assigned: 0,
+      ready_validating_assigned: 2,
+    })
+
+    expect(res.code).toBe('NO_AVAILABLE_TASKS')
+    expect(res.message).toContain('No available tasks')
+    expect(res.message).toContain('ready(')
+    expect(res.hint || '').toContain('only validating')
+    expect(res.hint || '').toContain('@sage')
+  })
+
+  it('adds an explanation when nothing is available for the agent', () => {
+    const res = formatTasksNextEmptyResponse({
+      agent: 'sage',
+      ready_doing_assigned: 0,
+      ready_todo_unassigned: 0,
+      ready_todo_assigned: 0,
+      ready_validating_assigned: 0,
+    })
+
+    expect(res.hint || '').toContain('/tasks/next only returns')
+  })
+
+  it('adds a hint for agentless pulls when queue is empty', () => {
+    const res = formatTasksNextEmptyResponse({
+      agent: undefined,
+      ready_doing_assigned: 0,
+      ready_todo_unassigned: 0,
+      ready_todo_assigned: 0,
+      ready_validating_assigned: 0,
+    })
+
+    expect(res.hint || '').toContain('unassigned todo')
+  })
+})


### PR DESCRIPTION
When /tasks/next returns {task:null}, the response previously only included message="No available tasks" which is ambiguous.

This adds:
- code=NO_AVAILABLE_TASKS
- diagnostics: ready_doing_assigned, ready_todo_unassigned, ready_todo_assigned, ready_validating_assigned
- hint (human-readable) for common states (validating-only, empty ready queue)

Also documents /tasks/next selection semantics in docs/GETTING-STARTED.md and adds unit tests.

Motivation: clarify why agents see null (no ready task under selection rules vs paused/throttled/WIP).