### PR TITLE
security: reserve system sender for internal callers

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1944,7 +1944,7 @@ async function escalateReviewerBreaches(breachedTasks) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        from: 'system',
+        from: 'dashboard',
         content,
         channel: 'general',
         timestamp: now
@@ -1974,7 +1974,7 @@ async function escalateAuthorBreaches(breachedTasks) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        from: 'system',
+        from: 'dashboard',
         content,
         channel: 'general',
         timestamp: now

--- a/src/server.ts
+++ b/src/server.ts
@@ -3636,6 +3636,24 @@ export async function createServer(): Promise<FastifyInstance> {
 
     const data = parsedBody.data
 
+    // Reserve system sender for server-internal control-plane messages.
+    // Prevent browser clients (dashboard.js) or external callers from spoofing system alerts.
+    //
+    // Allow explicit internal callers (tests/tools) via header:
+    //   x-reflectt-internal: true
+    if (data.from === 'system') {
+      const internal = String((request.headers as any)['x-reflectt-internal'] || '').toLowerCase() === 'true'
+      if (!internal) {
+        reply.code(403)
+        return {
+          success: false,
+          error: 'Sender "system" is reserved (use from="dashboard" or your agent name).',
+          code: 'SENDER_RESERVED',
+          hint: 'Only internal callers may emit system messages. Add header x-reflectt-internal:true for test/tooling.',
+        }
+      }
+    }
+
     // Require at least content or attachments
     if (!data.content && (!data.attachments || data.attachments.length === 0)) {
       reply.code(400)

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1438,10 +1438,16 @@ describe('My Now cockpit', () => {
   })
 
   it('GET /me/:agent returns single-pane payload with assigned/review lanes + blockers + changelog', async () => {
-    await req('POST', '/chat/messages', {
-      from: 'system',
-      channel: 'general',
-      content: '@cockpit-agent build failed on CI check for PR #999',
+    // Internal system message for cockpit signal extraction
+    await app.inject({
+      method: 'POST',
+      url: '/chat/messages',
+      headers: { 'content-type': 'application/json', 'x-reflectt-internal': 'true' },
+      payload: {
+        from: 'system',
+        channel: 'general',
+        content: '@cockpit-agent build failed on CI check for PR #999',
+      },
     })
 
     const { status, body } = await req('GET', '/me/cockpit-agent')
@@ -2160,6 +2166,18 @@ describe('Chat Messages', () => {
     expect(body.message).toBeDefined()
     expect(body.message.id).toBeDefined()
     authorMessageId = body.message.id
+  })
+
+  it('POST /chat/messages rejects reserved sender "system"', async () => {
+    const { status, body } = await req('POST', '/chat/messages', {
+      from: 'system',
+      content: 'should not be allowed',
+      channel: 'general',
+    })
+
+    expect(status).toBe(403)
+    expect(body.success).toBe(false)
+    expect(body.code).toBe('SENDER_RESERVED')
   })
 
   it('POST /chat/messages returns no warnings when content has no @mentions', async () => {

--- a/tests/chat-dedup.test.ts
+++ b/tests/chat-dedup.test.ts
@@ -15,6 +15,7 @@ async function sendMsg(from: string, content: string, channel = 'general', metad
   const res = await app.inject({
     method: 'POST',
     url: '/chat/messages',
+    headers: from === 'system' ? { 'x-reflectt-internal': 'true' } : undefined,
     payload: { from, content, channel, ...(metadata ? { metadata } : {}) },
   })
   const body = JSON.parse(res.body)

--- a/tests/chat-monotonic-timestamps.test.ts
+++ b/tests/chat-monotonic-timestamps.test.ts
@@ -18,6 +18,7 @@ async function post(content: string) {
   const res = await app.inject({
     method: 'POST',
     url: '/chat/messages',
+    headers: { 'x-reflectt-internal': 'true' },
     payload: { from: 'system', channel: 'task-notifications', content },
   })
   expect(res.statusCode).toBe(200)


### PR DESCRIPTION
Problem: Browser clients (dashboard.js) were POSTing /chat/messages with from="system". Old/stale dashboard tabs could spoof system alerts (including legacy 'Review SLA breach detected'), creating divergence between local vs cloud chat histories and false-positive noise.\n\nFix:\n- POST /chat/messages now rejects from="system" unless header x-reflectt-internal:true is present.\n- dashboard.js uses from="dashboard" for escalations (never system).\n- Tests updated to set x-reflectt-internal:true when simulating server system messages.\n\nThis ensures only server-internal components can emit true system messages.\n\nTests: npm test (1769 passed)