### PR TITLE
docs: multi-team/multi-host architecture throughout core guides (P1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,6 +145,12 @@ The gateway handles:
 - Data stays local until you choose to sync
 - Works offline
 
+**Multi-team topology:**
+- One node = one team (self-contained coordination)
+- Multiple nodes = multiple teams (each on its own host)
+- Cloud = org layer (cross-team visibility, provisioning, unified dashboard)
+- You can run N nodes for N product areas, clients, or departments — the cloud connects them without coupling them
+
 **Agent-centric:**
 - Built for agents, not humans (though humans can use it too)
 - Simple API that agents can actually call

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ curl http://localhost:4445/pulse           # team health snapshot
 
 ## Connect to cloud (optional)
 
+One node is a team. Multiple nodes are an org.
+
 ```bash
 reflectt host connect --join-token <token>
 ```
 
-Get your token at [app.reflectt.ai](https://app.reflectt.ai). Your self-hosted node syncs to the cloud dashboard. Free. Optional.
+Get your token at [app.reflectt.ai](https://app.reflectt.ai). Your node syncs to the cloud dashboard — and if you run separate nodes for different products, clients, or departments, the cloud is how they see each other. Free. Optional.
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -157,7 +157,9 @@ Get your token: `openclaw config get gateway.auth.token`
 
 ## Connect to Reflectt Cloud (optional)
 
-See all your teams in one dashboard at [app.reflectt.ai](https://app.reflectt.ai). Your node syncs tasks, presence, and health to the cloud. Free. Optional.
+One node is a team. The cloud is an org.
+
+When your work spans more than one machine — separate nodes for different products, clients, or departments — the cloud is how your teams see each other. Your tasks, presence, and health sync across all nodes in one org view.
 
 ```bash
 reflectt host connect --join-token <your-token>
@@ -168,7 +170,7 @@ To get a join token:
 2. Create a team
 3. Copy the join token from your team settings
 
-Once connected, your local node appears in the cloud dashboard alongside any other nodes in your org.
+Once connected, your local node appears in the cloud dashboard alongside any other nodes in your org. Each node stays independent — the cloud is what connects them.
 
 ---
 


### PR DESCRIPTION
Two tasks, one PR:

**task-1772920812786 (P1 — Docs rewrite: reflect multi-team multi-host arch)**
Done criteria met:
- Getting-started guide covers multi-host setup path ✓
- Architecture docs explain node-to-cloud relationship ✓
- No guide assumes single-node-only deployment ✓

**task-1772918982520 (P2 — Divisions copy — partial)**
Option C landed in GETTING-STARTED.md cloud section. Options A+B (hero/features on reflectt.ai) deferred until marketing site ownership is established (pixel confirmed out of scope for them).

Copy shipped:
> One node is a team. Multiple nodes are an org. [...] run separate nodes for different products, clients, or departments — the cloud is how they see each other.