### PR TITLE
fix: suppress TeamConfig watcher warnings on first run

### DIFF
--- a/src/team-config.ts
+++ b/src/team-config.ts
@@ -255,12 +255,19 @@ const FIRST_RUN_CODES = new Set([
   'team_roles_missing',
 ])
 
+// Track whether we've already shown the first-run message
+let firstRunMessageShown = false
+
 function logValidation(result: TeamConfigValidationResult, source: string) {
   // On first run (all issues are expected missing-file warnings), collapse to one friendly line
   const allFirstRun = result.issues.length > 0
     && result.issues.every(i => i.level === 'warning' && FIRST_RUN_CODES.has(i.code))
-  if (allFirstRun && source === 'startup') {
-    console.log('[TeamConfig] No team config found — using defaults. Customize: reflectt init')
+  if (allFirstRun) {
+    if (!firstRunMessageShown) {
+      console.log('[TeamConfig] No team config found — using defaults. Customize: reflectt init')
+      firstRunMessageShown = true
+    }
+    // Suppress repeated first-run warnings from file watchers
     return
   }
 


### PR DESCRIPTION
## Problem
PR #742 suppressed the 7 TeamConfig warnings on startup, but the file watcher re-triggered the same 5 warnings seconds later when TEAM.md was created by first-boot seeding. New users still saw noise.

## Fix
Track whether the first-run message was already shown. Suppress all subsequent first-run-only warnings from any source (startup, file watcher, etc). Non-first-run warnings and errors still log normally.

## Testing
1756 passed, 1 skipped, 0 failed

Follow-up to PR #742