### PR TITLE
fix: writeTaskToDb cascade delete wipes all task comments

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -755,33 +755,69 @@ class TaskManager {
     try {
       const db = getDb()
       const commentCount = this.getTaskCommentCount(task.id)
-      db.prepare(`
-        INSERT OR REPLACE INTO tasks (
-          id, title, description, status, assignee, reviewer, done_criteria,
-          created_by, created_at, updated_at, priority, blocked_by, epic_id,
-          tags, metadata, team_id, comment_count, due_at, scheduled_for
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(
-        task.id,
-        task.title,
-        task.description ?? null,
-        task.status,
-        task.assignee ?? null,
-        task.reviewer ?? null,
-        safeJsonStringify(task.done_criteria),
-        task.createdBy,
-        task.createdAt,
-        task.updatedAt,
-        task.priority ?? null,
-        safeJsonStringify(task.blocked_by),
-        task.epic_id ?? null,
-        safeJsonStringify(task.tags),
-        safeJsonStringify(task.metadata),
-        task.teamId ?? null,
-        commentCount,
-        task.dueAt ?? null,
-        task.scheduledFor ?? null,
-      )
+
+      // Use UPDATE for existing tasks to avoid INSERT OR REPLACE which triggers
+      // ON DELETE CASCADE on foreign keys (task_comments, task_history), wiping
+      // all comments/history for the task. Only INSERT for genuinely new tasks.
+      const existing = db.prepare('SELECT 1 FROM tasks WHERE id = ?').get(task.id)
+      if (existing) {
+        db.prepare(`
+          UPDATE tasks SET
+            title = ?, description = ?, status = ?, assignee = ?, reviewer = ?,
+            done_criteria = ?, created_by = ?, created_at = ?, updated_at = ?,
+            priority = ?, blocked_by = ?, epic_id = ?, tags = ?, metadata = ?,
+            team_id = ?, comment_count = ?, due_at = ?, scheduled_for = ?
+          WHERE id = ?
+        `).run(
+          task.title,
+          task.description ?? null,
+          task.status,
+          task.assignee ?? null,
+          task.reviewer ?? null,
+          safeJsonStringify(task.done_criteria),
+          task.createdBy,
+          task.createdAt,
+          task.updatedAt,
+          task.priority ?? null,
+          safeJsonStringify(task.blocked_by),
+          task.epic_id ?? null,
+          safeJsonStringify(task.tags),
+          safeJsonStringify(task.metadata),
+          task.teamId ?? null,
+          commentCount,
+          task.dueAt ?? null,
+          task.scheduledFor ?? null,
+          task.id,
+        )
+      } else {
+        db.prepare(`
+          INSERT INTO tasks (
+            id, title, description, status, assignee, reviewer, done_criteria,
+            created_by, created_at, updated_at, priority, blocked_by, epic_id,
+            tags, metadata, team_id, comment_count, due_at, scheduled_for
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(
+          task.id,
+          task.title,
+          task.description ?? null,
+          task.status,
+          task.assignee ?? null,
+          task.reviewer ?? null,
+          safeJsonStringify(task.done_criteria),
+          task.createdBy,
+          task.createdAt,
+          task.updatedAt,
+          task.priority ?? null,
+          safeJsonStringify(task.blocked_by),
+          task.epic_id ?? null,
+          safeJsonStringify(task.tags),
+          safeJsonStringify(task.metadata),
+          task.teamId ?? null,
+          commentCount,
+          task.dueAt ?? null,
+          task.scheduledFor ?? null,
+        )
+      }
     } catch (err) {
       console.error(`[Tasks] Failed to write task ${task.id} to SQLite:`, err)
     }


### PR DESCRIPTION
## P0 Root Cause

`writeTaskToDb()` used `INSERT OR REPLACE INTO tasks` which in SQLite is actually DELETE + INSERT. The `task_comments` table has `FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE`, so every task update **silently deleted all comments and history** for that task.

## Why it wasn't caught earlier
Comments only disappeared when a metadata update happened *after* the comment was written. The review_handoff stamping path (`patchTaskMetadata()` called right after `addTaskComment()`) triggered this every time. Normal comments survived because no immediate metadata update followed.

## Fix
Check if task exists → UPDATE for existing tasks, INSERT for new tasks. No cascade deletion triggered.

## Testing
1768 tests pass (includes sage's new review_handoff tests), 422/422 routes.