### PR TITLE
fix: collapse TeamConfig warnings into single message on first run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflectt-node",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",

--- a/src/team-config.ts
+++ b/src/team-config.ts
@@ -247,7 +247,23 @@ export function validateTeamConfig(): TeamConfigValidationResult {
   return result
 }
 
+// First-run codes: all warnings that fire on a clean install with no team files
+const FIRST_RUN_CODES = new Set([
+  'team_md_missing',
+  'team_md_missing_section',
+  'team_standards_missing',
+  'team_roles_missing',
+])
+
 function logValidation(result: TeamConfigValidationResult, source: string) {
+  // On first run (all issues are expected missing-file warnings), collapse to one friendly line
+  const allFirstRun = result.issues.length > 0
+    && result.issues.every(i => i.level === 'warning' && FIRST_RUN_CODES.has(i.code))
+  if (allFirstRun && source === 'startup') {
+    console.log('[TeamConfig] No team config found — using defaults. Customize: reflectt init')
+    return
+  }
+
   for (const issue of result.issues) {
     const prefix = issue.level === 'error' ? '[TeamConfig][ERROR]' : '[TeamConfig][WARN]'
     const loc = issue.path ? ` (${basename(issue.path)})` : ''


### PR DESCRIPTION
## Problem
On a clean install (`npx reflectt-node start`), users see 7 TeamConfig warning lines:
```
[TeamConfig][WARN][startup] team_md_missing_section (TEAM.md): TEAM.md missing required section matching "mission"
[TeamConfig][WARN][startup] team_md_missing_section (TEAM.md): TEAM.md missing required section matching "principle"
[TeamConfig][WARN][startup] team_md_missing_section (TEAM.md): TEAM.md missing required section matching "role"
[TeamConfig][WARN][startup] team_md_missing_section (TEAM.md): TEAM.md missing required section matching "work"
[TeamConfig][WARN][startup] team_standards_missing (TEAM-STANDARDS.md): ...
[TeamConfig][WARN][startup] team_roles_missing (TEAM-ROLES.yaml): ...
```
These are all expected on first run and make the product look broken to new users.

## Fix
Detect first-run state (all issues are expected missing-file/section warnings) and collapse to:
```
[TeamConfig] No team config found — using defaults. Customize: reflectt init
```

Errors and non-first-run warnings still log individually. Only affects `startup` source.

## Testing
1756 passed, 1 skipped, 0 failed

Source: task-1772892809003-l2zsexl8s