### PR TITLE
fix: auto-link insight when task created with source_insight metadata

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6265,7 +6265,22 @@ export async function createServer(): Promise<FastifyInstance> {
           .then(({ indexTask }) => indexTask(task.id, task.title, undefined, data.done_criteria))
           .catch(() => {})
       }
-      
+
+      // Auto-link insight when task is manually created with source_insight metadata.
+      // Mirrors the bridge's updateInsightStatus call so insights don't stay pending_triage
+      // after an agent manually files a task addressing them.
+      const sourceInsightId = typeof newMetadata.source_insight === 'string' ? newMetadata.source_insight : null
+      if (sourceInsightId && !sourceInsightId.startsWith('ins-test-')) {
+        try {
+          const linkedInsight = getInsight(sourceInsightId)
+          if (linkedInsight && linkedInsight.status !== 'task_created' && linkedInsight.status !== 'closed') {
+            updateInsightStatus(sourceInsightId, 'task_created', task.id)
+          }
+        } catch {
+          // Non-fatal: insight link failure must not block task creation
+        }
+      }
+
       trackTaskEvent('created')
       return { success: true, task: enrichTaskWithComments(task), warnings: creationWarnings }
     } catch (err: any) {


### PR DESCRIPTION
## Problem

When agents manually file a task with `metadata.source_insight`, the linked insight stays `pending_triage` — it never gets marked `task_created`. This causes the same insight to re-appear on every heartbeat, creating a phantom work loop.

The `InsightTaskBridge` already calls `updateInsightStatus` when it auto-creates tasks. Manually-filed tasks had no equivalent.

## Fix

After `taskManager.createTask()` in `POST /tasks`, check for `source_insight` in metadata and call `updateInsightStatus(id, 'task_created', task.id)`.

Guards:
- Skips test insights (`ins-test-*`)
- Skips insights already in `task_created` or `closed` state  
- Non-fatal: insight link failure does not block task creation

## Tests

1761 passed, 1 skipped

Fixes task-1772914167828-u3g4e4ewz