### PR TITLE
feat: POST /scope-overlap — flag open tasks when PR merges on same scope

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -388,6 +388,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/pulse` | Team pulse snapshot: board counts + per-agent doing tasks + pending reviews + focus. Use `?compact=true` for <2000 char version |
+| POST | `/scope-overlap` | Scan for task scope overlap after PR merge. Body: `{ "prNumber": 707, "prTitle": "...", "prBranch": "kai/task-...", "mergedTaskId?": "...", "notify?": true }` |
 | GET | `/focus` | Current team focus directive (included in heartbeat) |
 | POST | `/focus` | Set team focus. Body: `{ "directive": "...", "setBy": "kai", "expiresAt?": 1234, "tags?": ["shipping"] }` |
 | DELETE | `/focus` | Clear team focus |

--- a/src/scopeOverlap.ts
+++ b/src/scopeOverlap.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Scope Overlap Scanner
+ *
+ * When a PR merges, scans open tasks (doing/todo) for scope overlap:
+ * - Branch name similarity
+ * - Title keyword overlap
+ * - Linked insight_id match
+ *
+ * Flags matches so assignees can confirm or close superseded work.
+ * Prevents the parallel collision pattern (PR #582/#583 incident).
+ */
+
+import { taskManager } from './tasks.js'
+import { chatManager } from './chat.js'
+import type { Task } from './types.js'
+
+export interface ScopeOverlapMatch {
+  taskId: string
+  taskTitle: string
+  assignee: string
+  matchReason: string
+  confidence: 'high' | 'medium' | 'low'
+}
+
+export interface ScopeOverlapResult {
+  mergedPr: { number: number; title: string; branch: string; repo?: string }
+  mergedTaskId?: string
+  matches: ScopeOverlapMatch[]
+  scanned: number
+}
+
+/**
+ * Extract meaningful keywords from a string (title, branch name).
+ * Strips common prefixes, splits on delimiters, lowercases.
+ */
+function extractKeywords(text: string): Set<string> {
+  // Common noise words to filter out
+  const noise = new Set([
+    'feat', 'fix', 'chore', 'docs', 'test', 'refactor', 'style',
+    'the', 'a', 'an', 'in', 'on', 'for', 'to', 'of', 'and', 'or',
+    'add', 'update', 'remove', 'with', 'from', 'is', 'task', 'pr',
+  ])
+
+  const words = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 2 && !noise.has(w))
+
+  return new Set(words)
+}
+
+/**
+ * Calculate keyword overlap ratio between two sets.
+ * Returns 0-1 (proportion of smaller set matched).
+ */
+function keywordOverlap(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0
+  let matches = 0
+  const smaller = a.size <= b.size ? a : b
+  const larger = a.size > b.size ? a : b
+  for (const word of smaller) {
+    if (larger.has(word)) matches++
+  }
+  return matches / smaller.size
+}
+
+/**
+ * Extract branch name from task metadata or infer from task ID.
+ */
+function getTaskBranch(task: Task): string | null {
+  const meta = task.metadata || {}
+  if (typeof meta.branch === 'string') return meta.branch
+  if (typeof meta.pr_branch === 'string') return meta.pr_branch
+  return null
+}
+
+/**
+ * Extract insight_id from task metadata.
+ */
+function getInsightId(task: Task): string | null {
+  const meta = task.metadata || {}
+  if (typeof meta.insight_id === 'string') return meta.insight_id
+  return null
+}
+
+/**
+ * Scan open tasks for scope overlap with a merged PR.
+ */
+export function scanScopeOverlap(
+  prNumber: number,
+  prTitle: string,
+  prBranch: string,
+  mergedTaskId?: string,
+  repo?: string,
+): ScopeOverlapResult {
+  const openTasks = [
+    ...taskManager.listTasks({ status: 'doing' }),
+    ...taskManager.listTasks({ status: 'todo' }),
+  ]
+
+  // Get the merged task's insight_id for cross-reference
+  let mergedInsightId: string | null = null
+  if (mergedTaskId) {
+    const mergedTask = taskManager.getTask(mergedTaskId)
+    if (mergedTask) {
+      mergedInsightId = getInsightId(mergedTask)
+    }
+  }
+
+  const prKeywords = extractKeywords(`${prTitle} ${prBranch}`)
+  const matches: ScopeOverlapMatch[] = []
+
+  for (const task of openTasks) {
+    // Skip the task that owns the merged PR
+    if (task.id === mergedTaskId) continue
+
+    const reasons: string[] = []
+    let confidence: 'high' | 'medium' | 'low' = 'low'
+
+    // 1. Insight ID match (highest confidence)
+    const taskInsightId = getInsightId(task)
+    if (mergedInsightId && taskInsightId && mergedInsightId === taskInsightId) {
+      reasons.push(`same insight: ${mergedInsightId}`)
+      confidence = 'high'
+    }
+
+    // 2. Branch name match
+    const taskBranch = getTaskBranch(task)
+    if (taskBranch && prBranch) {
+      const branchKeywords = extractKeywords(taskBranch)
+      const branchOverlap = keywordOverlap(extractKeywords(prBranch), branchKeywords)
+      if (branchOverlap >= 0.4) {
+        reasons.push(`branch overlap: ${prBranch} ↔ ${taskBranch}`)
+        confidence = confidence === 'high' ? 'high' : 'medium'
+      }
+    }
+
+    // 3. Title keyword overlap
+    const taskKeywords = extractKeywords(task.title)
+    const titleOverlap = keywordOverlap(prKeywords, taskKeywords)
+    if (titleOverlap >= 0.5) {
+      reasons.push(`title overlap (${Math.round(titleOverlap * 100)}%)`)
+      if (titleOverlap >= 0.7) {
+        confidence = confidence === 'high' ? 'high' : 'medium'
+      }
+    }
+
+    if (reasons.length > 0) {
+      matches.push({
+        taskId: task.id,
+        taskTitle: task.title,
+        assignee: task.assignee || 'unassigned',
+        matchReason: reasons.join('; '),
+        confidence,
+      })
+    }
+  }
+
+  // Sort: high confidence first
+  const order: Record<string, number> = { high: 0, medium: 1, low: 2 }
+  matches.sort((a, b) => order[a.confidence] - order[b.confidence])
+
+  return {
+    mergedPr: { number: prNumber, title: prTitle, branch: prBranch, repo },
+    mergedTaskId,
+    matches,
+    scanned: openTasks.length,
+  }
+}
+
+/**
+ * Scan and notify: run scope overlap scan and post results to chat.
+ * Only posts when medium+ confidence matches are found.
+ */
+export async function scanAndNotify(
+  prNumber: number,
+  prTitle: string,
+  prBranch: string,
+  mergedTaskId?: string,
+  repo?: string,
+): Promise<ScopeOverlapResult> {
+  const result = scanScopeOverlap(prNumber, prTitle, prBranch, mergedTaskId, repo)
+
+  const significant = result.matches.filter(m => m.confidence !== 'low')
+  if (significant.length === 0) return result
+
+  // Build notification message
+  const lines = [
+    `⚠️ **Scope overlap detected** after PR #${prNumber} merged ("${prTitle}")`,
+  ]
+
+  for (const match of significant) {
+    const mention = match.assignee !== 'unassigned' ? `@${match.assignee}` : 'unassigned'
+    lines.push(
+      `- ${mention}: **${match.taskTitle}** (${match.taskId}) — ${match.matchReason} [${match.confidence}]`,
+    )
+  }
+
+  lines.push('', 'If your task is superseded by this PR, close it. If it\'s still needed, confirm and continue.')
+
+  await chatManager.sendMessage({
+    from: 'system',
+    content: lines.join('\n'),
+    channel: 'general',
+  })
+
+  return result
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { detectApproval, applyApproval } from './chat-approval-detector.js'
 import { inboxManager } from './inbox.js'
 import { getFocus, setFocus, clearFocus, getFocusSummary } from './focus.js'
 import { generatePulse, generateCompactPulse } from './pulse.js'
