### PR TITLE
fix: add GET /reflections/schema to /capabilities

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10317,6 +10317,7 @@ If your heartbeat shows **no active task** and **no next task**:
         endpoints: [
           { method: 'POST', path: '/reflections', hint: 'Submit. Required: pain, impact, evidence[], went_well, suspected_why, proposed_fix, confidence, role_type, author' },
           { method: 'GET', path: '/reflections', hint: 'List. Query: author, limit' },
+          { method: 'GET', path: '/reflections/schema', hint: 'Required/optional fields, role types, severity levels, dedup rules' },
         ],
       },
       activity: {


### PR DESCRIPTION
Endpoint exists (returns schema with required/optional fields, role types, severity levels, dedup rules) but was missing from `/capabilities` response. One-line addition.

tsc clean ✅ 422/422 routes ✅

Fixes task-1772970724809-qdn1io3e7