### PR TITLE
feat: team focus directive — priority anchor for heartbeats

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -387,6 +387,9 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/focus` | Current team focus directive (included in heartbeat) |
+| POST | `/focus` | Set team focus. Body: `{ "directive": "...", "setBy": "kai", "expiresAt?": 1234, "tags?": ["shipping"] }` |
+| DELETE | `/focus` | Clear team focus |
 | GET | `/presence` | All agents' presence |
 | GET | `/presence/:agent` | Single agent presence |
 | POST | `/presence/:agent` | Update presence. Body: `{ "status": "working|idle|blocked|reviewing|offline" }` |

--- a/src/db.ts
+++ b/src/db.ts
@@ -502,6 +502,16 @@ export function runMigrations(db: Database.Database): void {
         ALTER TABLE chat_messages ADD COLUMN attachments TEXT;
       `,
     },
+    {
+      version: 19,
+      sql: `
+        -- Team-level focus directive (priority anchor for heartbeats)
+        CREATE TABLE IF NOT EXISTS kv (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+      `,
+    },
   ]
 
   const insertMigration = db.prepare('INSERT INTO _migrations (version) VALUES (?)')
@@ -535,6 +545,7 @@ export function runMigrations(db: Database.Database): void {
     { version: 15, tables: ['context_memos'] },
     { version: 16, tables: ['hosts'] },
     { version: 17, tables: ['system_loop_ticks'] },
+    { version: 19, tables: ['kv'] },
   ]
 
   const existingTables = new Set(

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Team Focus — Priority Anchor
+ *
+ * Prevents context/priority drift between agent sessions.
+ * The team lead (or any agent) sets the current focus directive,
+ * and it's surfaced in every heartbeat response so agents wake up
+ * knowing what matters RIGHT NOW.
+ *
+ * Addresses insight ins-1771941663932-11l8qifnl:
+ * "Context and priorities drift between pushes"
+ */
+
+import { getDb } from './db.js'
+
+export interface TeamFocus {
+  directive: string          // e.g. "Features over fixes. Activity timeline is P0."
+  setBy: string              // agent or human who set it
+  setAt: number              // timestamp
+  expiresAt?: number | null  // optional auto-expire (e.g. end of day)
+  tags?: string[]            // optional categorization
+}
+
+const DB_KEY = 'team_focus'
+
+function db() {
+  return getDb()
+}
+
+export function getFocus(): TeamFocus | null {
+  const row = db().prepare('SELECT value FROM kv WHERE key = ?').get(DB_KEY) as { value: string } | undefined
+  if (!row) return null
+
+  try {
+    const focus = JSON.parse(row.value) as TeamFocus
+    // Check expiry
+    if (focus.expiresAt && Date.now() > focus.expiresAt) {
+      clearFocus()
+      return null
+    }
+    return focus
+  } catch {
+    return null
+  }
+}
+
+export function setFocus(directive: string, setBy: string, opts?: { expiresAt?: number; tags?: string[] }): TeamFocus {
+  const focus: TeamFocus = {
+    directive: directive.trim(),
+    setBy,
+    setAt: Date.now(),
+    expiresAt: opts?.expiresAt ?? null,
+    tags: opts?.tags,
+  }
+
+  db().prepare('INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)').run(DB_KEY, JSON.stringify(focus))
+  return focus
+}
+
+export function clearFocus(): void {
+  db().prepare('DELETE FROM kv WHERE key = ?').run(DB_KEY)
+}
+
+/** Compact summary for heartbeat inclusion (minimal tokens) */
+export function getFocusSummary(): { focus: string; setBy: string; setAt: number } | null {
+  const f = getFocus()
+  if (!f) return null
+  return { focus: f.directive, setBy: f.setBy, setAt: f.setAt }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import { chatManager } from './chat.js'
 import { taskManager } from './tasks.js'
 import { detectApproval, applyApproval } from './chat-approval-detector.js'
 import { inboxManager } from './inbox.js'
+import { getFocus, setFocus, clearFocus, getFocusSummary } from './focus.js'
 import { getDb } from './db.js'
 import type { AgentMessage, Task } from './types.js'
 import { isTestHarnessTask } from './test-task-filter.js'
@@ -9838,12 +9839,15 @@ export async function createServer(): Promise<FastifyInstance> {
     const allDrops = chatManager.getDropStats()
     const agentDrops = allDrops[agent]
 
+    const focusSummary = getFocusSummary()
+
     return {
       agent, ts: Date.now(),
       active: slim(activeTask), next: pauseStatus.paused ? null : slim(nextTask),
       inbox: slimInbox, inboxCount: inbox.length,
       queue: { todo: todoTasks.length, doing: doingTasks.length, validating: validatingTasks.length },
       intensity: { preset: intensity.preset, pullsRemaining: pullBudget.remaining, wipLimit: intensity.limits.wipLimit },
+      ...(focusSummary ? { focus: focusSummary } : {}),
       ...(agentDrops ? { drops: { total: agentDrops.total, rolling_1h: agentDrops.rolling_1h } } : {}),
       ...(pauseStatus.paused ? { paused: true, pauseMessage: pauseStatus.message, resumesAt: pauseStatus.entry?.pausedUntil ?? null } : {}),
       action: pauseStatus.paused ? `PAUSED: ${pauseStatus.message}`
@@ -10510,6 +10514,29 @@ If your heartbeat shows **no active task** and **no next task**:
     } catch (err: any) {
       return { success: false, error: err.message }
     }
+  })
+
+  // ── Team Focus ─────────────────────────────────────────────────────
+  // GET /focus — current team focus directive
+  app.get('/focus', async () => {
+    const focus = getFocus()
+    return focus ? { focus } : { focus: null, message: 'No focus set. Use POST /focus to set one.' }
+  })
+
+  // POST /focus — set team focus directive
+  app.post<{ Body: { directive: string; setBy: string; expiresAt?: number; tags?: string[] } }>('/focus', async (request) => {
+    const { directive, setBy, expiresAt, tags } = request.body || {} as any
+    if (!directive || !setBy) {
+      return { success: false, error: 'Required: directive, setBy' }
+    }
+    const focus = setFocus(directive, setBy, { expiresAt, tags })
+    return { success: true, focus }
+  })
+
+  // DELETE /focus — clear team focus
+  app.delete('/focus', async () => {
+    clearFocus()
+    return { success: true, message: 'Focus cleared' }
   })
 
   // Get all agent presences

--- a/tests/focus.test.ts
+++ b/tests/focus.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getFocus, setFocus, clearFocus, getFocusSummary } from '../src/focus.js'
+
+describe('Team Focus', () => {
+  beforeEach(() => {
+    clearFocus()
+  })
+
+  it('returns null when no focus is set', () => {
+    expect(getFocus()).toBeNull()
+    expect(getFocusSummary()).toBeNull()
+  })
+
+  it('sets and retrieves focus', () => {
+    const focus = setFocus('Features over fixes. Activity timeline is P0.', 'kai')
+    expect(focus.directive).toBe('Features over fixes. Activity timeline is P0.')
+    expect(focus.setBy).toBe('kai')
+    expect(focus.setAt).toBeGreaterThan(0)
+
+    const retrieved = getFocus()
+    expect(retrieved).not.toBeNull()
+    expect(retrieved!.directive).toBe('Features over fixes. Activity timeline is P0.')
+  })
+
+  it('returns compact summary for heartbeat', () => {
+    setFocus('Ship activity timeline', 'ryan', { tags: ['shipping'] })
+    const summary = getFocusSummary()
+    expect(summary).not.toBeNull()
+    expect(summary!.focus).toBe('Ship activity timeline')
+    expect(summary!.setBy).toBe('ryan')
+    expect(summary!.setAt).toBeGreaterThan(0)
+    // Summary should NOT include tags/expiresAt (minimal tokens)
+    expect((summary as any).tags).toBeUndefined()
+  })
+
+  it('clears focus', () => {
+    setFocus('Test directive', 'kai')
+    expect(getFocus()).not.toBeNull()
+    clearFocus()
+    expect(getFocus()).toBeNull()
+  })
+
+  it('expires focus when past expiresAt', () => {
+    setFocus('Expired directive', 'kai', { expiresAt: Date.now() - 1000 })
+    expect(getFocus()).toBeNull() // Should auto-clear
+  })
+
+  it('keeps focus when not yet expired', () => {
+    setFocus('Active directive', 'kai', { expiresAt: Date.now() + 60_000 })
+    const focus = getFocus()
+    expect(focus).not.toBeNull()
+    expect(focus!.directive).toBe('Active directive')
+  })
+
+  it('overwrites previous focus', () => {
+    setFocus('Old focus', 'kai')
+    setFocus('New focus', 'ryan')
+    const focus = getFocus()
+    expect(focus!.directive).toBe('New focus')
+    expect(focus!.setBy).toBe('ryan')
+  })
+})


### PR DESCRIPTION
## What
Adds `/focus` endpoints + includes team focus in heartbeat responses.

## Why
Insight ins-1771941663932-11l8qifnl: Context and priorities drift between pushes. Agents wake up and see their individual task but don't see the team-level priority.

## How
- `GET /focus` — current team directive
- `POST /focus` — set directive
- `DELETE /focus` — clear
- Heartbeat response now includes `focus` field when set
- Auto-expires past `expiresAt`
- DB migration v19: kv table

## Tests
7 new tests, full suite passes (1710/1710).

Task: task-1772633236872-uy3fb2bxa