### PR TITLE
feat: GET /pulse — team pulse snapshot endpoint

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -387,6 +387,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET | `/pulse` | Team pulse snapshot: board counts + per-agent doing tasks + pending reviews + focus. Use `?compact=true` for <2000 char version |
 | GET | `/focus` | Current team focus directive (included in heartbeat) |
 | POST | `/focus` | Set team focus. Body: `{ "directive": "...", "setBy": "kai", "expiresAt?": 1234, "tags?": ["shipping"] }` |
 | DELETE | `/focus` | Clear team focus |

--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Team Pulse — Single canonical snapshot of team state.
+ *
+ * Replaces ad-hoc "status NOW" pings in chat. One endpoint,
+ * everything a team lead needs to know at a glance.
+ *
+ * GET /pulse          — full snapshot
+ * GET /pulse?compact=true — <2000 chars, optimized for heartbeat context
+ */
+
+import { taskManager } from './tasks.js'
+import { presenceManager } from './presence.js'
+import { chatManager } from './chat.js'
+import { getFocusSummary } from './focus.js'
+import type { Task } from './types.js'
+
+export interface PulseAgent {
+  agent: string
+  status: string
+  doingTask?: { id: string; title: string; priority?: string } | null
+  lastActive?: number
+}
+
+export interface PulseSnapshot {
+  ts: number
+  deploy?: { version?: string; commit?: string; pid?: number; startedAt?: number }
+  focus?: { focus: string; setBy: string; setAt: number } | null
+  board: { todo: number; doing: number; validating: number; done: number; blocked: number }
+  agents: PulseAgent[]
+  pendingReviews: Array<{ taskId: string; title: string; reviewer: string }>
+  recentActivity?: { messagesLastHour: number; tasksCompletedToday: number }
+}
+
+export interface CompactPulse {
+  ts: number
+  focus?: string | null
+  board: string  // e.g. "T:3 D:2 V:1 ✓:5 B:0"
+  agents: string[] // e.g. ["link:working→task-123(activity endpoint)", "pixel:working→task-456(UI scaffold)"]
+  reviews: string[] // e.g. ["task-789→sage"]
+}
+
+function getDeployInfo(): PulseSnapshot['deploy'] {
+  try {
+    const buildInfo = require('./buildInfo.js')
+    return {
+      version: buildInfo.version || process.env.npm_package_version,
+      commit: buildInfo.commit,
+      pid: process.pid,
+      startedAt: buildInfo.startedAt,
+    }
+  } catch {
+    return { pid: process.pid }
+  }
+}
+
+export function generatePulse(): PulseSnapshot {
+  const allTasks = taskManager.listTasks({})
+  const todoCount = allTasks.filter(t => t.status === 'todo').length
+  const doingCount = allTasks.filter(t => t.status === 'doing').length
+  const validatingCount = allTasks.filter(t => t.status === 'validating').length
+  const doneCount = allTasks.filter(t => t.status === 'done').length
+  const blockedCount = allTasks.filter(t => t.status === 'blocked').length
+
+  const doingTasks = allTasks.filter(t => t.status === 'doing')
+  const validatingTasks = allTasks.filter(t => t.status === 'validating')
+
+  // Build per-agent state
+  const presences = presenceManager.getAllPresence()
+  const agents: PulseAgent[] = presences.map(p => {
+    const agentDoingTask = doingTasks.find(t =>
+      (t.assignee || '').toLowerCase() === p.agent.toLowerCase()
+    )
+    return {
+      agent: p.agent,
+      status: p.status || 'unknown',
+      doingTask: agentDoingTask ? {
+        id: agentDoingTask.id,
+        title: agentDoingTask.title,
+        priority: agentDoingTask.priority,
+      } : null,
+      lastActive: p.last_active || p.lastUpdate,
+    }
+  })
+
+  // Pending reviews
+  const pendingReviews = validatingTasks
+    .filter(t => t.reviewer)
+    .map(t => ({
+      taskId: t.id,
+      title: t.title,
+      reviewer: t.reviewer!,
+    }))
+
+  // Recent activity counts
+  const oneHourAgo = Date.now() - (60 * 60 * 1000)
+  const todayStart = new Date()
+  todayStart.setHours(0, 0, 0, 0)
+
+  const recentMessages = chatManager.getMessages({ since: oneHourAgo })
+  const tasksCompletedToday = allTasks.filter(t =>
+    t.status === 'done' && (t.updatedAt || 0) >= todayStart.getTime()
+  ).length
+
+  return {
+    ts: Date.now(),
+    deploy: getDeployInfo(),
+    focus: getFocusSummary(),
+    board: { todo: todoCount, doing: doingCount, validating: validatingCount, done: doneCount, blocked: blockedCount },
+    agents,
+    pendingReviews,
+    recentActivity: {
+      messagesLastHour: recentMessages.length,
+      tasksCompletedToday,
+    },
+  }
+}
+
+export function generateCompactPulse(): CompactPulse {
+  const pulse = generatePulse()
+
+  const boardStr = `T:${pulse.board.todo} D:${pulse.board.doing} V:${pulse.board.validating} ✓:${pulse.board.done} B:${pulse.board.blocked}`
+
+  const agentStrs = pulse.agents
+    .filter(a => a.status !== 'offline' && a.agent !== 'user')
+    .map(a => {
+      const taskInfo = a.doingTask
+        ? `→${a.doingTask.id.slice(-12)}(${(a.doingTask.title || '').slice(0, 30)})`
+        : '→idle'
+      return `${a.agent}:${a.status}${taskInfo}`
+    })
+
+  const reviewStrs = pulse.pendingReviews.map(r =>
+    `${r.taskId.slice(-12)}→${r.reviewer}`
+  )
+
+  return {
+    ts: pulse.ts,
+    focus: pulse.focus?.focus || null,
+    board: boardStr,
+    agents: agentStrs,
+    reviews: reviewStrs,
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import { taskManager } from './tasks.js'
 import { detectApproval, applyApproval } from './chat-approval-detector.js'
 import { inboxManager } from './inbox.js'
 import { getFocus, setFocus, clearFocus, getFocusSummary } from './focus.js'
+import { generatePulse, generateCompactPulse } from './pulse.js'
 import { getDb } from './db.js'
 import type { AgentMessage, Task } from './types.js'
 import { isTestHarnessTask } from './test-task-filter.js'
@@ -10514,6 +10515,15 @@ If your heartbeat shows **no active task** and **no next task**:
     } catch (err: any) {
       return { success: false, error: err.message }
     }
+  })
+
+  // ── Team Pulse ─────────────────────────────────────────────────────
+  app.get<{ Querystring: { compact?: string } }>('/pulse', async (request) => {
+    const compact = request.query.compact === 'true' || request.query.compact === '1'
+    if (compact) {
+      return generateCompactPulse()
+    }
+    return generatePulse()
   })
 
   // ── Team Focus ─────────────────────────────────────────────────────

