### PR TITLE
docs: remove stale drift caveat from TASKS_API_QUICKSTART

### DIFF
--- a/docs/TASKS_API_QUICKSTART.md
+++ b/docs/TASKS_API_QUICKSTART.md
@@ -45,29 +45,12 @@ TASK_ID="task-REPLACE_ME"
 
 ## 2) Move to `doing`
 
-> Note: docs/runtime drift currently exists for claim flow in some builds.
-> If `POST /tasks/:id/claim` fails with `doing requires metadata.eta`, use PATCH below.
-
-### Preferred (claim)
-
-```bash
-curl -s -X POST "$BASE/tasks/$TASK_ID/claim" \
-  -H 'Content-Type: application/json' \
-  -d '{"agent":"echo"}'
-```
-
-### Fallback (contract-safe patch)
-
 ```bash
 curl -s -X PATCH "$BASE/tasks/$TASK_ID" \
   -H 'Content-Type: application/json' \
   -d '{
     "assignee": "echo",
     "status": "doing",
-    "metadata": {
-      "eta": "30m",
-      "first_artifact_eta": "5m"
-    },
     "actor": "echo"
   }'
 ```


### PR DESCRIPTION
Follow-up to KNOWN_ISSUES.md ISSUE-001 closure (PR #768). The drift note was the ISSUE-001 caveat about metadata.eta — now fixed in v0.1.6. Simplified step 2: removed preferred/fallback split, PATCH is the single recommended path. -17 lines.