### PR TITLE
fix: dashboard wizard dismiss + task count showing 0

### DIFF
--- a/incidents/watchdog-incidents.jsonl
+++ b/incidents/watchdog-incidents.jsonl
@@ -104,3 +104,5 @@
 {"type":"stale_working","at":1772389640982,"agent":"pixel","taskId":"task-1772383147598-2xofiqz13","thresholdMs":2700000,"lastUpdateAt":1772386415894,"workingSinceAt":1772386537876}
 {"type":"stale_working","at":1772397203011,"agent":"link","taskId":"task-1771849175579-apuqqi0fd","thresholdMs":2700000,"lastUpdateAt":1772394472185,"workingSinceAt":1772394368602}
 {"type":"stale_working","at":1772412027791,"agent":"link","taskId":"task-1771849175579-apuqqi0fd","thresholdMs":2700000,"lastUpdateAt":1772409304819,"workingSinceAt":1772409304817}
+{"type":"stale_working","at":1772943984404,"agent":"pixel","taskId":"task-1772899959780-o1gjus1es","thresholdMs":2700000,"lastUpdateAt":1772941235087,"workingSinceAt":1772941090159}
+{"type":"stale_working","at":1772945366960,"agent":"pixel","taskId":"task-1772899959780-o1gjus1es","thresholdMs":2700000,"lastUpdateAt":1772941235087,"workingSinceAt":1772943984415}

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -726,9 +726,10 @@ async function loadPresence() {
 // ---- Tasks ----
 async function loadTasks(forceFull = false) {
   try {
-    const useDelta = !forceFull && lastTaskSync > 0;
+    // Force full load if we have no tasks yet (e.g. first load failed)
+    const useDelta = !forceFull && lastTaskSync > 0 && allTasks.length > 0;
     const qs = new URLSearchParams();
-    qs.set('limit', '80');
+    qs.set('limit', '200');
     if (useDelta) qs.set('updatedSince', String(lastTaskSync));
 
     const r = await fetch(BASE + '/tasks?' + qs.toString());
@@ -3020,13 +3021,21 @@ async function checkGettingStarted() {
 
 function dismissGettingStarted() {
   const panel = document.getElementById('getting-started');
-  if (panel) panel.classList.add('hidden');
+  if (panel) {
+    panel.classList.add('hidden');
+    panel.style.display = 'none';  // belt + suspenders
+  }
   try { localStorage.setItem('reflectt-gs-dismissed', '1'); } catch {}
 }
+// Expose globally for onclick handlers (safety net)
+window.dismissGettingStarted = dismissGettingStarted;
+window.dismissFirstBootBanner = dismissFirstBootBanner;
 
 updateClock();
 setInterval(updateClock, 30000);
 checkGettingStarted();
+// Retry getting-started check after 5s in case health wasn't ready at boot
+setTimeout(checkGettingStarted, 5000);
 refresh();
 connectEventStream();
 startAdaptiveRefresh();


### PR DESCRIPTION
## Problem
Local dashboard at /dashboard had two bugs after restart:
1. Getting Started wizard dismiss button did nothing
2. Tasks sidebar showed 0 despite API returning 174+ tasks

## Root Cause
1. **Wizard dismiss**: `dismissGettingStarted()` sets localStorage + adds CSS `hidden` class, but if `checkGettingStarted()` failed on init (server not ready yet), the wizard was shown and couldn't auto-hide. The dismiss function itself worked, but the `hidden` class could race with other styles.
2. **Task count 0**: Initial `loadTasks()` used delta optimization (`lastTaskSync > 0`) which returned early with no results if the first fetch failed. Subsequent refreshes kept using delta mode, never loading tasks. Also limit was 80 but system had 205+ tasks.

## Fix
1. Added `style.display=none` as belt+suspenders on dismiss, exposed functions on `window` for onclick safety
2. Added retry of `checkGettingStarted()` after 5s for slow server starts
3. Force full task load when `allTasks.length === 0` regardless of delta mode
4. Bumped task load limit from 80 to 200

Source: task-1772922555056-ckkj6klty