### PR TITLE
fix(sweeper): don't treat done tasks as PR Issues in digest

### DIFF
--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -586,11 +586,17 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
   }
 
   // ── Orphan PR detection ──────────────────────────────────────────────
-  // Scan all tasks with PR URLs where the task is done/cancelled but the PR
-  // was linked — these represent potential orphan open PRs
+  // Scan tasks with PR URLs where the task is cancelled (not done) but a PR
+  // was linked — these represent potential orphan open PRs.
+  //
+  // Note: We intentionally DO NOT scan `status=done` here.
+  // In practice, done tasks often have incomplete PR metadata (e.g. missing
+  // `pr_merged`), and relying on metadata-only checks creates noisy false
+  // positives that spam the sweeper digest. Live PR checks require `gh` and
+  // are intentionally avoided in the periodic sweep (execSync blocks).
+  // Use /drift-report for deeper investigation.
   const cancelledTasks = taskManager.listTasks({ status: 'cancelled' })
-  const doneAndCancelled = [...doneTasks, ...cancelledTasks]
-  for (const task of doneAndCancelled) {
+  for (const task of cancelledTasks) {
     const meta = (task.metadata || {}) as Record<string, unknown>
     const prUrl = extractPrUrl(meta)
     if (!prUrl || flaggedOrphanPRs.has(prUrl)) continue

--- a/tests/execution-sweeper.test.ts
+++ b/tests/execution-sweeper.test.ts
@@ -184,6 +184,45 @@ describe('Orphan PR detection accuracy', () => {
     expect(orphanForThisTask).toHaveLength(0)
   })
 
+  it('done task with PR URL but without pr_merged metadata is NOT flagged (avoid digest spam)', async () => {
+    // Simulate a common real-world case: task is marked done, PR metadata was never populated.
+    // We should NOT emit orphan_pr violations for done tasks during periodic sweep.
+
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/tasks',
+      payload: {
+        title: 'Orphan test — done task missing pr_merged metadata',
+        description: 'Regression: sweeper should not flag done tasks as orphan PRs',
+        status: 'done',
+        assignee: 'link',
+        reviewer: 'sage',
+        priority: 'P2',
+        createdBy: 'test',
+        eta: '1h',
+        done_criteria: ['Task is complete'],
+        metadata: {
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/99999',
+          // intentionally missing pr_merged / reviewer_approved
+        },
+      },
+    })
+    expect(createRes.statusCode).toBe(200)
+    const task = JSON.parse(createRes.body).task
+
+    // Advance time past the orphan threshold (2h) so the old logic would have flagged.
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(task.updatedAt + 3 * 60 * 60 * 1000)
+
+    const { sweepValidatingQueue } = await import('../src/executionSweeper.js')
+    const result = await sweepValidatingQueue()
+    const orphanForThisTask = result.violations.filter(
+      v => v.taskId === task.id && v.type === 'orphan_pr',
+    )
+    expect(orphanForThisTask).toHaveLength(0)
+
+    nowSpy.mockRestore()
+  })
+
   it('orphan alert includes @assignee and @reviewer mentions', async () => {
     const { sweepValidatingQueue } = await import('../src/executionSweeper.js')
     const result = await sweepValidatingQueue()


### PR DESCRIPTION
Closes task-1772816066628-1ehpi8x0z\n\nProblem: sweeper digest was flagging done tasks as PR Issues (orphan_pr) based on metadata-only checks, creating noisy false positives/spam after restarts.\n\nFix: orphan PR detection in periodic sweep now scans cancelled tasks only (not done). Done tasks with incomplete PR metadata are handled via /drift-report, not digest.\n\nTests: npm test