### PR TITLE
fix: 30-min grace period for deploy:stale badge — suppress commit-drift noise after fresh deploy

### DIFF
--- a/src/release.ts
+++ b/src/release.ts
@@ -60,6 +60,12 @@ function captureRepoSnapshot(): RepoSnapshot {
 }
 
 const startupSnapshot = captureRepoSnapshot()
+const SERVER_START_MS = Date.now()
+
+// Minimum time (ms) before commit-drift is reported as stale.
+// Prevents the badge from firing immediately after a deploy when a PR
+// lands within minutes of the server restart. Configurable via env.
+const DEPLOY_STALE_GRACE_MS = Number(process.env.DEPLOY_STALE_GRACE_MIN ?? 30) * 60_000
 
 function extractEndpointMentions(task: Task): string[] {
   const haystack = [task.title, task.description || '', ...(task.done_criteria || [])].join('\n')
@@ -154,8 +160,15 @@ export const releaseManager = {
     const deployMarker = await readDeployMarker()
 
     const reasons: string[] = []
+    const serverAgeMs = Date.now() - SERVER_START_MS
+    const withinGrace = serverAgeMs < DEPLOY_STALE_GRACE_MS
+
     if (startupSnapshot.commit !== current.commit) {
-      reasons.push('commit changed since server start')
+      // Suppress commit-drift during the grace window — a fresh deploy shouldn't
+      // be flagged stale just because another PR lands within minutes of restart.
+      if (!withinGrace) {
+        reasons.push('commit changed since server start')
+      }
     }
     if (!startupSnapshot.dirty && current.dirty) {
       reasons.push('working tree became dirty after server start')
@@ -167,6 +180,8 @@ export const releaseManager = {
     return {
       stale: reasons.length > 0,
       reasons,
+      withinGrace,
+      graceRemainingMs: withinGrace ? Math.max(0, DEPLOY_STALE_GRACE_MS - serverAgeMs) : 0,
       startup: startupSnapshot,
       current,
       lastDeploy: deployMarker,

--- a/tools/internal-names-guard.config.json
+++ b/tools/internal-names-guard.config.json
@@ -40,8 +40,8 @@
     },
     {
       "pathPattern": "^src/server\\.ts$",
-      "pattern": "(?:app\\.|docs\\.)?reflectt\\.ai",
-      "reason": "Public-facing URLs in /health openclaw.docs field and redirect guidance for unconfigured nodes"
+      "pattern": "app\\.reflectt\\.ai",
+      "reason": "Public-facing URL in /health openclaw.docs field for unconfigured nodes"
     }
   ]
 }


### PR DESCRIPTION
## Problem
`deploy:stale` badge fires within 7-8 minutes of a fresh deploy. Root cause: `getDeployStatus()` immediately flags any commit-SHA difference from startup — even if the server was just deployed and a new PR merged minutes later.

## Fix
Add a grace window (`DEPLOY_STALE_GRACE_MS`, default 30 min, configurable via `DEPLOY_STALE_GRACE_MIN` env). During the window, commit-drift is suppressed. 

Still fires immediately:
- Working tree becoming dirty mid-session
- Branch changing mid-session

Also exposes `withinGrace: bool` and `graceRemainingMs` in the deploy status response.

**Bonus**: Narrowed internal-names-guard `server.ts` allow pattern back to `app\.reflectt\.ai` only (previous broadening was incorrect per updated test expectations from upstream).

## Tests
1761 passed (1762 total, 1 skipped)

Closes task-1772914772433-3rlqrm7e1