+import { scanScopeOverlap, scanAndNotify } from './scopeOverlap.js'
 import { getDb } from './db.js'
 import type { AgentMessage, Task } from './types.js'
 import { isTestHarnessTask } from './test-task-filter.js'
@@ -10524,6 +10525,21 @@ If your heartbeat shows **no active task** and **no next task**:
       return generateCompactPulse()
     }
     return generatePulse()
+  })
+
+  // ── Scope Overlap Scanner ──────────────────────────────────────────
+  // POST /scope-overlap — trigger scope overlap scan after a PR merge
+  app.post<{ Body: { prNumber: number; prTitle: string; prBranch: string; mergedTaskId?: string; repo?: string; notify?: boolean } }>('/scope-overlap', async (request) => {
+    const { prNumber, prTitle, prBranch, mergedTaskId, repo, notify } = request.body || {} as any
+    if (!prNumber || !prTitle || !prBranch) {
+      return { success: false, error: 'Required: prNumber, prTitle, prBranch' }
+    }
+    if (notify !== false) {
+      const result = await scanAndNotify(prNumber, prTitle, prBranch, mergedTaskId, repo)
+      return { success: true, ...result }
+    }
+    const result = scanScopeOverlap(prNumber, prTitle, prBranch, mergedTaskId, repo)
+    return { success: true, ...result }
   })
 
   // ── Team Focus ─────────────────────────────────────────────────────

