### PR TITLE
fix: use dynamic version from package.json, add prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:watch": "vitest",
     "deploy": "bash scripts/post-merge-rebuild.sh",
     "hooks:install": "bash scripts/install-hooks.sh",
+    "prepublishOnly": "npm run build",
     "prepack": "chmod +x dist/cli.js"
   },
   "keywords": [

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,6 +13,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { z } from "zod"
 import { chatManager } from "./chat.js"
 import { taskManager } from "./tasks.js"
+import { PKG_VERSION } from "./version.js"
 import type { AgentMessage, Task } from "./types.js"
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -21,7 +22,7 @@ import type { AgentMessage, Task } from "./types.js"
 
 const server = new McpServer({
   name: "reflectt-node",
-  version: "0.1.0",
+  version: PKG_VERSION,
 })
 
 // Wrapper to avoid TS2589 (excessively deep type instantiation) with MCP SDK + Zod
@@ -608,7 +609,7 @@ async function handleJsonRpcMessage(message: any): Promise<any> {
       result: {
         protocolVersion: "2024-11-05",
         capabilities: { tools: {} },
-        serverInfo: { name: "reflectt-node", version: "0.1.0" },
+        serverInfo: { name: "reflectt-node", version: PKG_VERSION },
       },
     }
   }

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -6,6 +6,7 @@
  */
 import WebSocket from 'ws'
 import { openclawConfig } from './config.js'
+import { PKG_VERSION } from './version.js'
 import type { AgentMessage } from './types.js'
 
 interface OpenClawRequest {
@@ -130,7 +131,7 @@ export class OpenClawClient {
         client: {
           id: 'cli',
           displayName: 'Reflectt Node',
-          version: '0.1.0',
+          version: PKG_VERSION,
           platform: 'node',
           mode: 'cli',
         },
@@ -143,7 +144,7 @@ export class OpenClawClient {
           token: openclawConfig.gatewayToken
         } : undefined,
         locale: 'en-US',
-        userAgent: 'reflectt-node/0.1.0',
+        userAgent: `reflectt-node/${PKG_VERSION}`,
       })
       
       console.log('[OpenClaw] Handshake successful:', response)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,14 @@
+// Shared version — reads from package.json at runtime so it's never stale
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export const PKG_VERSION = (() => {
+  try {
+    const pkgPath = join(__dirname, '..', 'package.json')
+    return JSON.parse(readFileSync(pkgPath, 'utf-8')).version ?? '0.0.0'
+  } catch { return '0.0.0' }
+})()


### PR DESCRIPTION
## Problem
`npx reflectt-node --version` shows `0.1.0` instead of `0.1.5`. The published npm package had a stale `dist/cli.js` with hardcoded `.version('0.1.0')` because the dist was built when package.json was still at 0.1.0.

Additionally, `src/mcp.ts` and `src/openclaw.ts` had hardcoded `'0.1.0'` version strings.

## Fix
- Created shared `src/version.ts` that reads from `package.json` at runtime
- Replaced all hardcoded `'0.1.0'` version strings with `PKG_VERSION` import
- Added `prepublishOnly: "npm run build"` to prevent stale dist from ever shipping again

## Testing
- 1756 tests passed, 1 skipped, 0 failed
- Route/docs contract check passed (419/419)
- Verified no remaining `0.1.0` in dist output after build

## Note
After merge, needs a `npm publish` (even as patch 0.1.6) to fix the live npm package.

Source: task-1772892743589-69mrgtzk8