### PR TITLE
fix: prevent domain-limited agents from auto-assigning as out-of-lane reviewers

### DIFF
--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -546,6 +546,13 @@ export function suggestReviewer(
     )
     const affinityBonus = Math.min(matchedTags.length * 0.1, 0.3)
 
+    // Domain-mismatch penalty: domain-limited agents (voice, designer, growth, analyst)
+    // that have zero affinity-tag overlap with this task are likely the wrong reviewer.
+    // Penalize them to prevent e.g. content/voice agents winning reviewer slots on
+    // engineering PRs. Ops/reviewer roles are general-purpose and exempt from this penalty.
+    const DOMAIN_LIMITED_ROLES = ['voice', 'designer', 'growth', 'analyst']
+    const mismatchPenalty = DOMAIN_LIMITED_ROLES.includes(agent.role) && agent.affinityTags.length > 0 && matchedTags.length === 0 ? 0.4 : 0
+
     // Load penalty: more validating work = lower score
     const loadPenalty = (validatingLoad * 0.3) + (pendingLoad * 0.1)
 
@@ -557,7 +564,7 @@ export function suggestReviewer(
     ).length
     const slaRiskPenalty = highPriorityReviewLoad * 0.2
 
-    const score = Math.round((roleBonus + affinityBonus - loadPenalty - slaRiskPenalty) * 100) / 100
+    const score = Math.round((roleBonus + affinityBonus - loadPenalty - slaRiskPenalty - mismatchPenalty) * 100) / 100
 
     return { agent: agent.name, score, validatingLoad, role: agent.role }
   })


### PR DESCRIPTION
## Problem
Echo (role: voice/content) kept getting auto-assigned as reviewer for frontend/cloud PRs. Root cause: two gaps in the routing logic:

1. **Config gap**: Echo had `alwaysRoute` but was missing `routingMode: opt-in`, so it was treated as general-purpose and eligible for anything that wasn't `db-migration`.
2. **Scoring gap**: `suggestReviewer` had no penalty for domain-limited agents (voice, designer, growth, analyst) with zero affinity-tag overlap with the task. When ops agents were temporarily penalized by load, echo could win with just the base `roleBonus`.

## Fix
**Code (`src/assignment.ts`)**:
- Add `mismatchPenalty` (0.4) in `suggestReviewer` for agents with `voice/designer/growth/analyst` roles that have zero affinity-tag overlap with the task
- Ops/reviewer roles are exempt — they're general-purpose reviewers by design

**Config (`~/.reflectt/TEAM-ROLES.yaml`)**:
- Add `routingMode: opt-in` + `neverRouteUnlessLane: content` to echo
- Add explicit `neverRoute` patterns for backend/api/ui/frontend/dashboard/deploy/ci/infra

The config change is the hard gate; the code change is the defense-in-depth for other agents that might have the same pattern.

## Tests
1761 passed (1762 total, 1 skipped)

Closes task-1772908940739-b7xc76xmi