--- a/tests/pulse.test.ts
+++ b/tests/pulse.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+import { describe, it, expect } from 'vitest'
+import { generatePulse, generateCompactPulse } from '../src/pulse.js'
+
+describe('Team Pulse', () => {
+  it('returns a valid pulse snapshot', () => {
+    const pulse = generatePulse()
+    expect(pulse.ts).toBeGreaterThan(0)
+    expect(pulse.board).toBeDefined()
+    expect(typeof pulse.board.todo).toBe('number')
+    expect(typeof pulse.board.doing).toBe('number')
+    expect(typeof pulse.board.validating).toBe('number')
+    expect(typeof pulse.board.done).toBe('number')
+    expect(typeof pulse.board.blocked).toBe('number')
+    expect(Array.isArray(pulse.agents)).toBe(true)
+    expect(Array.isArray(pulse.pendingReviews)).toBe(true)
+    expect(pulse.deploy).toBeDefined()
+    expect(typeof pulse.deploy!.pid).toBe('number')
+  })
+
+  it('returns recentActivity with message and task counts', () => {
+    const pulse = generatePulse()
+    expect(pulse.recentActivity).toBeDefined()
+    expect(typeof pulse.recentActivity!.messagesLastHour).toBe('number')
+    expect(typeof pulse.recentActivity!.tasksCompletedToday).toBe('number')
+  })
+
+  it('compact pulse is under 2000 chars', () => {
+    const compact = generateCompactPulse()
+    const serialized = JSON.stringify(compact)
+    expect(serialized.length).toBeLessThan(2000)
+    expect(compact.ts).toBeGreaterThan(0)
+    expect(typeof compact.board).toBe('string')
+    expect(compact.board).toMatch(/T:\d+ D:\d+ V:\d+ ✓:\d+ B:\d+/)
+    expect(Array.isArray(compact.agents)).toBe(true)
+    expect(Array.isArray(compact.reviews)).toBe(true)
+  })
+
+  it('compact pulse includes focus when set', () => {
+    // Focus may or may not be set in test environment
+    const compact = generateCompactPulse()
+    expect('focus' in compact).toBe(true)
+    // focus is either a string or null
+    expect(compact.focus === null || typeof compact.focus === 'string').toBe(true)
+  })
+
+  it('agents array includes status and optional doingTask', () => {
+    const pulse = generatePulse()
+    for (const agent of pulse.agents) {
+      expect(agent.agent).toBeDefined()
+      expect(typeof agent.status).toBe('string')
+      // doingTask is either null or has id+title
+      if (agent.doingTask) {
+        expect(agent.doingTask.id).toBeDefined()
+        expect(agent.doingTask.title).toBeDefined()
+      }
+    }
+  })
+
+  it('pendingReviews includes taskId, title, and reviewer', () => {
+    const pulse = generatePulse()
+    for (const review of pulse.pendingReviews) {
+      expect(review.taskId).toBeDefined()
+      expect(review.title).toBeDefined()
+      expect(review.reviewer).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## What
`GET /pulse` returns a single canonical snapshot of team state. `?compact=true` for <2000 chars.

## Why
Task task-1772779963844: stop status storms. Instead of pinging every agent, check `/pulse`.

## What's in it
- Board counts (todo/doing/validating/done/blocked)
- Per-agent status + current doing task
- Pending reviews (who needs to review what)
- Team focus directive
- Deploy info (version/commit/pid)
- Recent activity (messages last hour, tasks completed today)

## Tests
6 new, 1716/1716 suite green.