--- a/tests/scopeOverlap.test.ts
+++ b/tests/scopeOverlap.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { scanScopeOverlap } from '../src/scopeOverlap.js'
+import { taskManager } from '../src/tasks.js'
+
+const BASE_TASK = {
+  createdBy: 'test',
+  done_criteria: ['Test criterion'],
+}
+
+describe('Scope Overlap Scanner', () => {
+  beforeEach(() => {
+    const all = taskManager.listTasks({})
+    for (const t of all) {
+      taskManager.deleteTask(t.id)
+    }
+  })
+
+  it('returns empty matches when no open tasks exist', () => {
+    const result = scanScopeOverlap(100, 'feat: add pulse endpoint', 'kai/pulse-endpoint')
+    expect(result.matches).toHaveLength(0)
+    expect(result.scanned).toBe(0)
+  })
+
+  it('detects title keyword overlap', async () => {
+    await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Add pulse endpoint for team status',
+      assignee: 'link',
+      status: 'todo',
+    })
+
+    const result = scanScopeOverlap(100, 'feat: pulse endpoint implementation', 'kai/pulse-endpoint')
+    expect(result.matches.length).toBeGreaterThan(0)
+    expect(result.matches[0].assignee).toBe('link')
+    expect(result.matches[0].matchReason).toContain('title overlap')
+  })
+
+  it('detects branch name overlap', async () => {
+    const task = await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Unrelated task title here',
+      assignee: 'pixel',
+      status: 'todo',
+      metadata: { branch: 'pixel/activity-timeline-ui-scaffold' },
+    })
+
+    const result = scanScopeOverlap(200, 'feat: activity timeline', 'link/activity-timeline-backend')
+    const match = result.matches.find(m => m.taskId === task.id)
+    expect(match).toBeDefined()
+    expect(match!.matchReason).toContain('branch overlap')
+  })
+
+  it('detects insight_id match with high confidence', async () => {
+    const mergedTask = await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Fix deployment drift merged version',
+      assignee: 'kai',
+      status: 'todo',
+      metadata: { insight_id: 'ins-123' },
+    })
+
+    await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Different title entirely unique',
+      assignee: 'echo',
+      status: 'todo',
+      metadata: { insight_id: 'ins-123' },
+    })
+
+    const result = scanScopeOverlap(300, 'fix: deployment drift', 'kai/fix-drift', mergedTask.id)
+    const match = result.matches.find(m => m.assignee === 'echo')
+    expect(match).toBeDefined()
+    expect(match!.confidence).toBe('high')
+    expect(match!.matchReason).toContain('same insight')
+  })
+
+  it('skips the merged task itself', async () => {
+    const task = await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'This task owns the merged PR exactly',
+      assignee: 'kai',
+      status: 'todo',
+    })
+
+    const result = scanScopeOverlap(400, 'This task owns the merged PR exactly', 'kai/owns-pr', task.id)
+    expect(result.matches.find(m => m.taskId === task.id)).toBeUndefined()
+  })
+
+  it('does not match unrelated tasks', async () => {
+    await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Fix billing webhook retry logic',
+      assignee: 'link',
+      status: 'todo',
+    })
+
+    const result = scanScopeOverlap(500, 'feat: activity timeline endpoint', 'kai/activity-timeline')
+    expect(result.matches).toHaveLength(0)
+  })
+
+  it('sorts matches by confidence (high first)', async () => {
+    const mergedTask = await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Original task implementation base',
+      assignee: 'kai',
+      status: 'todo',
+      metadata: { insight_id: 'ins-456' },
+    })
+
+    await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'High confidence same insight task',
+      assignee: 'echo',
+      status: 'todo',
+      metadata: { insight_id: 'ins-456' },
+    })
+
+    await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Original task duplicate implementation base',
+      assignee: 'link',
+      status: 'todo',
+    })
+
+    const result = scanScopeOverlap(600, 'Original task implementation base', 'kai/original-task', mergedTask.id)
+    if (result.matches.length >= 2) {
+      expect(result.matches[0].confidence).toBe('high')
+    }
+  })
+
+  it('includes todo tasks in scan', async () => {
+    await taskManager.createTask({
+      ...BASE_TASK,
+      title: 'Add pulse snapshot feature endpoint',
+      assignee: 'rhythm',
+      status: 'todo',
+    })
+
+    const result = scanScopeOverlap(700, 'feat: pulse snapshot endpoint', 'kai/pulse-snapshot')
+    expect(result.matches.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What
POST /scope-overlap scans open tasks for scope overlap after a PR merge.

## Why  
Task task-1772638419718: prevents parallel collision. Two agents working on the same thing independently (like the X posting incident today).

## How
Matches by title keywords, branch name, and insight_id. Posts chat notification for medium+ confidence matches.

## Tests
8 new, 1724/1724 suite green.