### PR TITLE
fix(tasks/next): treat assignee=unassigned as unassigned

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9575,7 +9575,10 @@ export async function createServer(): Promise<FastifyInstance> {
 
       // "Ready" counts: match /tasks/next selection semantics (blocked excluded)
       const readyTodo = taskManager.listTasks({ status: 'todo', includeBlocked: false, includeTest })
-      const ready_todo_unassigned = readyTodo.filter(t => !t.assignee || String(t.assignee).trim().length === 0).length
+      const ready_todo_unassigned = readyTodo.filter(t => {
+        const a = String(t.assignee || '').trim().toLowerCase()
+        return a.length === 0 || a === 'unassigned'
+      }).length
       const ready_todo_assigned = agent
         ? taskManager.listTasks({ status: 'todo', assigneeIn: aliases, includeBlocked: false, includeTest }).length
         : 0

--- a/src/tasks-next-diagnostics.ts
+++ b/src/tasks-next-diagnostics.ts
@@ -35,7 +35,7 @@ export function formatTasksNextEmptyResponse(
     }
   } else {
     if (diagnostics.ready_todo_unassigned === 0) {
-      hint = 'No unassigned todo tasks exist. Create a todo with no assignee (assignee=null) to enable pull-based routing.'
+      hint = 'No unassigned todo tasks exist. Create a todo with no assignee (omit assignee / assignee=null / assignee="unassigned") to enable pull-based routing.'
     }
   }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1596,9 +1596,11 @@ class TaskManager {
       }
     }
 
-    // Then check todo tasks: unassigned or assigned to this agent
+    // Then check todo tasks: unassigned (NULL/empty/'unassigned') or assigned to this agent
+    // NOTE: server CreateTaskSchema historically defaulted assignee to the string "unassigned",
+    // so we must treat that sentinel as unassigned for pull-based assignment.
     const todoUnassignedRows = db.prepare(
-      'SELECT * FROM tasks WHERE status = ? AND assignee IS NULL'
+      "SELECT * FROM tasks WHERE status = ? AND (assignee IS NULL OR TRIM(assignee) = '' OR LOWER(assignee) = 'unassigned')"
     ).all('todo') as TaskRow[]
     let tasks = todoUnassignedRows.map(rowToTask).filter(t => !isBlocked(t) && filterTestTask(t))
 

--- a/tests/tasks-next-unassigned-sentinel.test.ts
+++ b/tests/tasks-next-unassigned-sentinel.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, afterEach } from 'vitest'
+import { taskManager } from '../src/tasks.js'
+
+const CREATED: string[] = []
+
+afterEach(() => {
+  for (const id of CREATED) {
+    try { taskManager.deleteTask(id) } catch {}
+  }
+  CREATED.length = 0
+})
+
+describe('getNextTask unassigned sentinel', () => {
+  it('treats assignee="unassigned" as unassigned for pull-based routing', async () => {
+    const t = await taskManager.createTask({
+      title: 'TEST: unassigned sentinel pull',
+      status: 'todo',
+      assignee: 'unassigned',
+      done_criteria: ['done'],
+      createdBy: 'test',
+      reviewer: 'sage',
+    })
+    CREATED.push(t.id)
+
+    const next = taskManager.getNextTask('some-agent')
+    expect(next).toBeTruthy()
+    expect(next!.id).toBe(t.id)
+  })
+})


### PR DESCRIPTION
Fixes task-1772801034404-fbmtig0kf (follow-up).

Problem:
- /tasks/next selection treated only NULL/empty assignee as unassigned.
- Our API historically defaults assignee to the sentinel string "unassigned", which made many todo tasks effectively invisible to pull-based routing.

Changes:
- TaskManager.getNextTask now treats assignee NULL/empty/"unassigned" as unassigned.
- /tasks/next diagnostics counts treat "unassigned" as unassigned.
- Update empty-queue hint copy to mention omit/null/"unassigned".
- Add regression test: tasks-next-unassigned-sentinel.

Expected:
- /tasks/next?agent=sage (and others) can now pull backlog tasks that were created with assignee="unassigned".