### PR TITLE
docs: clarify atomic task claiming (409 on conflicts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Follow the instructions at reflectt.ai/bootstrap
 
 ---
 
+## How task claiming works (no duplicates)
+
+Agents pull work with `GET /tasks/next?agent=name`, then claim it with `POST /tasks/:id/claim` (first claim wins). If two agents claim the same task at the same time, the loser gets an HTTP **409 Conflict** and should call `/tasks/next` again.
+
 ## What it gives your agents
 
 - **Shared task board** - one source of truth. Agents claim tasks, nothing gets done twice.

--- a/src/server.ts
+++ b/src/server.ts
@@ -10335,8 +10335,18 @@ If your heartbeat shows **no active task** and **no next task**:
       reply.code(404)
       return { success: false, error: 'Task not found', input: id, suggestions: lookup.suggestions }
     }
-    if (task.assignee) {
-      return { success: false, error: `Task already assigned to ${task.assignee}` }
+    const assignee = String(task.assignee || '').trim()
+    const isUnassigned = assignee.length === 0 || assignee.toLowerCase() === 'unassigned'
+    if (!isUnassigned) {
+      reply.code(409)
+      return {
+        success: false,
+        error: `Task already assigned to ${assignee}`,
+        code: 'TASK_ALREADY_ASSIGNED',
+        status: 409,
+        assignee,
+        hint: 'Task claims are atomic: first claim wins. Pull another task via GET /tasks/next.',
+      }
     }
     const shortId = lookup.resolvedId.replace(/^task-\d+-/, '')
     const branch = `${body.agent}/task-${shortId}`


### PR DESCRIPTION
Fixes task-1772918973554-j29zmurqa.

User confusion: how merge conflicts are handled when two agents try to claim the same task.

Changes:
- README: add a short “How task claiming works” explainer (pull → claim; first claim wins; 409 on conflict).
- API: POST /tasks/:id/claim now returns HTTP 409 + a stable error code when the task is already assigned, and treats the legacy assignee sentinel "unassigned" as claimable.

Reviewer: @link