### PR TITLE
feat: task bounce gate — track validating→doing regressions

### DIFF
--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -35,6 +35,7 @@ export interface PulseSnapshot {
   agents: PulseAgent[]
   pendingReviews: Array<{ taskId: string; title: string; reviewer: string }>
   recentActivity?: { messagesLastHour: number; tasksCompletedToday: number }
+  highBounceTasks?: Array<{ taskId: string; title: string; bounceCount: number; assignee?: string }>
 }
 
 export interface CompactPulse {
@@ -45,6 +46,7 @@ export interface CompactPulse {
   board: string  // e.g. "T:3 D:2 V:1 ✓:5 B:0"
   agents: string[] // e.g. ["link:working→task-123(activity endpoint)", "pixel:working→task-456(UI scaffold)"]
   reviews: string[] // e.g. ["task-789→sage"]
+  highBounce?: string[] // e.g. ["abc123(bounces:3)→link"] — tasks that keep regressing
 }
 
 function getDeployInfo(): PulseSnapshot['deploy'] {
@@ -126,6 +128,19 @@ export function generatePulse(): PulseSnapshot {
     t.status === 'done' && (t.updatedAt || 0) >= todayStart.getTime()
   ).length
 
+  // High-bounce tasks: any non-done task with bounce_count >= 1
+  const highBounceTasks = allTasks
+    .filter(t => t.status !== 'done' && t.status !== 'cancelled')
+    .map(t => ({
+      taskId: t.id,
+      title: t.title,
+      bounceCount: typeof (t.metadata as any)?.bounce_count === 'number' ? (t.metadata as any).bounce_count as number : 0,
+      assignee: t.assignee,
+    }))
+    .filter(t => t.bounceCount >= 1)
+    .sort((a, b) => b.bounceCount - a.bounceCount)
+    .slice(0, 10)
+
   return {
     ts: Date.now(),
     deploy: getDeployInfo(),
@@ -138,6 +153,7 @@ export function generatePulse(): PulseSnapshot {
       messagesLastHour: recentMessages.length,
       tasksCompletedToday,
     },
+    highBounceTasks: highBounceTasks.length > 0 ? highBounceTasks : undefined,
   }
 }
 
@@ -177,6 +193,10 @@ export function generateCompactPulse(): CompactPulse {
     `${r.taskId.slice(-12)}→${r.reviewer}`
   )
 
+  const bounceWarnings = (pulse.highBounceTasks || []).map(t =>
+    `${t.taskId.slice(-12)}(bounces:${t.bounceCount})→${t.assignee || 'unassigned'}`
+  )
+
   return {
     ts: pulse.ts,
     deploy: deployStr,
@@ -185,5 +205,6 @@ export function generateCompactPulse(): CompactPulse {
     board: boardStr,
     agents: agentStrs,
     reviews: reviewStrs,
+    ...(bounceWarnings.length > 0 ? { highBounce: bounceWarnings } : {}),
   }
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1342,6 +1342,44 @@ class TaskManager {
 
     let transitionEvent: Record<string, unknown> | undefined
 
+    // ── Bounce gate: validating → doing ────────────────────────────────────
+    // A task bouncing from validating back to doing is a signal of rework.
+    // Track bounce_count in metadata. On the 3rd bounce (bounce_count >= 2),
+    // require a documented reason before allowing the regression.
+    if (task.status === 'validating' && nextStatus === 'doing') {
+      const meta = (task.metadata || {}) as Record<string, unknown>
+      const currentBounce = typeof meta.bounce_count === 'number' ? meta.bounce_count : 0
+      const newBounceCount = currentBounce + 1
+
+      if (currentBounce >= 2) {
+        // 3rd+ bounce: require documented reason
+        if (!transition || typeof transition !== 'object') {
+          throw new Error(
+            `Bounce gate: this task has bounced ${currentBounce} times. ` +
+            `Provide metadata.transition = { type: "bounce_back", reason: "..." } explaining the rework.`
+          )
+        }
+        const bounceReason = (transition as Record<string, unknown>).reason
+        if (typeof bounceReason !== 'string' || bounceReason.trim().length === 0) {
+          throw new Error(
+            `Bounce gate: metadata.transition.reason is required when re-opening a task that has bounced ${currentBounce} times.`
+          )
+        }
+      }
+
+      // Merge bounce_count into metadata, preserving existing task metadata
+      // (task.metadata has eta etc; updates.metadata may have transition or be empty)
+      const existingMeta = {
+        ...(task.metadata || {}),
+        ...((updates.metadata || {}) as Record<string, unknown>),
+      }
+      updates.metadata = {
+        ...existingMeta,
+        bounce_count: newBounceCount,
+        last_bounce_at: Date.now(),
+      }
+    }
+
     if (task.status === 'doing' && nextStatus === 'blocked') {
       const parsed = requireTransition('pause', ['reason'], 'doing->blocked transition')
       transitionEvent = {

--- a/tests/task-bounce-gate.test.ts
+++ b/tests/task-bounce-gate.test.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Task bounce gate tests
+//
+// Proves: when a task bounces from validating back to doing,
+// bounce_count increments in metadata. On the 3rd bounce (bounce_count >= 2),
+// a documented reason is required.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { taskManager } from '../src/tasks.js'
+
+describe('Task bounce gate (validating → doing)', () => {
+  const createdIds: string[] = []
+
+  afterEach(() => {
+    for (const id of createdIds) {
+      try { taskManager.deleteTask(id) } catch { /* ok */ }
+    }
+    createdIds.length = 0
+  })
+
+  async function createValidatingTask(): Promise<string> {
+    const task = await taskManager.createTask({
+      title: 'TEST: bounce gate task',
+      status: 'todo',
+      assignee: 'forge',
+      reviewer: 'kai',
+      createdBy: 'test',
+      done_criteria: ['Feature shipped'],
+      metadata: {
+        eta: '~1h',
+        reflection_exempt: true,
+        reflection_exempt_reason: 'test fixture',
+      },
+    })
+    createdIds.push(task.id)
+
+    // Move to doing
+    await taskManager.updateTask(task.id, { status: 'doing' })
+
+    // Move to validating (requires artifact_path)
+    await taskManager.updateTask(task.id, {
+      status: 'validating',
+      metadata: {
+        eta: '~1h',
+        artifact_path: 'process/TEST-bounce.md',
+        qa_bundle: {
+          lane: 'eng',
+          summary: 'done',
+          review_packet: {
+            task_id: task.id,
+            pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+            commit: 'abc1234',
+            changed_files: ['src/tasks.ts'],
+            artifact_path: 'process/TEST-bounce.md',
+            caveats: 'none',
+          },
+        },
+        review_handoff: {
+          task_id: task.id,
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+          commit_sha: 'abc1234',
+          artifact_path: 'process/TEST-bounce.md',
+          known_caveats: 'none',
+        },
+        reflection_exempt: true,
+        reflection_exempt_reason: 'test fixture',
+      },
+    })
+
+    return task.id
+  }
+
+  it('bounce 1: increments bounce_count to 1, no reason required', async () => {
+    const id = await createValidatingTask()
+
+    // First bounce: validating → doing
+    await taskManager.updateTask(id, { status: 'doing' })
+
+    const updated = taskManager.listTasks({}).find(t => t.id === id)
+    expect(updated?.metadata?.bounce_count).toBe(1)
+    expect(updated?.metadata?.last_bounce_at).toBeTypeOf('number')
+    expect(updated?.status).toBe('doing')
+  })
+
+  it('bounce 2: increments bounce_count to 2, still no reason required', async () => {
+    const id = await createValidatingTask()
+
+    // First bounce
+    await taskManager.updateTask(id, { status: 'doing' })
+
+    // Move back to validating
+    await taskManager.updateTask(id, {
+      status: 'validating',
+      metadata: {
+        eta: '~1h',
+        artifact_path: 'process/TEST-bounce.md',
+        bounce_count: 1, // carry forward
+        qa_bundle: {
+          lane: 'eng',
+          summary: 'done',
+          review_packet: {
+            task_id: id,
+            pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+            commit: 'abc1234',
+            changed_files: ['src/tasks.ts'],
+            artifact_path: 'process/TEST-bounce.md',
+            caveats: 'none',
+          },
+        },
+        review_handoff: {
+          task_id: id,
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+          commit_sha: 'abc1234',
+          artifact_path: 'process/TEST-bounce.md',
+          known_caveats: 'none',
+        },
+        reflection_exempt: true,
+        reflection_exempt_reason: 'test fixture',
+      },
+    })
+
+    // Second bounce: no reason needed yet
+    await taskManager.updateTask(id, { status: 'doing' })
+
+    const updated = taskManager.listTasks({}).find(t => t.id === id)
+    expect(updated?.metadata?.bounce_count).toBe(2)
+  })
+
+  it('bounce 3+: requires documented reason (throws without it)', async () => {
+    const id = await createValidatingTask()
+
+    // Artificially set bounce_count to 2 (simulating 2 previous bounces)
+    await taskManager.patchTaskMetadata(id, { bounce_count: 2 })
+
+    // Move back to validating
+    await taskManager.updateTask(id, {
+      status: 'validating',
+      metadata: {
+        eta: '~1h',
+        artifact_path: 'process/TEST-bounce.md',
+        bounce_count: 2,
+        qa_bundle: {
+          lane: 'eng',
+          summary: 'done',
+          review_packet: {
+            task_id: id,
+            pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+            commit: 'abc1234',
+            changed_files: ['src/tasks.ts'],
+            artifact_path: 'process/TEST-bounce.md',
+            caveats: 'none',
+          },
+        },
+        review_handoff: {
+          task_id: id,
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+          commit_sha: 'abc1234',
+          artifact_path: 'process/TEST-bounce.md',
+          known_caveats: 'none',
+        },
+        reflection_exempt: true,
+        reflection_exempt_reason: 'test fixture',
+      },
+    })
+
+    // 3rd bounce: should throw without reason
+    await expect(
+      taskManager.updateTask(id, { status: 'doing' })
+    ).rejects.toThrow(/Bounce gate/)
+  })
+
+  it('bounce 3+: succeeds when reason is provided', async () => {
+    const id = await createValidatingTask()
+
+    // Artificially set bounce_count to 2
+    await taskManager.patchTaskMetadata(id, { bounce_count: 2 })
+
+    // Move back to validating
+    await taskManager.updateTask(id, {
+      status: 'validating',
+      metadata: {
+        eta: '~1h',
+        artifact_path: 'process/TEST-bounce.md',
+        bounce_count: 2,
+        qa_bundle: {
+          lane: 'eng',
+          summary: 'done',
+          review_packet: {
+            task_id: id,
+            pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+            commit: 'abc1234',
+            changed_files: ['src/tasks.ts'],
+            artifact_path: 'process/TEST-bounce.md',
+            caveats: 'none',
+          },
+        },
+        review_handoff: {
+          task_id: id,
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/999',
+          commit_sha: 'abc1234',
+          artifact_path: 'process/TEST-bounce.md',
+          known_caveats: 'none',
+        },
+        reflection_exempt: true,
+        reflection_exempt_reason: 'test fixture',
+      },
+    })
+
+    // 3rd bounce with documented reason: should succeed
+    await expect(
+      taskManager.updateTask(id, {
+        status: 'doing',
+        metadata: {
+          transition: {
+            type: 'bounce_back',
+            reason: 'Reviewer found edge case in auth flow — need to revisit token refresh logic',
+          },
+        },
+      })
+    ).resolves.toBeDefined()
+
+    const updated = taskManager.listTasks({}).find(t => t.id === id)
+    expect(updated?.metadata?.bounce_count).toBe(3)
+    expect(updated?.status).toBe('doing')
+  })
+
+  it('pulse surfaces high-bounce tasks', async () => {
+    const id = await createValidatingTask()
+
+    // Set bounce_count = 2 directly
+    await taskManager.patchTaskMetadata(id, { bounce_count: 2 })
+
+    const { generatePulse } = await import('../src/pulse.js')
+    const pulse = generatePulse()
+
+    const bounced = pulse.highBounceTasks?.find(t => t.taskId === id)
+    expect(bounced).toBeDefined()
+    expect(bounced?.bounceCount).toBe(2)
+  })
+})


### PR DESCRIPTION
## What

Adds a bounce counter to the task lifecycle. When a task bounces from `validating` back to `doing`, it's a signal of rework. After the 3rd bounce it requires a documented reason.

## How it works

**`applyLaneStateLock` (tasks.ts):**
- `validating → doing` transition: increment `metadata.bounce_count`
- First 2 bounces: pass through silently (count is tracked)
- 3rd bounce (`bounce_count >= 2`): throws unless `metadata.transition = { type: "bounce_back", reason: "..." }` is provided
- Existing task metadata (eta, etc.) is preserved during the merge

**`pulse.ts`:**
- `highBounceTasks` field added to `PulseSnapshot` and `CompactPulse`
- Surfaces all non-done tasks with `bounce_count >= 1`, sorted by count, capped at 10
- Compact pulse includes `highBounce: ["taskId(bounces:N)→assignee"]`

## Tests (5)

| Test | Result |
|---|---|
| 1st bounce: bounce_count = 1, no reason required | ✅ |
| 2nd bounce: bounce_count = 2, no reason required | ✅ |
| 3rd bounce without reason: throws | ✅ |
| 3rd bounce with documented reason: succeeds | ✅ |
| Pulse surfaces high-bounce tasks | ✅ |

Implements: task-1772899661988-yp0lcvgtc