### PR TITLE
fix: indirect activity no longer overrides task-derived presence status

### DIFF
--- a/src/presence.ts
+++ b/src/presence.ts
@@ -270,6 +270,29 @@ class PresenceManager {
   }
 
   /**
+   * Touch agent presence: bump lastUpdate without overriding status.
+   * Used for indirect activity signals (chat messages, reflections, task creation)
+   * that prove the agent is alive but shouldn't override task-derived status.
+   * If the agent is offline/idle/unknown, promotes to 'working'.
+   */
+  touchPresence(agent: string): AgentPresence {
+    const now = Date.now()
+    const existing = this.presence.get(agent)
+
+    if (!existing || existing.status === 'offline' || existing.status === 'idle') {
+      return this.updatePresence(agent, 'working')
+    }
+
+    const updated = { ...existing, lastUpdate: now, last_active: now }
+    this.presence.set(agent, updated)
+
+    const activity = this.getActivity(agent)
+    activity.last_active = now
+
+    return updated
+  }
+
+  /**
    * Update agent presence
    */
   updatePresence(agent: string, status: PresenceStatus, task?: string, since?: number, updateActivity = true): AgentPresence {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3522,7 +3522,7 @@ export async function createServer(): Promise<FastifyInstance> {
     // Auto-update presence: if you're posting, you're active
     if (data.from) {
       presenceManager.recordActivity(data.from, 'message')
-      presenceManager.updatePresence(data.from, 'working')
+      presenceManager.touchPresence(data.from)
 
       // Activation funnel: first team message
       emitActivationEvent('first_team_message_sent', data.from, {
@@ -5632,7 +5632,7 @@ export async function createServer(): Promise<FastifyInstance> {
       }
 
       presenceManager.recordActivity(data.author, 'message')
-      presenceManager.updatePresence(data.author, 'working')
+      presenceManager.touchPresence(data.author)
 
       // Heartbeat discipline: compute gap since previous comment for doing tasks
       let heartbeatWarning: string | undefined
@@ -6220,7 +6220,7 @@ export async function createServer(): Promise<FastifyInstance> {
       
       // Auto-update presence: creating tasks = working
       if (data.createdBy) {
-        presenceManager.updatePresence(data.createdBy, 'working')
+        presenceManager.touchPresence(data.createdBy)
       }
 
       // Fire-and-forget: index task for semantic search
@@ -11431,7 +11431,7 @@ If your heartbeat shows **no active task** and **no next task**:
       // Update presence: publishing content = working
       if (body.publishedBy) {
         presenceManager.recordActivity(body.publishedBy, 'message')
-        presenceManager.updatePresence(body.publishedBy, 'working')
+        presenceManager.touchPresence(body.publishedBy)
       }
 
       return { success: true, publication }
@@ -11497,7 +11497,7 @@ If your heartbeat shows **no active task** and **no next task**:
 
       // Update presence when adding content to calendar
       if (body.createdBy) {
-        presenceManager.updatePresence(body.createdBy, 'working')
+        presenceManager.touchPresence(body.createdBy)
       }
 
       return { success: true, item }


### PR DESCRIPTION
## Problem
Chat messages, comments, and content publishing unconditionally set agent presence to 'working', overriding the real task-derived status. An agent reviewing a PR who sends a chat message would flip from 'reviewing' to 'working' — making health data unreliable.

## Fix
Added `touchPresence()` method: bumps `lastUpdate` (preventing offline decay) without overriding status. Offline/idle agents get promoted to 'working'; active agents keep their current status.

5 call sites changed from `updatePresence(agent, 'working')` to `touchPresence(agent)`:
- Chat message handler (line 3525)
- Task comment handler (line 5635)
- Task creation handler (line 6223)
- Content publish handler (line 11434)
- Calendar item handler (line 11500)

Direct status sources (heartbeat, task state transitions) still use `updatePresence` with explicit status.

## Testing
1759 passed, 1 skipped, 0 failed
Route/docs contract: 419/419

Fixes: task-1772899603304-qc0zmidhe