### PR TITLE
fix(funnel): bucket no-preflight-run drops separately; warn on missing preflight metadata

### DIFF
--- a/src/activationEvents.ts
+++ b/src/activationEvents.ts
@@ -162,6 +162,17 @@ export async function emitActivationEvent(
   // Idempotent: skip if already recorded
   if (userMap.has(type)) return false
 
+  // Warn at ingestion time if host_preflight_failed arrives without structured metadata.
+  // This means the caller is not providing failed_checks/first_blocker, which makes
+  // failure reason analysis impossible. The emitter (preflight.ts) always provides these,
+  // so a null here signals a non-standard code path.
+  if (type === 'host_preflight_failed' && (!metadata || (!metadata.failed_checks && !metadata.first_blocker))) {
+    console.warn(
+      `[ActivationFunnel] host_preflight_failed for userId=${userId} has no failed_checks or first_blocker metadata. ` +
+      `Failure reason will appear as "unspecified" in the funnel. Emit metadata.failed_checks=[...] and metadata.first_blocker=<checkId>.`
+    )
+  }
+
   const timestamp = Date.now()
   userMap.set(type, timestamp)
 
@@ -461,27 +472,35 @@ export function getFailureDistribution(): FailureDistribution[] {
       if (reachedPrev && !reachedThis) {
         droppedCount++
 
-        // Preflight failures: use host_preflight_failed metadata (failed_checks/first_blocker)
+        // Preflight failures: use host_preflight_failed metadata (failed_checks/first_blocker).
+        // If no host_preflight_failed event exists, the user never attempted preflight.
         if (step === 'host_preflight_passed') {
           const failEvent = eventLog.find(e => e.userId === u.userId && e.type === 'host_preflight_failed')
-          const meta = failEvent?.metadata
-          if (meta) {
-            const fc: unknown = (meta as any).failed_checks
-            if (Array.isArray(fc)) {
-              for (const check of fc) {
-                const reason = String(check)
+          if (!failEvent) {
+            // User reached signup but never ran preflight — distinct from a failed run
+            reasonCounts.set('no_preflight_run', (reasonCounts.get('no_preflight_run') || 0) + 1)
+          } else {
+            const meta = failEvent.metadata
+            if (meta) {
+              const fc: unknown = (meta as any).failed_checks
+              if (Array.isArray(fc) && fc.length > 0) {
+                for (const check of fc) {
+                  const reason = String(check)
+                  reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
+                }
+              } else if (typeof fc === 'string' && fc) {
+                const reason = fc
+                reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
+              } else if ((meta as any).first_blocker) {
+                const reason = String((meta as any).first_blocker)
+                reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
+              } else if ((meta as any).error) {
+                const reason = String((meta as any).error)
                 reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
               }
-            } else if (typeof fc === 'string' && fc) {
-              const reason = fc
-              reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
-            } else if ((meta as any).first_blocker) {
-              const reason = String((meta as any).first_blocker)
-              reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
-            } else if ((meta as any).error) {
-              const reason = String((meta as any).error)
-              reasonCounts.set(reason, (reasonCounts.get(reason) || 0) + 1)
+              // metadata present but no extractable reason: falls through to unspecified
             }
+            // metadata null/undefined: falls through to unspecified
           }
         }
 

--- a/tests/activationEvents.test.ts
+++ b/tests/activationEvents.test.ts
@@ -239,6 +239,18 @@ describe('Onboarding Telemetry Dashboard', () => {
       expect(preflightDrop.reasons.some(r => r.reason === 'cloud-reachable')).toBe(true)
     })
 
+    it('buckets users with no preflight attempt as no_preflight_run (not unspecified)', async () => {
+      // u1 signs up but never runs preflight (no host_preflight_failed event emitted)
+      await emitActivationEvent('signup_completed', 'u1')
+
+      const dist = getFailureDistribution()
+      const preflightDrop = dist.find(s => s.step === 'host_preflight_passed')!
+      expect(preflightDrop.droppedCount).toBe(1)
+      // Should be no_preflight_run, not unspecified
+      expect(preflightDrop.reasons.some(r => r.reason === 'no_preflight_run')).toBe(true)
+      expect(preflightDrop.reasons.some(r => r.reason === 'unspecified')).toBe(false)
+    })
+
     it('provides a non-unspecified bucket for workspace_ready drops', async () => {
       await emitActivationEvent('signup_completed', 'u1')
       await emitActivationEvent('host_preflight_passed', 'u1')


### PR DESCRIPTION
Closes task-1772842558708-soyyxpjuz (P2, @sage review)

## Problem

`GET /activation/funnel/failures` was showing `unspecified: 4` at the `host_preflight_passed` step. Root cause: 4 users (`u-dash-1`, `u-trend-1`, `u3`, `user-2`) had `signup_completed` but **zero** `host_preflight_failed` events — they never ran preflight. The consumer code found no failure event and fell through to `unspecified`.

## Fix

1. **Consumer**: In `getFailureDistribution`, when a user dropped at `host_preflight_passed` with **no** `host_preflight_failed` event, bucket as `no_preflight_run` (distinct from an actual failure with missing metadata).
2. **Ingestion**: In `emitActivationEvent`, warn at ingestion time if `host_preflight_failed` arrives without `failed_checks` or `first_blocker` metadata — makes non-standard callers visible immediately.
3. **Test**: New test confirms `no_preflight_run` bucket appears and `unspecified` is absent for the drop.

## Receipts (post-deploy)

- `/activation/funnel/failures` should now show `no_preflight_run: 4` instead of `unspecified: 4`
- `unspecified` only appears when there IS a `host_preflight_failed` event but its metadata has no extractable reason

## Changes

- `src/activationEvents.ts` — `getFailureDistribution` + `emitActivationEvent`
- `tests/activationEvents.test.ts` — regression test