### PR TITLE
fix: review SLA false positives on needs_author tasks

### DIFF
--- a/src/boardHealthWorker.ts
+++ b/src/boardHealthWorker.ts
@@ -721,6 +721,15 @@ export class BoardHealthWorker {
 
       // Check reviewer activity on this task using the review_last_activity_at metadata field
       const meta = (task.metadata || {}) as Record<string, unknown>
+
+      // ── Skip tasks where reviewer has already acted ──
+      // If review_state is 'needs_author', the ball is with the assignee, not the reviewer.
+      // If reviewer_decision exists, the reviewer has already made a decision (approved/rejected).
+      // In either case, SLA breach should not page the reviewer.
+      const reviewState = typeof meta.review_state === 'string' ? meta.review_state : ''
+      const reviewerDecision = meta.reviewer_decision
+      if (reviewState === 'needs_author' || reviewerDecision != null) continue
+
       const reviewEnteredAt = normalizeEpochMs((meta as any).entered_validating_at) || (task.updatedAt ?? task.createdAt)
       const reviewLastActivityAt = normalizeEpochMs((meta as any).review_last_activity_at) || reviewEnteredAt
 

--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -437,6 +437,11 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
       continue
     }
 
+    // Skip tasks where reviewer has already acted — ball is with the author.
+    // If review_state is 'needs_author' or reviewer_decision exists, the reviewer
+    // has done their part. SLA alerts/reassignment should not target the reviewer.
+    if (reviewState === 'needs_author' || meta.reviewer_decision != null) continue
+
     const enteredAt = (meta.entered_validating_at as number) || task.updatedAt
     const lastActivity = (meta.review_last_activity_at as number) || enteredAt
     const ageSinceActivity = now - lastActivity
@@ -910,6 +915,24 @@ export function generateDriftReport(): DriftReport {
     const ageMinutes = msToMinutes(ageSinceActivity)
     const prUrl = extractPrUrl(meta)
     const prMerged = !!(meta.pr_merged)
+
+    // Skip tasks where reviewer has already acted — these are waiting on author, not reviewer.
+    const reviewState = meta.review_state as string | undefined
+    if (reviewState === 'needs_author' || meta.reviewer_decision != null) {
+      cleanCount++
+      validatingEntries.push({
+        taskId: task.id,
+        title: task.title,
+        status: task.status,
+        reviewer: task.reviewer ?? '',
+        assignee: task.assignee ?? '',
+        age_minutes: ageMinutes,
+        issue: 'clean',
+        detail: `Waiting on author (review_state: ${reviewState || 'n/a'}, reviewer acted)`,
+        prUrl: prUrl || undefined,
+      })
+      continue
+    }
 
     let issue: DriftReportEntry['issue'] = 'clean'
     let detail = 'On track'


### PR DESCRIPTION
## Problem
Review SLA checker treated all validating tasks as 'waiting on reviewer' regardless of review_state. Tasks where the reviewer already rejected (review_state=needs_author, reviewer_decision exists) triggered false SLA breach alerts.

## Fix
Skip tasks from SLA breach / reassignment when:
- `review_state === 'needs_author'` (reviewer acted, ball with author)
- `reviewer_decision != null` (reviewer has made a decision)

Applied to both `boardHealthWorker.ts` (SLA reassignment) and `executionSweeper.ts` (SLA alerts + drift report).

## Testing
1768 tests pass, 422/422 routes.

Closes task-1772979040783-ntajmbxmj