### PR TITLE
fix: normalize in-progress→doing status alias, backfill orphaned tasks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6093,7 +6093,12 @@ export async function createServer(): Promise<FastifyInstance> {
   // Create task
   app.post('/tasks', async (request, reply) => {
     try {
-      const data = CreateTaskSchema.parse(request.body)
+      // Normalize legacy "in-progress" → "doing" before schema validation
+      const rawPostBody = request.body as Record<string, unknown>
+      if (rawPostBody && typeof rawPostBody === 'object' && rawPostBody.status === 'in-progress') {
+        rawPostBody.status = 'doing'
+      }
+      const data = CreateTaskSchema.parse(rawPostBody)
 
       // Reject TEST: prefixed tasks in production to prevent CI pollution
       if (process.env.NODE_ENV === 'production' && typeof data.title === 'string' && data.title.startsWith('TEST:')) {
@@ -6812,7 +6817,13 @@ export async function createServer(): Promise<FastifyInstance> {
   // Update task
   app.patch<{ Params: { id: string } }>('/tasks/:id', async (request, reply) => {
     try {
-      const parsed = UpdateTaskSchema.parse(request.body)
+      // Normalize legacy "in-progress" → "doing" before schema validation.
+      // Some agents (and older MCP callers) use the deprecated status name.
+      const rawBody = request.body as Record<string, unknown>
+      if (rawBody && typeof rawBody === 'object' && rawBody.status === 'in-progress') {
+        rawBody.status = 'doing'
+      }
+      const parsed = UpdateTaskSchema.parse(rawBody)
       const lookup = taskManager.resolveTaskId(request.params.id)
       if (lookup.matchType === 'ambiguous') {
         reply.code(400)

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -341,6 +341,20 @@ class TaskManager {
       // Also check legacy location for migration
       importJsonlIfNeeded(db, LEGACY_TASKS_FILE, 'tasks', importTasks)
 
+      // ── Backfill: normalize legacy "in-progress" → "doing" ────────────────
+      // Older callers used "in-progress" before the enum was locked to "doing".
+      // These tasks are invisible to list/next endpoints (status not in allowlist)
+      // but counted by health/stats, causing confusion and PATCH 400 loops.
+      const inProgressCount = (db.prepare(
+        `SELECT COUNT(*) as n FROM tasks WHERE status = 'in-progress'`
+      ).get() as { n: number }).n
+      if (inProgressCount > 0) {
+        db.prepare(`UPDATE tasks SET status = 'doing', updated_at = ? WHERE status = 'in-progress'`)
+          .run(Date.now())
+        console.log(`[Tasks] Backfilled ${inProgressCount} in-progress → doing`)
+      }
+      // ──────────────────────────────────────────────────────────────────────
+
       // All tasks queried from SQLite on demand — no in-memory Map
       const count = taskCount()
       console.log(`[Tasks] SQLite has ${count} tasks (all queries go to DB)`)


### PR DESCRIPTION
## What

- **PATCH /tasks/:id** and **POST /tasks** now coerce `status='in-progress'` → `'doing'` before schema validation
- **Startup backfill**: any task in SQLite with `status='in-progress'` is migrated to `'doing'` on load (these tasks were invisible to `/tasks` list and `/tasks/next`)

## Why

Health endpoint showed 9 task API errors in the last hour:
- 5x PATCH 400 on `task-1772899213950-pwsvpuc0s` — agent sending `{"status":"in-progress"}` instead of `"doing"`
- 2x PATCH 422 on cancelled tasks — state machine correctly rejecting (expected)
- 2x POST 400 — definition-of-ready check rejecting short titles (one-off burst)
- 1x health/tasks 404 — transient

The in-progress→doing alias eliminates the 400 loop. The backfill surfaces 3 stuck tasks that were in DB but invisible to all list/next queries.

## Tests
1756 passed, 1 skipped

Closes task-1772899473026-hbee03zns