### PR TITLE
feat: /pulse includes deploy + alert-preflight summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflectt-node",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",

--- a/public/docs.md
+++ b/public/docs.md
@@ -387,7 +387,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/pulse` | Team pulse snapshot: board counts + per-agent doing tasks + pending reviews + focus. Use `?compact=true` for <2000 char version |
+| GET | `/pulse` | Team pulse snapshot: board counts + per-agent doing tasks + pending reviews + focus + deploy info + alert-preflight mode. Use `?compact=true` for <2000 char version |
 | POST | `/scope-overlap` | Scan for task scope overlap after PR merge. Body: `{ "prNumber": 707, "prTitle": "...", "prBranch": "kai/task-...", "mergedTaskId?": "...", "notify?": true }` |
 | GET | `/focus` | Current team focus directive (included in heartbeat) |
 | POST | `/focus` | Set team focus. Body: `{ "directive": "...", "setBy": "kai", "expiresAt?": 1234, "tags?": ["shipping"] }` |

--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -16,6 +16,7 @@ import { presenceManager } from './presence.js'
 import { chatManager } from './chat.js'
 import { getFocusSummary } from './focus.js'
 import { getBuildInfo } from './buildInfo.js'
+import { getPreflightMetrics } from './alert-preflight.js'
 import type { Task } from './types.js'
 
 export interface PulseAgent {
@@ -27,7 +28,8 @@ export interface PulseAgent {
 
 export interface PulseSnapshot {
   ts: number
-  deploy?: { version?: string; commit?: string; pid?: number; startedAt?: number }
+  deploy?: { version?: string; commit?: string; pid?: number; startedAt?: number; uptimeS?: number }
+  alertPreflight?: { mode: string; totalChecked: number; suppressed: number; canaryFlagged: number }
   focus?: { focus: string; setBy: string; setAt: number } | null
   board: { todo: number; doing: number; validating: number; done: number; blocked: number }
   agents: PulseAgent[]
@@ -37,6 +39,8 @@ export interface PulseSnapshot {
 
 export interface CompactPulse {
   ts: number
+  deploy?: string  // e.g. "a481ec9 up:2h34m v0.1.5"
+  alertPreflight?: string  // e.g. "enforce checked:1 suppressed:1"
   focus?: string | null
   board: string  // e.g. "T:3 D:2 V:1 ✓:5 B:0"
   agents: string[] // e.g. ["link:working→task-123(activity endpoint)", "pixel:working→task-456(UI scaffold)"]
@@ -46,14 +50,31 @@ export interface CompactPulse {
 function getDeployInfo(): PulseSnapshot['deploy'] {
   try {
     const info = getBuildInfo()
+    const startedAtMs = info.startedAtMs
+    const uptimeS = startedAtMs ? Math.round((Date.now() - startedAtMs) / 1000) : undefined
     return {
       version: info.appVersion || process.env.npm_package_version,
       commit: info.gitShortSha || info.gitSha,
       pid: process.pid,
-      startedAt: info.startedAtMs,
+      startedAt: startedAtMs,
+      uptimeS,
     }
   } catch {
     return { pid: process.pid }
+  }
+}
+
+function getAlertPreflightSummary(): PulseSnapshot['alertPreflight'] {
+  try {
+    const m = getPreflightMetrics()
+    return {
+      mode: m.mode,
+      totalChecked: m.totalChecked,
+      suppressed: m.suppressed,
+      canaryFlagged: m.canaryFlagged,
+    }
+  } catch {
+    return undefined
   }
 }
 
@@ -108,6 +129,7 @@ export function generatePulse(): PulseSnapshot {
   return {
     ts: Date.now(),
     deploy: getDeployInfo(),
+    alertPreflight: getAlertPreflightSummary(),
     focus: getFocusSummary(),
     board: { todo: todoCount, doing: doingCount, validating: validatingCount, done: doneCount, blocked: blockedCount },
     agents,
@@ -121,6 +143,24 @@ export function generatePulse(): PulseSnapshot {
 
 export function generateCompactPulse(): CompactPulse {
   const pulse = generatePulse()
+
+  // Deploy summary
+  const d = pulse.deploy
+  let deployStr: string | undefined
+  if (d) {
+    const uptimeHrs = d.uptimeS ? `${Math.floor(d.uptimeS / 3600)}h${Math.floor((d.uptimeS % 3600) / 60)}m` : '?'
+    deployStr = `${d.commit || '?'} up:${uptimeHrs} v${d.version || '?'}`
+  }
+
+  // Alert-preflight summary
+  const ap = pulse.alertPreflight
+  let apStr: string | undefined
+  if (ap) {
+    apStr = `${ap.mode} checked:${ap.totalChecked} suppressed:${ap.suppressed}`
+    if (ap.mode === 'canary' && ap.canaryFlagged > 0) {
+      apStr += ` flagged:${ap.canaryFlagged}`
+    }
+  }
 
   const boardStr = `T:${pulse.board.todo} D:${pulse.board.doing} V:${pulse.board.validating} ✓:${pulse.board.done} B:${pulse.board.blocked}`
 
@@ -139,6 +179,8 @@ export function generateCompactPulse(): CompactPulse {
 
   return {
     ts: pulse.ts,
+    deploy: deployStr,
+    alertPreflight: apStr,
     focus: pulse.focus?.focus || null,
     board: boardStr,
     agents: agentStrs,

--- a/tests/pulse.test.ts
+++ b/tests/pulse.test.ts
@@ -67,4 +67,44 @@ describe('Team Pulse', () => {
       expect(review.reviewer).toBeDefined()
     }
   })
+
+  it('full pulse includes deploy with uptimeS', () => {
+    const pulse = generatePulse()
+    expect(pulse.deploy).toBeDefined()
+    expect(typeof pulse.deploy!.pid).toBe('number')
+    // uptimeS may be undefined if startedAtMs is not set, but the field should exist
+    if (pulse.deploy!.startedAt) {
+      expect(typeof pulse.deploy!.uptimeS).toBe('number')
+      expect(pulse.deploy!.uptimeS).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('full pulse includes alertPreflight summary', () => {
+    const pulse = generatePulse()
+    expect(pulse.alertPreflight).toBeDefined()
+    expect(typeof pulse.alertPreflight!.mode).toBe('string')
+    expect(['canary', 'enforce', 'off']).toContain(pulse.alertPreflight!.mode)
+    expect(typeof pulse.alertPreflight!.totalChecked).toBe('number')
+    expect(typeof pulse.alertPreflight!.suppressed).toBe('number')
+  })
+
+  it('compact pulse includes deploy and alertPreflight strings', () => {
+    const compact = generateCompactPulse()
+    // deploy string format: "commit up:XhYm vZ.Z.Z"
+    if (compact.deploy) {
+      expect(typeof compact.deploy).toBe('string')
+      expect(compact.deploy).toContain('up:')
+    }
+    // alertPreflight string format: "mode checked:N suppressed:N"
+    if (compact.alertPreflight) {
+      expect(typeof compact.alertPreflight).toBe('string')
+      expect(compact.alertPreflight).toContain('checked:')
+    }
+  })
+
+  it('compact pulse with deploy+alertPreflight still under 2000 chars', () => {
+    const compact = generateCompactPulse()
+    const serialized = JSON.stringify(compact)
+    expect(serialized.length).toBeLessThan(2000)
+  })
 })


### PR DESCRIPTION
Full pulse adds alertPreflight and deploy.uptimeS. Compact pulse adds deploy/alertPreflight strings for heartbeat context. 4 new tests. Compact still <2000 chars.

1741/1741 tests green.