### PR TITLE
fix: inbox excludes targeted messages for other agents

### DIFF
--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -286,6 +286,11 @@ class InboxManager {
       return { priority: 'high', reason: 'dm' }
     }
     
+    // Targeted message for someone else — skip unless @mentioned
+    if (message.to && message.to !== agent && !this.isMentioned(message, agent)) {
+      return null
+    }
+    
     // High priority: @mention
     if (this.isMentioned(message, agent)) {
       return { priority: 'high', reason: 'mention' }


### PR DESCRIPTION
## Follow-up to PR #796

PR #796 added `to: reviewer` on review notifications, but the inbox `calculatePriority()` still matched via channel subscription path. Scout's canary confirmed: echo's inbox still received review_routing messages targeted to scout.

## Fix
In `calculatePriority()`: if `message.to` is set and `message.to !== agent` and agent is not @mentioned, return `null` (skip). This runs before the channel subscription check.

## Testing
1766 tests pass, 422/422 route-docs.

Canary: scout should re-verify `/inbox/echo` after deploy.

Fixes task-1772929504184-k69oee99a