### PR TITLE
fix: filter presence roster to registry-known agents

### DIFF
--- a/src/presence.ts
+++ b/src/presence.ts
@@ -10,6 +10,7 @@
 
 import { eventBus } from './events.js'
 import { getDb } from './db.js'
+import { getAgentRoles } from './assignment.js'
 
 export type PresenceStatus = 'idle' | 'working' | 'reviewing' | 'blocked' | 'offline'
 
@@ -159,12 +160,18 @@ class PresenceManager {
         'SELECT DISTINCT assignee as agent FROM tasks WHERE status = \'doing\' AND assignee IS NOT NULL AND assignee != \'\''
       ).all() as Array<{ agent: string }>
 
+      // Build set of known agents from TEAM-ROLES registry to prevent cross-node leakage
+      const knownAgents = new Set(getAgentRoles().map(r => r.name.toLowerCase()))
+
       const agents = new Set<string>()
       for (const row of [...chatAgents, ...taskAgents]) {
         const name = (row.agent || '').toLowerCase().trim()
-        // Skip system/email senders and empty names
+        // Skip system/email senders, empty names, and agents not in registry
         if (name && !name.startsWith('email:') && name !== 'system' && name !== 'user') {
-          agents.add(name)
+          // Only seed agents known to this node's TEAM-ROLES registry
+          if (knownAgents.size === 0 || knownAgents.has(name)) {
+            agents.add(name)
+          }
         }
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10618,14 +10618,22 @@ If your heartbeat shows **no active task** and **no next task**:
   app.get('/presence', async () => {
     const explicitPresences = presenceManager.getAllPresence()
     const allActivity = presenceManager.getAllActivity()
+
+    // Filter to agents known to this node's TEAM-ROLES registry
+    const knownAgentNames = new Set(getAgentRoles().map(r => r.name.toLowerCase()))
     
-    // Build map of explicit presence by agent
-    const presenceMap = new Map(explicitPresences.map(p => [p.agent, p]))
+    // Build map of explicit presence by agent (filtered to registry)
+    const presenceMap = new Map(
+      explicitPresences
+        .filter(p => knownAgentNames.size === 0 || knownAgentNames.has(p.agent.toLowerCase()))
+        .map(p => [p.agent, p])
+    )
     
-    // Add inferred presence for agents with only activity
+    // Add inferred presence for agents with only activity (registry-gated)
     const now = Date.now()
     for (const activity of allActivity) {
-      if (!presenceMap.has(activity.agent) && activity.last_active) {
+      if (!presenceMap.has(activity.agent) && activity.last_active
+          && (knownAgentNames.size === 0 || knownAgentNames.has(activity.agent.toLowerCase()))) {
         const inactiveMs = now - activity.last_active
         
         let status: PresenceStatus = 'offline'


### PR DESCRIPTION
## Problem

Mac Daddy dashboard shows agent-1, agent-2, agent-3 which are EVI-Fly placeholder names. These leak into the presence roster via:
1. `seedPresenceFromRecentActivity()` — discovers agents from `chat_messages` without checking against TEAM-ROLES registry
2. `/presence` endpoint — infers agents from activity data without registry gating

## Root Cause

Cross-node chat messages (from cloud sync or shared DB) contain agent names from other nodes. The presence system treats any chat author as a potential agent.

## Fix

- `seedPresenceFromRecentActivity()` now filters discovered agents against `getAgentRoles()` registry
- `/presence` endpoint filters both explicit presences and activity-inferred presences against the registry
- Graceful fallback: if registry is empty (no TEAM-ROLES.yaml / fresh install), all agents are allowed to prevent lockout

## Tests

All 1737 tests pass.

Fixes: task-1772826288688-h1ctdsuu9