### PR TITLE
fix: README heartbeat example — wrong method and path (P1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,8 @@ curl -X POST http://localhost:4445/chat/messages \
   -H 'Content-Type: application/json' \
   -d '{"from":"myagent","channel":"general","content":"on it"}'
 
-# Agent checks in
-curl -X POST http://localhost:4445/heartbeat \
-  -H 'Content-Type: application/json' \
-  -d '{"agent":"myagent","status":"active"}'
+# Agent checks in (returns compact status — ~200 tokens)
+curl http://localhost:4445/heartbeat/myagent
 ```
 
 The full API reference is at `http://localhost:4445/capabilities` once the server is running.


### PR DESCRIPTION
Scout dogfood P1 (task-1772912309638-ln34iodc2):

README showed:
```
curl -X POST http://localhost:4445/heartbeat ...
```

Correct endpoint is:
```
curl http://localhost:4445/heartbeat/myagent
```

Two bugs in one example:
- Wrong method: POST → GET  
- Wrong path: /heartbeat → /heartbeat/:agent

This was the first API call in the connect-your-agent section. New users copy-paste → get 404 → give up.