### PR TITLE
fix: branch guard + expose DB path in /health/deploy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { startTeamConfigLinter, stopTeamConfigLinter } from './team-config.js'
 import { statSync, readdirSync, existsSync, readFileSync, writeFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
-import { hostname as osHostname } from 'os'
+import { hostname as osHostname, homedir } from 'os'
 import { randomBytes } from 'crypto'
 
 function checkBuildFreshness(): void {
@@ -178,6 +178,31 @@ async function main() {
 
   // Docker identity isolation (must run before bootstrap)
   checkDockerIdentity()
+
+  // Branch guard: refuse to run non-main branch against production DB
+  // unless REFLECTT_ALLOW_BRANCH_DB=1 is set
+  try {
+    const { getBuildInfo } = await import('./buildInfo.js')
+    const build = getBuildInfo()
+    const branch = build.gitBranch || ''
+    const isMainBranch = branch === 'main' || branch === 'master' || branch === ''
+    const isProdDb = DATA_DIR === join(homedir(), '.reflectt', 'data')
+    const allowOverride = process.env.REFLECTT_ALLOW_BRANCH_DB === '1'
+
+    if (!isMainBranch && isProdDb && !allowOverride) {
+      console.error('')
+      console.error(`🚫 [BRANCH GUARD] Refusing to start: branch "${branch}" is using production DB path`)
+      console.error(`   DB path: ${DATA_DIR}`)
+      console.error(`   Only "main" branch should run against the production database.`)
+      console.error(`   To override: set REFLECTT_ALLOW_BRANCH_DB=1`)
+      console.error('')
+      process.exit(1)
+    } else if (!isMainBranch && isProdDb && allowOverride) {
+      console.warn(`⚠️  [BRANCH GUARD] Running branch "${branch}" against production DB (override active)`)
+    }
+  } catch {
+    // Non-fatal — skip if build-info not available
+  }
 
   // Docker bootstrap guidance (non-blocking)
   checkDockerBootstrap()

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { resolve, sep, join } from 'path'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type { WebSocket } from 'ws'
 import { execSync } from 'child_process'
-import { serverConfig, openclawConfig, isDev, REFLECTT_HOME } from './config.js'
+import { serverConfig, openclawConfig, isDev, REFLECTT_HOME, DATA_DIR } from './config.js'
 import { trackRequest, getRequestMetrics } from './request-tracker.js'
 import { getPreflightMetrics, snapshotDailyMetrics, getDailySnapshots, startAutoSnapshot } from './alert-preflight.js'
 
@@ -3113,6 +3113,8 @@ export async function createServer(): Promise<FastifyInstance> {
       pid: build.pid,
       nodeVersion: build.nodeVersion,
       uptime: build.uptime,
+      dataDir: DATA_DIR,
+      reflecttHome: REFLECTT_HOME,
     }
   })
 


### PR DESCRIPTION
## Changes
1. **Branch guard** (`src/index.ts`): Non-main branch + production DB path → `process.exit(1)`. Override: `REFLECTT_ALLOW_BRANCH_DB=1`.
2. **DB path in /health/deploy** (`src/server.ts`): Now exposes `dataDir` + `reflecttHome` for auditing.

Combined with PR #728 (startup count guard) and PR #729 (scoped test delete), this is 3 layers of DB wipe prevention.

Part of task-1772833873215-kd4j6r1y8