### PR TITLE
fix: stop continuity loop from creating ghost tasks for placeholder agents

### DIFF
--- a/src/continuity-loop.ts
+++ b/src/continuity-loop.ts
@@ -17,6 +17,8 @@ import { generateRecurringCandidates } from './insight-promotion.js'
 import { tickReflectionNudges } from './reflection-automation.js'
 import { routeMessage } from './messageRouter.js'
 import { getDb, safeJsonStringify, safeJsonParse } from './db.js'
+import { presenceManager } from './presence.js'
+import { getAgentRolesSource } from './assignment.js'
 
 // ── Types ──
 
@@ -119,6 +121,31 @@ function getConfig(): ContinuityConfig {
   }
 }
 
+function resolveMonitoredAgents(configAgents: string[]): string[] {
+  const trimmed = (configAgents || []).map(a => String(a || '').trim()).filter(Boolean)
+
+  // If no agents explicitly configured, auto-discover from real runtime presence.
+  // This avoids creating tasks for placeholder agents (e.g. agent-1/2/3) on fresh installs.
+  if (trimmed.length === 0) {
+    return presenceManager
+      .getAllPresence()
+      .filter(p => p.status !== 'offline')
+      .map(p => p.agent)
+      .filter(Boolean)
+  }
+
+  // If we are running with built-in placeholder roles (no TEAM-ROLES.yaml found),
+  // only target agents that have actually checked in via presence.
+  const rolesSource = getAgentRolesSource().source
+  if (rolesSource === 'builtin') {
+    return trimmed.filter(a => Boolean(presenceManager.getPresence(a)))
+  }
+
+  // Otherwise, allow configured agents, but still prefer skipping totally unknown agents.
+  return trimmed
+}
+
+
 // ── Core loop ──
 
 /**
@@ -145,7 +172,9 @@ export async function tickContinuityLoop(): Promise<{
     stats.lastRunAt = now
   }
 
-  if (!config.enabled || config.agents.length === 0) {
+  const monitoredAgents = resolveMonitoredAgents(config.agents)
+
+  if (!config.enabled || monitoredAgents.length === 0) {
     return { actions: [], agentsChecked: 0, replenished: 0 }
   }
 
@@ -153,7 +182,7 @@ export async function tickContinuityLoop(): Promise<{
   const actions: ContinuityAction[] = []
   let replenished = 0
 
-  for (const agent of config.agents) {
+  for (const agent of monitoredAgents) {
     // Cooldown check
     if (lastReplenishAt[agent] && now - lastReplenishAt[agent] < cooldownMs) continue
 
@@ -223,7 +252,7 @@ export async function tickContinuityLoop(): Promise<{
     }
   }
 
-  return { actions, agentsChecked: config.agents.length, replenished }
+  return { actions, agentsChecked: monitoredAgents.length, replenished }
 }
 
 // ── Insight → Task replenishment ──


### PR DESCRIPTION
Fixes `task-1772924539282-9gawgeter`.

## Problem
On fresh installs / new hosts, `TEAM-ROLES.yaml` may be missing. In that case the assignment engine falls back to built-in placeholder roles (`agent-1/2/3`). If `policy.json` (or readyQueueFloor/continuityLoop config) references those agents, the continuity loop can promote insights into tasks assigned to **nonexistent agents**, creating ghost tasks that block queues.

## Fix
Continuity loop now resolves the monitored agent list safely:
- If **no agents** are configured, it auto-discovers agents from runtime `presence`.
- If agent roles source is **builtin** (placeholder roles), it filters the configured agent list to **only agents present in presence**.

This prevents task creation for `agent-1/2/3` unless they are actually real presences.

## Tests
- `npm test` (1761 passed)

## Notes
Does not change the assignment engine’s built-in fallback roles; it only prevents automation from targeting placeholders.
