### PR TITLE
fix: suppress vector search warning on startup

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -684,7 +684,10 @@ export function initVectorSearch(): void {
     _vecInitialized = true
     console.log('[DB] Vector search tables initialized')
   } catch (err: any) {
-    console.warn('[DB] Vector search not available:', err?.message)
+    // Vector search is optional — only log at debug level to avoid alarming new users
+    if (process.env.DEBUG || process.env.REFLECTT_DEBUG) {
+      console.warn('[DB] Vector search not available:', err?.message)
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,10 @@ async function main() {
       const { initVectorSearch } = await import('./db.js')
       initVectorSearch()
     } catch {
-      console.warn('⚠️  Vector search not available (sqlite-vec not installed)')
+      // Vector search is optional — silent unless debug mode
+      if (process.env.DEBUG || process.env.REFLECTT_DEBUG) {
+        console.warn('⚠️  Vector search not available (sqlite-vec not installed)')
+      }
     }
 
     // Team config linter (TEAM.md + TEAM-ROLES.yaml + TEAM-STANDARDS.md)


### PR DESCRIPTION
## Problem
Every startup logs `[DB] Vector search not available: require is not defined` — looks like an error to new users. Vector search (sqlite-vec) is optional and not having it is the normal case.

## Fix
Only log when `DEBUG` or `REFLECTT_DEBUG` env var is set. Both `src/db.ts` and `src/index.ts` warning paths suppressed.

## Testing
1756 passed, 1 skipped, 0 failed

Source: task-1772894106546-enttgunsg