### PR TITLE
fix: compliance violations only fire for agents with active doing tasks

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -540,19 +540,23 @@ class TeamHealthMonitor {
         ? Math.floor((now - lastValidStatusAt) / 1000 / 60)
         : 9999
 
+      const activeTask = tasks.find(t => t.assignee === agent && t.status === 'doing')
+
       let state: ComplianceState = 'ok'
-      if (lastValidStatusAgeMin > expectedCadenceMin) {
-        state = 'violation'
-      } else if (lastValidStatusAgeMin >= Math.max(0, expectedCadenceMin - 10)) {
-        state = 'warning'
+      // Compliance violations only apply to agents with an active doing task.
+      // Idle agents between tasks should not show violation — they have nothing to report on.
+      if (activeTask) {
+        if (lastValidStatusAgeMin > expectedCadenceMin) {
+          state = 'violation'
+        } else if (lastValidStatusAgeMin >= Math.max(0, expectedCadenceMin - 10)) {
+          state = 'warning'
+        }
       }
 
       const hasEscalation = incidents.some(i => i.agent === agent)
       if (hasEscalation) {
         state = 'escalated'
       }
-
-      const activeTask = tasks.find(t => t.assignee === agent && t.status === 'doing')
 
       return {
         agent,


### PR DESCRIPTION
## Problem
Health page shows VIOLATION for kai, link, pixel when their `lastValidStatusAgeMin` exceeds the cadence window — even when they have no active task and are simply idle between work.

Root cause: `activeTask` was computed in `getCollaborationCompliance()` but never used to guard the state logic.

## Fix
Move `activeTask` lookup before the state evaluation. Violation/warning state only fires when `activeTask !== undefined`. Idle agents default to `ok`. Escalation (from incidents) still overrides regardless of task state.

Fixes: task-1772914805145-a7w8m2qje