### PR TITLE
fix: sweeper pr_drift skips needs_author/decided tasks

### DIFF
--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -654,6 +654,10 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
   // Also check validating tasks for PR drift (merged but not advanced)
   for (const task of validating) {
     const meta = (task.metadata || {}) as Record<string, unknown>
+    // Skip tasks where reviewer already acted — ball is with author, not a drift issue
+    const driftReviewState = meta.review_state as string | undefined
+    if (driftReviewState === 'needs_author' || meta.reviewer_decision != null) continue
+
     if (meta.pr_merged && task.status === 'validating') {
       const mergedAt = (meta.pr_merged_at as number) || task.updatedAt
       const driftAge = now - mergedAt


### PR DESCRIPTION
Third and final SLA false-positive path. The pr_drift loop in executionSweeper (validating tasks with pr_merged=true) didn't check review_state/reviewer_decision. This was the source of the sweeper digest noise Ryan flagged.

1768 tests pass, 422/422 routes.