### PR TITLE
fix: cloud chat sync message gaps — oldest-first cursor walk

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -581,6 +581,10 @@ class ChatManager {
     since?: number
     before?: number
     after?: number
+    /** When true, return the oldest N messages matching the filter (ASC with LIMIT).
+     *  Default behavior returns the newest N (DESC then reversed to ASC).
+     *  Use oldestFirst for cursor-based sync to avoid skipping messages. */
+    oldestFirst?: boolean
   }): AgentMessage[] {
     const db = getDb()
     const conditions: string[] = []
@@ -620,9 +624,13 @@ class ChatManager {
     // without always hitting the cap (legacy JSONL imports often exceed 20).
     const limit = options?.limit !== undefined ? options.limit : 100
 
-    // Fetch newest-first for efficiency, then return ascending.
+    // Default: fetch newest-first for efficiency, then return ascending (shows latest N messages).
+    // oldestFirst: fetch oldest-first with limit (for cursor-based sync — ensures no messages skipped).
+    const oldestFirst = options?.oldestFirst === true
     const sql = limit > 0
-      ? `SELECT * FROM (SELECT * FROM chat_messages ${where} ORDER BY timestamp DESC LIMIT ?) ORDER BY timestamp ASC`
+      ? oldestFirst
+        ? `SELECT * FROM chat_messages ${where} ORDER BY timestamp ASC LIMIT ?`
+        : `SELECT * FROM (SELECT * FROM chat_messages ${where} ORDER BY timestamp DESC LIMIT ?) ORDER BY timestamp ASC`
       : `SELECT * FROM chat_messages ${where} ORDER BY timestamp ASC`
 
     if (limit > 0) params.push(limit)

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -965,10 +965,16 @@ async function syncChat(): Promise<void> {
   }
 
   // Get recent messages since last sync, excluding cloud-relayed messages
-  // to prevent echo: cloud→node→cloud sync loop
+  // to prevent echo: cloud→node→cloud sync loop.
+  //
+  // CRITICAL: use oldestFirst=true so the cursor walks forward through ALL
+  // messages without skipping. Default getMessages returns newest-N (DESC
+  // then reversed), which drops older messages in high-traffic windows.
+  // This was the root cause of cloud chat sync gaps Ryan reported.
   const recentMessages = chatManager.getMessages({
-    since: chatSyncCursor,
-    limit: 50,
+    after: chatSyncCursor,
+    limit: 100,
+    oldestFirst: true,
   }).filter(m => (m.metadata as any)?.source !== 'cloud-relay')
 
   // Send to cloud and get pending outbound messages


### PR DESCRIPTION
## P0: Cloud chat shows stale/different messages vs node

### Root Cause
`chatManager.getMessages({ since, limit: 50 })` returns the **newest 50** messages (SQL: `ORDER BY timestamp DESC LIMIT 50`, then reversed). During high-traffic windows (18+ messages in 5 minutes this morning), the cursor advanced past older messages that were never synced to cloud.

### Fix
- Added `oldestFirst` option to `getMessages()` — uses `ORDER BY timestamp ASC LIMIT ?` instead of the DESC+reverse pattern
- Cloud sync now uses `oldestFirst: true` so the cursor walks forward through ALL messages sequentially
- Increased batch size from 50 to 100

### Testing
1768 tests pass, 422/422 routes.

Closes task-1772983446030-k37ahotwv