### PR TITLE
fix: REFLECTT_TEST_MODE guard on all unscoped DELETE in tests

### DIFF
--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -12,6 +12,8 @@ describe('files', () => {
     // Clean DB table between tests to avoid cross-test pollution
     const { getDb } = await import('../src/db.js')
     const db = getDb()
+    // Defense-in-depth: only wipe in test mode (setup.ts sets REFLECTT_HOME to temp dir)
+    if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
     try { db.exec('DELETE FROM files') } catch {}
   })
 

--- a/tests/host-registry.test.ts
+++ b/tests/host-registry.test.ts
@@ -3,6 +3,8 @@ import { getDb } from '../src/db.js'
 import { upsertHostHeartbeat, getHost, listHosts, removeHost } from '../src/host-registry.js'
 
 function clearHosts() {
+  // Defense-in-depth: only wipe in test mode (setup.ts sets REFLECTT_HOME to temp dir)
+  if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
   try { getDb().prepare('DELETE FROM hosts').run() } catch { /* table may not exist */ }
 }
 

--- a/tests/insight-local-admin.test.ts
+++ b/tests/insight-local-admin.test.ts
@@ -51,6 +51,8 @@ beforeAll(async () => {
 })
 
 beforeEach(() => {
+  // Defense-in-depth: only wipe in test mode (setup.ts sets REFLECTT_HOME to temp dir)
+  if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
   const db = getDb()
   try {
     db.prepare('DELETE FROM insights').run()

--- a/tests/insight-mutation.test.ts
+++ b/tests/insight-mutation.test.ts
@@ -15,6 +15,8 @@ beforeEach(() => {
   process.env.REFLECTT_ENABLE_INSIGHT_MUTATION_API = 'true'
   delete process.env.REFLECTT_INSIGHT_MUTATION_TOKEN
 
+  // Defense-in-depth: only wipe in test mode (setup.ts sets REFLECTT_HOME to temp dir)
+  if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
   const db = getDb()
   db.prepare('DELETE FROM insights').run()
   _clearInsightMutationAuditLog()

--- a/tests/mention-rescue.test.ts
+++ b/tests/mention-rescue.test.ts
@@ -35,6 +35,8 @@ beforeEach(() => {
     )
   `)
   // Clear between tests
+  // Defense-in-depth: only wipe in test mode (setup.ts sets REFLECTT_HOME to temp dir)
+  if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
   db.exec('DELETE FROM mention_rescue_state')
 })
 

--- a/tests/suppression-ledger.test.ts
+++ b/tests/suppression-ledger.test.ts
@@ -8,6 +8,8 @@ describe('Suppression Ledger', () => {
 
   beforeEach(() => {
     // Clear ledger between tests
+    // Defense-in-depth: only wipe in test mode (setup.ts sets REFLECTT_HOME to temp dir)
+    if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
     const db = getDb()
     db.prepare('DELETE FROM suppression_ledger').run()
     ledger = new SuppressionLedger(30 * 60 * 1000) // 30m window


### PR DESCRIPTION
## Problem
6 test files had unscoped `DELETE FROM` on various tables. If test DB isolation ever fails again, these could wipe production data.

## Fix
Added `REFLECTT_TEST_MODE` check before each unscoped DELETE — throws error if not in test mode.

Files: host-registry, files, suppression-ledger, insight-local-admin, insight-mutation, mention-rescue.

1755 tests pass.

Closes task-1772836923884-hjklh01y5