### PR TITLE
fix: pulse ESM import + /capabilities registration

### DIFF
--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -15,6 +15,7 @@ import { taskManager } from './tasks.js'
 import { presenceManager } from './presence.js'
 import { chatManager } from './chat.js'
 import { getFocusSummary } from './focus.js'
+import { getBuildInfo } from './buildInfo.js'
 import type { Task } from './types.js'
 
 export interface PulseAgent {
@@ -44,12 +45,12 @@ export interface CompactPulse {
 
 function getDeployInfo(): PulseSnapshot['deploy'] {
   try {
-    const buildInfo = require('./buildInfo.js')
+    const info = getBuildInfo()
     return {
-      version: buildInfo.version || process.env.npm_package_version,
-      commit: buildInfo.commit,
+      version: info.appVersion || process.env.npm_package_version,
+      commit: info.gitShortSha || info.gitSha,
       pid: process.pid,
-      startedAt: buildInfo.startedAt,
+      startedAt: info.startedAtMs,
     }
   } catch {
     return { pid: process.pid }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10015,6 +10015,7 @@ If your heartbeat shows **no active task** and **no next task**:
         description: 'System health and discovery',
         endpoints: [
           { method: 'GET', path: '/health', hint: 'System health + version + stats' },
+          { method: 'GET', path: '/pulse', compact: true, hint: 'Team pulse snapshot: deploy + board + per-agent doing + reviews. Query: compact' },
           { method: 'GET', path: '/capabilities', hint: 'This endpoint. Query: category to filter' },
           { method: 'GET', path: '/me/:agent', compact: true, hint: 'Full dashboard. Use /heartbeat/:agent for polls.' },
           { method: 'GET', path: '/docs', hint: 'Full API reference (68K chars). Use /capabilities instead when possible.' },


### PR DESCRIPTION
Follow-up to PR #707 — addresses Sage's review feedback on task-1772779963844-jp07z3k24:

1. **ESM fix**: Replaced `require('./buildInfo.js')` with proper ESM `import { getBuildInfo } from './buildInfo.js'` — avoids the same class of ESM/require bugs that hit alert-preflight.
2. **Capabilities**: Added `GET /pulse` to `/capabilities` system category so endpoint is discoverable.
3. **Test**: Compact output <2000 chars test already existed and passes (6/6 ✅).

All tests pass, clean tsc compile.