### PR TITLE
fix(tasks): allow null dueAt/scheduledFor to clear fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,8 +44,8 @@ export interface Task {
   tags?: string[]
   metadata?: Record<string, unknown>
   teamId?: string
-  dueAt?: number         // epoch ms — when the task is due
-  scheduledFor?: number  // epoch ms — when work should start
+  dueAt?: number | null         // epoch ms — when the task is due (null clears)
+  scheduledFor?: number | null  // epoch ms — when work should start (null clears)
 }
 
 export type TaskHistoryEventType = 'created' | 'assigned' | 'status_changed' | 'commented' | 'lane_transition'


### PR DESCRIPTION
Hotfix for main build break introduced by PR #715.

Problem:
- UpdateTaskSchema allows dueAt/scheduledFor to be null (to clear), but Task type had dueAt?: number.
- tsc fails: number|null|undefined not assignable to number|undefined.

Fix:
- Allow dueAt and scheduledFor to be `number | null` in Task interface.

Tests:
- npm test passes locally (1734 tests).

Follow-up:
- Consider adding a merge gate so PRs with failing `test`/`tsc` cannot be merged.