### PR TITLE
fix: remove broken bootstrap URL from CLOUD_PROVISIONING.md

### DIFF
--- a/docs/CLOUD_PROVISIONING.md
+++ b/docs/CLOUD_PROVISIONING.md
@@ -135,5 +135,5 @@ Get your join token at app.reflectt.ai → your team → Settings → Join token
 ## Related
 
 - [Gateway setup](./gateway-setup.md)
-- [Bootstrap instructions for agents](https://reflectt.ai/bootstrap)
+- [Agent API reference](http://localhost:4445/capabilities) (once your node is running)
 - [reflectt-node on GitHub](https://github.com/reflectt/reflectt-node)


### PR DESCRIPTION
Last remaining `reflectt.ai/bootstrap` reference — Scout dogfood confirmed it's JS-only, agents get an empty page. Replaced with API reference endpoint (self-hosted). Companion to PRs #748 and #752.