### PR TITLE
fix: prevent cloud-relay message echo in chat sync

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -932,11 +932,12 @@ async function syncChat(): Promise<void> {
     return
   }
 
-  // Get recent messages since last sync
+  // Get recent messages since last sync, excluding cloud-relayed messages
+  // to prevent echo: cloud→node→cloud sync loop
   const recentMessages = chatManager.getMessages({
     since: chatSyncCursor,
     limit: 50,
-  })
+  }).filter(m => (m.metadata as any)?.source !== 'cloud-relay')
 
   // Send to cloud and get pending outbound messages
   const payload = recentMessages.map(m => ({


### PR DESCRIPTION
## Problem

Cloud chat double-posts messages. Messages sent from cloud dashboard appear twice and may not deliver to agents correctly.

## Root Cause (node-side)

Messages relayed from cloud (via `/chat/sync` pending pickup) are injected locally with `metadata.source = 'cloud-relay'`. But the next sync cycle picks them up as "recent messages" and pushes them back to cloud — creating an echo loop.

## Fix

Filter `cloud-relay` messages out of the sync payload so they're never sent back to cloud.

## Related

Cloud-side dedup fix for Realtime race is in reflectt-cloud (separate PR).

1756 tests pass.

Fixes: task-1772860715837-pawymd4hm