### PR TITLE
feat: POST /agents + DELETE /agents/:name — manage team agents via API

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -218,6 +218,8 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | GET | `/tasks/board-health` | Board-level health metrics for backlog replenishment. Returns per-agent breakdown (doing, validating, todo, active counts), `needsWork`/`lowWatermark` flags, and `replenishNeeded` trigger (fires when 2+ agents idle or <3 backlog tasks). Query: `include_test=1` to include test-harness tasks. |
 | GET | `/agents` | Agent list — alias for /agents/roles. Returns all agents with roles, WIP status, affinity tags. |
 | GET | `/agents/roles` | Agent role registry with live WIP status. Returns all agents with `name`, `displayName`, `role`, `affinityTags`, `protectedDomains`, `wipCap`, `wipCount`, `overCap`. |
+| POST | `/agents` | Add agent to team. Body: `{ name, role, description?, affinityTags?, wipCap? }`. Hot-reloads TEAM-ROLES.yaml. |
+| DELETE | `/agents/:name` | Remove agent from team. Hot-reloads TEAM-ROLES.yaml. |
 | POST | `/config/identity` | Set an agent's display name. Body: `{ "agent": "agent-1", "displayName": "Juniper" }`. Persists to TEAM-ROLES.yaml, hot-reloads. Dashboard and mentions use display name. |
 | PUT | `/config/team-roles` | Write TEAM-ROLES.yaml. Body: `{ "yaml": "agents:\n  - name: link\n    role: engineer..." }`. Hot-reloads on save. Used by bootstrap agent to configure team from user intent. |
 | GET | `/resolve/mention/:mention` | Resolve a mention string (name, displayName, or alias) to canonical agent ID. Returns `{ agent, displayName, role }`. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -7939,6 +7939,116 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
+  // POST /agents — Add a single agent to the team
+  app.post('/agents', async (request, reply) => {
+    const body = request.body as Record<string, unknown>
+    const name = typeof body.name === 'string' ? body.name.trim().toLowerCase() : ''
+    const role = typeof body.role === 'string' ? body.role.trim() : ''
+    const description = typeof body.description === 'string' ? body.description.trim() : ''
+
+    if (!name) { reply.code(400); return { success: false, error: 'name is required' } }
+    if (!role) { reply.code(400); return { success: false, error: 'role is required' } }
+    if (/[^a-z0-9_-]/.test(name)) { reply.code(400); return { success: false, error: 'name must be lowercase alphanumeric (a-z, 0-9, -, _)' } }
+
+    // Check if agent already exists
+    const existing = getAgentRoles().find(r => r.name === name)
+    if (existing) { reply.code(409); return { success: false, error: `Agent "${name}" already exists (role: ${existing.role})` } }
+
+    // Read existing YAML and append new agent
+    const { readFileSync, writeFileSync, existsSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const filePath = join(REFLECTT_HOME, 'TEAM-ROLES.yaml')
+
+    let yaml = ''
+    if (existsSync(filePath)) {
+      yaml = readFileSync(filePath, 'utf-8')
+    }
+    if (!yaml.includes('agents:')) {
+      yaml = 'agents:\n'
+    }
+
+    // Build agent YAML entry
+    const affinityTags = Array.isArray(body.affinityTags) ? body.affinityTags : [role]
+    const wipCap = typeof body.wipCap === 'number' ? body.wipCap : 2
+    const desc = description || `${role} agent.`
+
+    const entry = [
+      `  - name: ${name}`,
+      `    role: ${role}`,
+      `    description: ${desc}`,
+      `    affinityTags: [${affinityTags.join(', ')}]`,
+      `    wipCap: ${wipCap}`,
+    ].join('\n')
+
+    // Insert before lanes: section (if present), otherwise append
+    const lanesIdx = yaml.indexOf('\nlanes:')
+    if (lanesIdx >= 0) {
+      yaml = yaml.slice(0, lanesIdx) + '\n' + entry + yaml.slice(lanesIdx)
+    } else {
+      yaml = yaml.trimEnd() + '\n' + entry + '\n'
+    }
+
+    try {
+      writeFileSync(filePath, yaml, 'utf-8')
+      const { loadAgentRoles } = await import('./assignment.js')
+      const reloaded = loadAgentRoles()
+      return {
+        success: true,
+        agent: { name, role, description: desc, wipCap },
+        totalAgents: reloaded.roles.length,
+        hint: `Agent "${name}" added to team and hot-reloaded. Start heartbeating: GET /heartbeat/${name}`,
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to save agent'
+      reply.code(500)
+      return { success: false, error: msg }
+    }
+  })
+
+  // DELETE /agents/:name — Remove an agent from the team
+  app.delete<{ Params: { name: string } }>('/agents/:name', async (request, reply) => {
+    const name = request.params.name.toLowerCase()
+    const existing = getAgentRoles().find(r => r.name === name)
+    if (!existing) { reply.code(404); return { success: false, error: `Agent "${name}" not found` } }
+
+    const { readFileSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const filePath = join(REFLECTT_HOME, 'TEAM-ROLES.yaml')
+    let yaml = readFileSync(filePath, 'utf-8')
+
+    // Remove the agent block: from "  - name: <name>" to the next "  - name:" or top-level key or EOF
+    const lines = yaml.split('\n')
+    const filtered: string[] = []
+    let skipping = false
+    for (const line of lines) {
+      if (line.match(new RegExp(`^\\s+-\\s+name:\\s+${name}\\s*$`))) {
+        skipping = true
+        continue
+      }
+      if (skipping) {
+        // Stop skipping at next agent entry, top-level key, or blank line before top-level
+        if (line.match(/^\s+-\s+name:\s/) || line.match(/^[a-z]/)) {
+          skipping = false
+          filtered.push(line)
+        }
+        continue
+      }
+      filtered.push(line)
+    }
+    yaml = filtered.join('\n')
+
+    try {
+      writeFileSync(filePath, yaml, 'utf-8')
+      const { loadAgentRoles } = await import('./assignment.js')
+      const reloaded = loadAgentRoles()
+      return { success: true, removed: name, totalAgents: reloaded.roles.length }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to remove agent'
+      reply.code(500)
+      return { success: false, error: msg }
+    }
+  })
+
   // Resolve a mention string (name, displayName, or alias) to an agent ID
   app.get<{ Params: { mention: string } }>('/resolve/mention/:mention', async (request) => {
     const agentName = resolveAgentMention(request.params.mention)


### PR DESCRIPTION
Fixes the UX gap where adding agents after onboarding required editing YAML manually.

`POST /agents` — add agent (name, role, description, affinityTags, wipCap)
`DELETE /agents/:name` — remove agent

Both hot-reload TEAM-ROLES.yaml. Validated live on Mac Daddy.

Route-docs: 422/422 ✅ | Tests: 1761/1761 ✅