### PR TITLE
Insights: localhost-only cooldown/close endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ process/*
 !process/TASK-u7edc3c9y.md
 !process/TASK-fp0l0cvaq.md
 !process/TASK-k5jnlclwu.md
+!process/TASK-0pfupmpad.md

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -218,6 +218,26 @@ To avoid this friction:
 
 ---
 
+## Local admin endpoints (insight hygiene)
+
+Sometimes you’ll want to manually cool down or close a noisy/stale insight candidate.
+
+These endpoints are **localhost-only** (loopback) and intended for operator hygiene:
+
+- `POST /insights/:id/cooldown` — set status to `cooldown` (defaults to 14d)
+- `POST /insights/:id/close` — set status to `closed`
+
+Example:
+
+```bash
+curl -X POST http://localhost:4445/insights/ins-.../cooldown \
+  -H 'content-type: application/json' \
+  -d '{"actor":"sage","reason":"stale candidate","notes":"already fixed"}'
+```
+
+Optional auth:
+- If you set `REFLECTT_INSIGHT_MUTATION_TOKEN`, include it via `x-reflectt-admin-token: ...` (or `Authorization: Bearer ...`).
+
 → **Source:** [github.com/reflectt/reflectt-node](https://github.com/reflectt/reflectt-node)
 → **Cloud:** [app.reflectt.ai](https://app.reflectt.ai)
 → **Bootstrap (for agents):** [reflectt.ai/bootstrap](https://reflectt.ai/bootstrap)

--- a/process/TASK-0pfupmpad.md
+++ b/process/TASK-0pfupmpad.md
@@ -1,0 +1,46 @@
+# TASK-0pfupmpad — Localhost insight cooldown/close endpoints
+
+Task: task-1772810491278-0pfupmpad
+
+## Problem
+
+Operators can end up with stale/noisy insight candidates that should be cooled down or closed, but the existing admin mutation endpoint (`PATCH /insights/:id`) is disabled behind `REFLECTT_ENABLE_INSIGHT_MUTATION_API`.
+
+For day-to-day hygiene, we need a safe **loopback-only** path to cooldown/close an insight without enabling broad mutation.
+
+## Solution
+
+Added narrow localhost-only endpoints:
+
+- `POST /insights/:id/cooldown`
+  - requires JSON body: `{ actor, reason }`
+  - optional: `notes`, `cooldown_ms`, `cooldown_until`, `cooldown_reason`
+  - sets status=`cooldown`
+  - defaults cooldown window to **14 days** if not provided
+
+- `POST /insights/:id/close`
+  - requires JSON body: `{ actor, reason }`
+  - optional: `notes`
+  - sets status=`closed`
+
+Security:
+- Both endpoints are **loopback-only**.
+- If `REFLECTT_INSIGHT_MUTATION_TOKEN` is set, the caller must provide it via `x-reflectt-admin-token` or `Authorization: Bearer ...`.
+
+Audit:
+- Both endpoints write to the existing `insight-mutation-audit.jsonl` stream via `recordInsightMutation()`.
+
+## Proof
+
+Tests:
+
+```bash
+npx vitest run tests/insight-local-admin.test.ts
+```
+
+Covers:
+- loopback caller can cooldown/close
+- non-loopback caller receives 403
+
+Docs:
+- `docs/GETTING-STARTED.md` updated with endpoint usage and token behavior.

--- a/src/insight-mutation.ts
+++ b/src/insight-mutation.ts
@@ -7,6 +7,8 @@ import { getDb, safeJsonParse, safeJsonStringify } from './db.js'
 import { DATA_DIR } from './config.js'
 import { INSIGHT_STATUSES, type Insight, type InsightStatus } from './insights.js'
 
+const DEFAULT_COOLDOWN_14D_MS = 14 * 24 * 60 * 60 * 1000
+
 // ── Audit log ─────────────────────────────────────────────────────────────
 
 const AUDIT_FILE = process.env.REFLECTT_INSIGHT_MUTATION_AUDIT_FILE || path.join(DATA_DIR, 'insight-mutation-audit.jsonl')
@@ -60,6 +62,24 @@ export interface InsightPatchRequest {
   }
 }
 
+export interface InsightCooldownRequest {
+  actor: string
+  reason: string
+  /** Absolute ms timestamp; defaults to now+14d */
+  cooldown_until?: number
+  /** Stored in cooldown_reason; defaults to reason */
+  cooldown_reason?: string
+  /** Optional operator notes (merged into metadata.notes) */
+  notes?: string
+}
+
+export interface InsightCloseRequest {
+  actor: string
+  reason: string
+  /** Optional operator notes (merged into metadata.notes) */
+  notes?: string
+}
+
 function parseClusterKeyString(clusterKey: string): { workflow_stage: string; failure_family: string; impacted_unit: string } | null {
   const parts = clusterKey.split('::').map(p => p.trim()).filter(Boolean)
   if (parts.length !== 3) return null
@@ -76,6 +96,8 @@ function diff(before: Insight, after: Insight): Array<{ field: string; before: u
     'workflow_stage',
     'failure_family',
     'impacted_unit',
+    'cooldown_until',
+    'cooldown_reason',
     'metadata',
     'updated_at',
   ]
@@ -87,18 +109,8 @@ function diff(before: Insight, after: Insight): Array<{ field: string; before: u
   return changes
 }
 
-export function patchInsightById(insightId: string, patch: InsightPatchRequest): { success: boolean; insight?: Insight; error?: string } {
-  const db = getDb()
-
-  if (!patch.actor?.trim()) return { success: false, error: 'actor is required' }
-  if (!patch.reason?.trim()) return { success: false, error: 'reason is required' }
-
-  const row = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
-  if (!row) return { success: false, error: 'Insight not found' }
-
-  // Defer to rowToInsight mapping via getInsight to keep consistent shapes.
-  const current = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
-  const before: Insight = {
+function rowToInsightShape(current: any): Insight {
+  return {
     id: current.id,
     cluster_key: current.cluster_key,
     workflow_stage: current.workflow_stage,
@@ -122,6 +134,26 @@ export function patchInsightById(insightId: string, patch: InsightPatchRequest):
     created_at: current.created_at,
     updated_at: current.updated_at,
   } as unknown as Insight
+}
+
+function mergeAllowedMetadata(beforeMeta: Record<string, unknown> | undefined, notes?: string, cluster_key_override?: string): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...(beforeMeta ?? {}) }
+  if (typeof notes === 'string') next.notes = notes
+  if (typeof cluster_key_override === 'string') next.cluster_key_override = cluster_key_override
+  return next
+}
+
+export function patchInsightById(insightId: string, patch: InsightPatchRequest): { success: boolean; insight?: Insight; error?: string } {
+  const db = getDb()
+
+  if (!patch.actor?.trim()) return { success: false, error: 'actor is required' }
+  if (!patch.reason?.trim()) return { success: false, error: 'reason is required' }
+
+  const row = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
+  if (!row) return { success: false, error: 'Insight not found' }
+
+  const current = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
+  const before: Insight = rowToInsightShape(current)
 
   // Validate status
   if (patch.status !== undefined) {
@@ -196,6 +228,104 @@ export function patchInsightById(insightId: string, patch: InsightPatchRequest):
     reason: patch.reason,
     changes: diff(before, after),
     context: 'PATCH /insights/:id',
+  })
+
+  return { success: true, insight: after }
+}
+
+export function cooldownInsightById(
+  insightId: string,
+  req: InsightCooldownRequest,
+): { success: boolean; insight?: Insight; error?: string } {
+  const db = getDb()
+
+  if (!req.actor?.trim()) return { success: false, error: 'actor is required' }
+  if (!req.reason?.trim()) return { success: false, error: 'reason is required' }
+
+  const current = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
+  if (!current) return { success: false, error: 'Insight not found' }
+
+  const before = rowToInsightShape(current)
+
+  const now = Date.now()
+  const until = typeof req.cooldown_until === 'number' && Number.isFinite(req.cooldown_until)
+    ? req.cooldown_until
+    : now + DEFAULT_COOLDOWN_14D_MS
+
+  const cooldownReason = (req.cooldown_reason && String(req.cooldown_reason).trim())
+    ? String(req.cooldown_reason).trim()
+    : req.reason
+
+  // Merge metadata (allowlist only)
+  const beforeMetaStr = (current.metadata ?? null) as string | null
+  const nextMeta = mergeAllowedMetadata(before.metadata as any, req.notes)
+  const nextMetaStr = safeJsonStringify(nextMeta)
+
+  db.prepare(`
+    UPDATE insights SET
+      status = 'cooldown',
+      cooldown_until = ?,
+      cooldown_reason = ?,
+      metadata = ?,
+      updated_at = ?
+    WHERE id = ?
+  `).run(until, cooldownReason, nextMetaStr ?? beforeMetaStr, now, insightId)
+
+  const updated = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
+  const after = rowToInsightShape(updated)
+
+  void recordInsightMutation({
+    timestamp: now,
+    insightId,
+    actor: req.actor,
+    reason: req.reason,
+    changes: diff(before, after),
+    context: 'POST /insights/:id/cooldown',
+  })
+
+  return { success: true, insight: after }
+}
+
+export function closeInsightById(
+  insightId: string,
+  req: InsightCloseRequest,
+): { success: boolean; insight?: Insight; error?: string } {
+  const db = getDb()
+
+  if (!req.actor?.trim()) return { success: false, error: 'actor is required' }
+  if (!req.reason?.trim()) return { success: false, error: 'reason is required' }
+
+  const current = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
+  if (!current) return { success: false, error: 'Insight not found' }
+
+  const before = rowToInsightShape(current)
+  const now = Date.now()
+
+  // Merge metadata (allowlist only)
+  const beforeMetaStr = (current.metadata ?? null) as string | null
+  const nextMeta = mergeAllowedMetadata(before.metadata as any, req.notes)
+  const nextMetaStr = safeJsonStringify(nextMeta)
+
+  db.prepare(`
+    UPDATE insights SET
+      status = 'closed',
+      cooldown_until = NULL,
+      cooldown_reason = NULL,
+      metadata = ?,
+      updated_at = ?
+    WHERE id = ?
+  `).run(nextMetaStr ?? beforeMetaStr, now, insightId)
+
+  const updated = db.prepare('SELECT * FROM insights WHERE id = ?').get(insightId) as any
+  const after = rowToInsightShape(updated)
+
+  void recordInsightMutation({
+    timestamp: now,
+    insightId,
+    actor: req.actor,
+    reason: req.reason,
+    changes: diff(before, after),
+    context: 'POST /insights/:id/close',
   })
 
   return { success: true, insight: after }

--- a/src/server.ts
+++ b/src/server.ts
@@ -134,7 +134,7 @@ import { slotManager as canvasSlots } from './canvas-slots.js'
 import { createReflection, getReflection, listReflections, countReflections, reflectionStats, validateReflection, ROLE_TYPES, SEVERITY_LEVELS, recordReflectionDuplicate } from './reflections.js'
 import { ingestReflection, getInsight, listInsights, insightStats, INSIGHT_STATUSES, extractClusterKey, tickCooldowns, updateInsightStatus, getOrphanedInsights, reconcileInsightTaskLinks, getLoopSummary, sweepShippedCandidates } from './insights.js'
 import { queryActivity, ACTIVITY_SOURCES } from './activity.js'
-import { patchInsightById } from './insight-mutation.js'
+import { patchInsightById, cooldownInsightById, closeInsightById } from './insight-mutation.js'
 import { promoteInsight, validatePromotionInput, generateRecurringCandidates, listPromotionAudits, getPromotionAuditByInsight, type PromotionInput } from './insight-promotion.js'
 import { runIntake, batchIntake, pipelineMaintenance, getPipelineStats } from './intake-pipeline.js'
 import { listLineage, getLineage, lineageStats } from './lineage.js'
@@ -8837,6 +8837,119 @@ export async function createServer(): Promise<FastifyInstance> {
           ...(typeof metadata.cluster_key_override === 'string' ? { cluster_key_override: metadata.cluster_key_override } : {}),
         },
       } : {}),
