### PR TITLE
fix: prevent review_routing messages from leaking into non-target inboxes

### DIFF
--- a/src/inbox.ts
+++ b/src/inbox.ts
@@ -281,6 +281,26 @@ class InboxManager {
     agent: string, 
     state: InboxState
   ): { priority: 'high' | 'medium' | 'low'; reason: string } | null {
+    // Access constraint: a DM addressed to another agent is never relevant,
+    // even if the channel is subscribed (prevents review_routing leaks).
+    if (message.to && message.to !== agent) {
+      return null
+    }
+
+    const meta = (message.metadata ?? {}) as Record<string, unknown>
+    const kind = typeof meta.kind === 'string' ? meta.kind : ''
+
+    // review_routing messages are targeted; do not surface them in non-target inboxes
+    // just because the agent subscribes to the channel.
+    if (kind === 'review_routing') {
+      const reviewer = typeof meta.reviewer === 'string' ? meta.reviewer : ''
+      const assignee = typeof meta.assignee === 'string' ? meta.assignee : ''
+      const targeted = Boolean((reviewer && agent === reviewer) || (assignee && agent === assignee))
+      if (!targeted && !this.isMentioned(message, agent) && message.to !== agent) {
+        return null
+      }
+    }
+
     // High priority: DM
     if (message.to === agent) {
       return { priority: 'high', reason: 'dm' }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2713,6 +2713,45 @@ describe('Inbox', () => {
     expect(getStatus).toBe(200)
     expect(getBody.subscriptions).toEqual(['reviews', 'blockers'])
   })
+
+  it('does not show review_routing messages in non-target inboxes (even if subscribed)', async () => {
+    const reviewer = 'revieweragent'
+    const nonTarget = 'nontargetagent'
+
+    // Ensure nonTarget is subscribed to reviews (isolation)
+    await req('POST', `/inbox/${nonTarget}/subscribe`, { channels: ['reviews'] })
+
+    const t0 = Date.now()
+    const token1 = `INBOX-REVIEW-ROUTING-DM-${t0}`
+
+    // DM-style review ping addressed to reviewer, posted in #reviews
+    const { status: ps, body: pb } = await req('POST', '/chat/messages', {
+      from: 'system',
+      to: reviewer,
+      channel: 'reviews',
+      content: `@${reviewer} task-1234567890123-abcdefg review requested: **${token1}**`,
+      metadata: { kind: 'review_routing', reviewer, assignee: 'builder' },
+    })
+    expect(ps).toBe(200)
+    expect(pb.message?.channel).toBe('reviews')
+
+    // Ensure the message exists in the channel stream (persisted)
+    const { status: cs, body: cb } = await req('GET', `/chat/messages?channel=reviews&since=${t0 - 1}&limit=50`)
+    expect(cs).toBe(200)
+    const channelHas = (cb.messages || []).some((m: any) => String(m.content || '').includes(token1))
+    expect(channelHas).toBe(true)
+
+    const { status: s1, body: b1 } = await req('GET', `/inbox/${nonTarget}?since=${t0 - 1}&limit=50`)
+    expect(s1).toBe(200)
+    const hasLeak1 = (b1.messages || []).some((m: any) => String(m.content || '').includes(token1))
+    expect(hasLeak1).toBe(false)
+
+    // Sanity: reviewer should see their own review ping
+    const { status: s2, body: b2 } = await req('GET', `/inbox/${reviewer}?since=${t0 - 1}&limit=50`)
+    expect(s2).toBe(200)
+    const reviewerSees = (b2.messages || []).some((m: any) => String(m.content || '').includes(token1))
+    expect(reviewerSees).toBe(true)
+  })
 })
 
 describe('Mention Ack', () => {


### PR DESCRIPTION
Fixes task-1772955288702-pid8yjh1x.

## Problem
ReviewRequested/review_routing messages posted to channel=reviews were appearing in non-reviewer inboxes with reason=subscribed.

## Root cause
Inbox relevance logic treated `message.to` as a *priority* (DM), but not an *access constraint*. So agents subscribed to #reviews could see messages even when `to` targeted a different agent.

## Fix
In `InboxManager.calculatePriority()`:
- If `message.to` is set and `message.to !== agent` → return null (never relevant).
- Treat `metadata.kind === 'review_routing'` as targeted: only surface for reviewer/assignee, explicit @mention, or `to=agent`.

## Tests
- Added regression test in `tests/api.test.ts`.
- `npm test` passed (1768 tests).

Evidence (from @scout): echo inbox included a reviews message with `to=scout` and `metadata.kind=review_routing`.
