### PR TITLE
fix: overview page shows task stats + activity instead of blank

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -94,6 +94,45 @@ function updateOverviewEmptyState() {
   el.style.display = (hasTasks || hasMessages) ? 'none' : '';
 }
 
+function updateOverviewSummary() {
+  const panel = document.getElementById('overview-summary');
+  if (!panel) return;
+  const hasTasks = allTasks.length > 0;
+  const hasMessages = allMessages.length > 0;
+  panel.style.display = (hasTasks || hasMessages) ? '' : 'none';
+
+  // Stats
+  const statsEl = document.getElementById('overview-stats');
+  if (statsEl) {
+    const counts = { doing: 0, todo: 0, validating: 0, done: 0, blocked: 0 };
+    allTasks.forEach(t => { if (counts[t.status] !== undefined) counts[t.status]++; });
+    const statStyle = 'text-align:center;padding:10px;background:var(--bg-secondary, rgba(255,255,255,0.03));border-radius:8px;border:1px solid var(--border)';
+    const numStyle = 'font-size:20px;font-weight:600;color:var(--text-bright)';
+    const labelStyle = 'font-size:11px;color:var(--text-muted);margin-top:2px';
+    statsEl.innerHTML = [
+      { label: 'In Progress', count: counts.doing, color: 'var(--accent, #3B57E8)' },
+      { label: 'To Do', count: counts.todo, color: 'var(--text-muted)' },
+      { label: 'Validating', count: counts.validating, color: '#E8A83B' },
+      { label: 'Done', count: counts.done, color: '#4CAF50' },
+      { label: 'Blocked', count: counts.blocked, color: '#E84C3B' },
+    ].map(s => `<div style="${statStyle}"><div style="${numStyle};color:${s.color}">${s.count}</div><div style="${labelStyle}">${s.label}</div></div>`).join('');
+  }
+
+  // Recent activity — last 8 messages
+  const actEl = document.getElementById('overview-activity-list');
+  if (actEl && allMessages.length > 0) {
+    const recent = allMessages.slice(-8).reverse();
+    actEl.innerHTML = recent.map(m => {
+      const time = new Date(m.timestamp || m.ts || Date.now()).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const from = m.from || m.author || 'system';
+      const text = (m.content || m.text || '').slice(0, 120);
+      return `<div style="padding:4px 0;border-bottom:1px solid var(--border)"><span style="color:var(--accent);font-weight:500">${from}</span> <span style="opacity:0.5">${time}</span><br>${text}${text.length >= 120 ? '…' : ''}</div>`;
+    }).join('');
+  } else if (actEl) {
+    actEl.innerHTML = '<div style="opacity:0.5">No recent messages</div>';
+  }
+}
+
 // Delta cursors for lower payload refreshes
 let lastTaskSync = 0;
 let lastChatSync = 0;
@@ -732,6 +771,7 @@ async function loadTasks(forceFull = false) {
   if (navTaskBadge) navTaskBadge.textContent = allTasks.length;
   updateFirstBootBanner();
   updateOverviewEmptyState();
+  updateOverviewSummary();
 }
 
 function renderProjectTabs() {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2181,6 +2181,18 @@ ${internalMode ? `<div id="pause-banner" class="pause-banner" style="display:non
     </div>
   </div>
 
+  <!-- Overview summary — always visible when tasks/messages exist -->
+  <div class="panel" id="overview-summary" style="display:none">
+    <div class="panel-header">📊 Team Overview</div>
+    <div class="panel-body" id="overview-summary-body">
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:12px;margin-bottom:16px" id="overview-stats"></div>
+      <div id="overview-recent">
+        <div style="font-size:13px;font-weight:500;color:var(--text-bright);margin-bottom:8px">Recent Activity</div>
+        <div id="overview-activity-list" style="font-size:12px;color:var(--text-muted);line-height:1.6"></div>
+      </div>
+    </div>
+  </div>
+
   <div class="panel focus-only" style="display:none">
     <div class="panel-header">🧭 Runtime Truth Card <span class="count" id="truth-count">loading…</span></div>
     <div class="panel-body" id="truth-body"></div>


### PR DESCRIPTION
## Problem
Overview page (the landing page after install) shows completely blank main content area. The Getting Started panel auto-hides when all steps are done, and the empty state hides when tasks exist — leaving nothing visible.

## Fix
Added an overview summary panel with:
- Task status grid (doing/todo/validating/done/blocked counts)
- Recent activity feed (last 8 chat messages)

Shows when tasks or messages exist (inverse of empty state).

Changes: `src/dashboard.ts` (HTML template), `public/dashboard.js` (rendering logic)

## Testing
1761 tests pass, route/docs 419/419.

Fixes: task-1772914759074-wkwjl94jx