+    })
+
+    if (!result.success) {
+      const notFound = result.error === 'Insight not found'
+      reply.code(notFound ? 404 : 400)
+      return { success: false, error: result.error }
+    }
+
+    return { success: true, insight: result.insight }
+  })
+
+  // Narrow localhost-only admin endpoints for routine hygiene: cooldown/close.
+  // These avoid enabling the broader PATCH /insights/:id mutation API.
+  app.post<{ Params: { id: string } }>('/insights/:id/cooldown', async (request, reply) => {
+    const ip = String((request as any).ip || '')
+    const isLoopback = ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1'
+    if (!isLoopback) {
+      reply.code(403)
+      return {
+        success: false,
+        error: 'Forbidden: localhost-only endpoint',
+        hint: `Request ip (${ip || 'unknown'}) is not loopback`,
+      }
+    }
+
+    const requiredToken = process.env.REFLECTT_INSIGHT_MUTATION_TOKEN
+    if (requiredToken) {
+      const raw = (request.headers as any)['x-reflectt-admin-token']
+      let provided = Array.isArray(raw) ? raw[0] : raw
+      const auth = (request.headers as any).authorization
+      if ((!provided || typeof provided !== 'string') && typeof auth === 'string' && auth.startsWith('Bearer ')) {
+        provided = auth.slice('Bearer '.length)
+      }
+
+      if (typeof provided !== 'string' || provided !== requiredToken) {
+        reply.code(403)
+        return {
+          success: false,
+          error: 'Forbidden: missing/invalid admin token',
+          hint: 'Provide x-reflectt-admin-token header (or Authorization: Bearer ...) matching REFLECTT_INSIGHT_MUTATION_TOKEN.'
+        }
+      }
+    }
+
+    const body = (request.body ?? {}) as Record<string, unknown>
+    const actor = typeof body.actor === 'string' ? body.actor : ''
+    const reason = typeof body.reason === 'string' ? body.reason : ''
+    const notes = typeof body.notes === 'string' ? body.notes : undefined
+    const cooldown_reason = typeof body.cooldown_reason === 'string' ? body.cooldown_reason : undefined
+
+    const cooldown_until = typeof body.cooldown_until === 'number' && Number.isFinite(body.cooldown_until)
+      ? body.cooldown_until
+      : (typeof body.cooldown_ms === 'number' && Number.isFinite(body.cooldown_ms)
+        ? Date.now() + Math.max(0, body.cooldown_ms)
+        : undefined)
+
+    const result = cooldownInsightById(request.params.id, {
+      actor,
+      reason,
+      ...(notes ? { notes } : {}),
+      ...(cooldown_until ? { cooldown_until } : {}),
+      ...(cooldown_reason ? { cooldown_reason } : {}),
+    })
+
+    if (!result.success) {
+      const notFound = result.error === 'Insight not found'
+      reply.code(notFound ? 404 : 400)
+      return { success: false, error: result.error }
+    }
+
+    return { success: true, insight: result.insight }
+  })
+
+  app.post<{ Params: { id: string } }>('/insights/:id/close', async (request, reply) => {
+    const ip = String((request as any).ip || '')
+    const isLoopback = ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1'
+    if (!isLoopback) {
+      reply.code(403)
+      return {
+        success: false,
+        error: 'Forbidden: localhost-only endpoint',
+        hint: `Request ip (${ip || 'unknown'}) is not loopback`,
+      }
+    }
+
+    const requiredToken = process.env.REFLECTT_INSIGHT_MUTATION_TOKEN
+    if (requiredToken) {
+      const raw = (request.headers as any)['x-reflectt-admin-token']
+      let provided = Array.isArray(raw) ? raw[0] : raw
+      const auth = (request.headers as any).authorization
+      if ((!provided || typeof provided !== 'string') && typeof auth === 'string' && auth.startsWith('Bearer ')) {
+        provided = auth.slice('Bearer '.length)
+      }
+
+      if (typeof provided !== 'string' || provided !== requiredToken) {
+        reply.code(403)
+        return {
+          success: false,
+          error: 'Forbidden: missing/invalid admin token',
+          hint: 'Provide x-reflectt-admin-token header (or Authorization: Bearer ...) matching REFLECTT_INSIGHT_MUTATION_TOKEN.'
+        }
+      }
+    }
+
+    const body = (request.body ?? {}) as Record<string, unknown>
+    const actor = typeof body.actor === 'string' ? body.actor : ''
+    const reason = typeof body.reason === 'string' ? body.reason : ''
+    const notes = typeof body.notes === 'string' ? body.notes : undefined
+
+    const result = closeInsightById(request.params.id, {
+      actor,
+      reason,
+      ...(notes ? { notes } : {}),
     })
 
     if (!result.success) {

--- a/tests/insight-local-admin.test.ts
+++ b/tests/insight-local-admin.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { createServer } from '../src/server.js'
+import { getDb } from '../src/db.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+function insertInsight(overrides: Record<string, unknown> = {}) {
+  const db = getDb()
+  const id = String(overrides.id ?? `ins-local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  const now = Date.now()
+
+  db.prepare(`
+    INSERT INTO insights (
+      id, cluster_key, workflow_stage, failure_family, impacted_unit,
+      title, status, score, priority, reflection_ids, independent_count,
+      evidence_refs, authors, promotion_readiness, recurring_candidate,
+      task_id, metadata, created_at, updated_at, cooldown_until, cooldown_reason
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    overrides.cluster_key ?? 'testing::unit::local-admin',
+    overrides.workflow_stage ?? 'testing',
+    overrides.failure_family ?? 'unit',
+    overrides.impacted_unit ?? 'local-admin',
+    overrides.title ?? 'Local admin endpoint test insight',
+    overrides.status ?? 'candidate',
+    overrides.score ?? 5,
+    overrides.priority ?? 'P2',
+    overrides.reflection_ids ?? '[]',
+    overrides.independent_count ?? 1,
+    overrides.evidence_refs ?? '[]',
+    overrides.authors ?? '["test"]',
+    overrides.promotion_readiness ?? 'not_ready',
+    overrides.recurring_candidate ?? 0,
+    overrides.task_id ?? null,
+    overrides.metadata ?? null,
+    overrides.created_at ?? now,
+    overrides.updated_at ?? now,
+    overrides.cooldown_until ?? null,
+    overrides.cooldown_reason ?? null,
+  )
+
+  return id
+}
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+beforeEach(() => {
+  const db = getDb()
+  try {
+    db.prepare('DELETE FROM insights').run()
+  } catch {
+    // ok
+  }
+})
+
+describe('Localhost-only insight hygiene endpoints', () => {
+  it('POST /insights/:id/cooldown works on loopback and sets cooldown fields', async () => {
+    const id = insertInsight()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/insights/${id}/cooldown`,
+      remoteAddress: '127.0.0.1',
+      payload: {
+        actor: 'sage',
+        reason: 'stale candidate',
+        notes: 'already fixed upstream',
+        cooldown_ms: 60_000,
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.insight.status).toBe('cooldown')
+    expect(typeof body.insight.cooldown_until).toBe('number')
+    expect(body.insight.cooldown_until).toBeGreaterThan(Date.now() - 5_000)
+    expect(body.insight.cooldown_reason).toContain('stale candidate')
+  })
+
+  it('POST /insights/:id/close works on loopback', async () => {
+    const id = insertInsight()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/insights/${id}/close`,
+      remoteAddress: '127.0.0.1',
+      payload: {
+        actor: 'sage',
+        reason: 'duplicate/noisy',
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.insight.status).toBe('closed')
+  })
+
+  it('rejects non-loopback callers (403)', async () => {
+    const id = insertInsight()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/insights/${id}/close`,
+      remoteAddress: '10.0.0.2',
+      payload: {
+        actor: 'sage',
+        reason: 'should fail',
+      },
+    })
+
+    expect(res.statusCode).toBe(403)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(false)
+    expect(String(body.error)).toMatch(/localhost-only/i)
+  })
+})


### PR DESCRIPTION
Fixes task-1772810491278-0pfupmpad.

Why:
- PATCH /insights/:id mutation API is gated behind REFLECTT_ENABLE_INSIGHT_MUTATION_API, which blocks routine operator hygiene (cooldown/close stale candidates).

What:
- Add narrow, loopback-only endpoints:
  - POST /insights/:id/cooldown (defaults to 14d; optional cooldown_ms/cooldown_until/cooldown_reason/notes)
  - POST /insights/:id/close (optional notes)
- If REFLECTT_INSIGHT_MUTATION_TOKEN is set, require x-reflectt-admin-token (or Authorization: Bearer ...).
- Extend insight-mutation audit diff to include cooldown fields.
- Docs: docs/GETTING-STARTED.md.

Proof:
- npx vitest run tests/insight-local-admin.test.ts