### PR TITLE
fix: reviewRequested notifications target only assigned reviewer

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7457,6 +7457,7 @@ export async function createServer(): Promise<FastifyInstance> {
         const prLine = prUrl ? `\nPR: ${prUrl}` : ''
         chatManager.sendMessage({
           from: 'system',
+          to: existing.reviewer,
           content: `@${existing.reviewer} [reviewRequested:${task.id}] ${task.title} → validating${prLine}`,
           channel: 'task-notifications',
           metadata: {
@@ -7575,6 +7576,7 @@ export async function createServer(): Promise<FastifyInstance> {
         const reviewMsg = `@${task.reviewer} review requested: **${task.title}** (${task.id})${prLink}. Please approve or flag issues.`
         chatManager.sendMessage({
           from: 'system',
+          to: task.reviewer,
           content: reviewMsg,
           channel: 'reviews',
           metadata: {


### PR DESCRIPTION
## Summary
reviewRequested notifications were broadcasting to ALL agents subscribed to `#reviews` and `#task-notifications` channels. Since both are in `DEFAULT_INBOX_SUBSCRIPTIONS`, every agent received review requests in their inbox — even when they weren't the reviewer.

## Root Cause
Both review notification messages used `channel: 'reviews'` / `channel: 'task-notifications'` without a `to` field, so the inbox router treated them as channel broadcasts.

## Fix
Added `to: reviewer` on both review notification `sendMessage()` calls. The inbox's `calculatePriority()` checks `message.to === agent` first (DM path, high priority) — non-matching agents get `null` (not delivered to inbox). Messages still appear in the channel's chat history for anyone who browses it.

## Testing
- 1766 tests pass, 422/422 route-docs
- Canary: when task enters validating with reviewer=scout, only scout should see the reviewRequested notification in their inbox; other agents won't.

Fixes task-1772929504184-k69oee99a