### PR TITLE
fix: stop SSE from broadcasting review notifications to unrelated agents

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -303,8 +303,21 @@ class EventBus {
         return false
       }
       
-      if (event.type === 'message_posted' && data.to && data.to !== subscription.agent) {
-        return false
+      if (event.type === 'message_posted') {
+        // DM addressed to a different agent — suppress
+        if (data.to && data.to !== subscription.agent) {
+          return false
+        }
+        // Channel messages: only deliver if the agent is @mentioned in content
+        // (or it's a DM/direct to this agent, or there's no agent filter set)
+        // This prevents review notifications from broadcasting to all SSE subscribers.
+        if (!data.to && data.channel && data.channel !== 'general') {
+          const mentionPattern = new RegExp(`@${subscription.agent}\\b`, 'i')
+          const isMentioned = mentionPattern.test(data.content || '')
+          if (!isMentioned) {
+            return false
+          }
+        }
       }
 
       if (event.type === 'memory_written' && data.agent !== subscription.agent) {


### PR DESCRIPTION
Fixes dual-delivery review notifications reported by @scout.

## Root cause
Agent-scoped SSE subscriptions only filtered `message_posted` events when `data.to` (DM) was set. Channel messages (`task-notifications`, `reviews`, etc.) have no `to`, so they were delivered to *all* agent-scoped SSE subscribers.

## Fix
In `Events.matchSubscription()` (`src/events.ts`): when `subscription.agent` is set and event is `message_posted` for a non-general channel message with no `to`, only deliver if the content @mentions that agent.

## Impact
- Review requested notifications (and other channel system pings) no longer appear in unrelated agents' inbox streams.
- DM semantics unchanged.

## Tests
`npm test` (1761 passed)

Refs: task-1772901450361 report (echo receiving scout review notif).
