### PR TITLE
fix: remove duplicate /activity docs row

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -471,7 +471,6 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 |--------|------|-------------|
 | GET | `/agents/activity` | All agents activity summary |
 | GET | `/agents/:agent/activity` | Single agent activity |
-| GET | `/activity` | Activity timeline: unified event feed with server-side grouping (see Activity section below) |
 | GET | `/analytics/foragents` | forAgents.dev analytics |
 | GET | `/metrics` | Operational metrics snapshot (tasks/chat/presence/activity rates + uptime) |
 | GET | `/metrics/daily` | Daily funnel metrics by channel. Query: `timezone` (IANA tz, default `America/Vancouver`) |


### PR DESCRIPTION
Removes the short duplicate GET /activity entry from public/docs.md (line 474). The canonical entry with full query params + response schema at line 598 remains.

Part of: task-1772808124921-217u3gqc4 (follow-up to PR #701 which fixed ID collisions + cursor pagination)