### PR TITLE
test: add sweeper digest suppression regressions

### DIFF
--- a/docs/internal/sweeper-alert-payloads.md
+++ b/docs/internal/sweeper-alert-payloads.md
@@ -64,8 +64,15 @@ Notes:
 
 All alerts use `@{agent_name}` format (e.g., `@link`, `@sage`, `@kai`). Falls back to `@unassigned` when no agent is set.
 
+## Digest suppression semantics
+
+- `DIGEST_SUPPRESSION_MS` is the cooldown for re-posting an unchanged sweeper digest. Current value: **2 hours**.
+- The digest fingerprint is based on the stable set of `type:taskId` pairs only. Changes to rendered copy, titles, or `age_minutes` do **not** create a new digest by themselves.
+- Scope is **process-local / in-memory**. The suppression window holds across repeated sweeps in the same runtime, but resets on process restart.
+- A genuinely changed finding set (added/removed violation, or a violation changes type) produces a new fingerprint and is emitted immediately.
+
 ## Live PR State Check
 
-Before emitting `orphan_pr` alerts, the sweeper checks live PR state via `gh pr view`. Only OPEN PRs trigger alerts. Merged and closed PRs are skipped with a dry-run log entry.
+Periodic sweeps do **not** call `gh pr view` for orphan detection; they rely on task metadata only to avoid blocking the event loop.
 
-Cache: 5-minute TTL per PR URL to avoid GitHub API rate limits.
+Use `/drift-report` when you need live PR-state confirmation. That path may check GitHub state and can distinguish open vs merged/closed PRs.

--- a/process/TASK-xih4ypuy3.md
+++ b/process/TASK-xih4ypuy3.md
@@ -1,0 +1,42 @@
+# Task: Sweeper digest suppression + cancelled-task filtering regression coverage
+
+**Task ID:** task-1772973048702-xih4ypuy3  
+**Branch:** harmony/task-xih4ypuy3
+
+## Summary
+
+Added regression coverage and docs clarification around sweeper digest suppression behavior and orphan-PR filtering for cancelled tasks.
+
+## Changes
+
+### 1. Deterministic digest fingerprint coverage
+- Added a unit-level assertion that the digest fingerprint is derived from the stable set of `type:taskId` pairs.
+- Verified that churn in rendered copy (`title`, `message`, `age_minutes`) does not change the fingerprint.
+- Verified that adding a new violation changes the fingerprint and therefore re-emits the digest.
+
+### 2. Cancelled-task orphan-PR filtering regression
+- Added a regression test covering cancelled tasks with either:
+  - `metadata.cancel_reason`
+  - `metadata.duplicate_of`
+- Verified these tasks are excluded from orphan-PR findings during periodic sweep.
+
+### 3. Semantics clarification
+- Documented `DIGEST_SUPPRESSION_MS` semantics:
+  - current window is 2 hours
+  - fingerprint is based on violation identity, not rendered copy churn
+  - suppression is process-local / in-memory and resets on restart
+- Corrected orphan-PR wording in the cancelled-task scan path from “done task” to “cancelled task” in alert/log copy.
+
+## Files Changed
+- `src/executionSweeper.ts`
+- `tests/sweeper-digest-dedupe.test.ts`
+- `tests/execution-sweeper.test.ts`
+- `docs/internal/sweeper-alert-payloads.md`
+
+## Test Proof
+- `npm test -- --run tests/sweeper-digest-dedupe.test.ts tests/execution-sweeper.test.ts`
+- Result: **2 files passed, 19 tests passed**
+
+## Known Caveats
+- Digest suppression remains process-local/in-memory; restart persistence is intentionally not part of this task.
+- Targeted test run still emits unrelated fixture noise from existing sweeper test setup (`artifact-mirror` / `unauthorized_approval` log lines), but the suite passes cleanly.

--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -619,11 +619,10 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
     )
     if (activeRef) continue
 
-    // PR on a done task with no active task referencing it
-    // Check metadata flags that indicate the PR was merged/resolved
+    // PR on a cancelled task with no active task referencing it.
+    // Check metadata flags that indicate the PR was merged/resolved.
     const prMerged = !!(meta.pr_merged)
     const reviewerApproved = !!(meta.reviewer_approved)
-    const taskDone = task.status === 'done'
 
     // If metadata says merged, skip
     if (prMerged) continue
@@ -643,11 +642,11 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
         reviewer: task.reviewer,
         type: 'orphan_pr',
         age_minutes: msToMinutes(completedAge),
-        message: `🔍 Orphan PR detected: ${prUrl} linked to done task "${task.title}" (${task.id}). PR may still be open — ${assigneeMention} close or merge it. ${reviewerMention} — confirm status.`,
+        message: `🔍 Orphan PR detected: ${prUrl} linked to cancelled task "${task.title}" (${task.id}). PR may still be open — ${assigneeMention} close or merge it. ${reviewerMention} — confirm status.`,
         remediation: generateRemediation({ taskId: task.id, issue: 'orphan_pr', prUrl }),
       })
       flaggedOrphanPRs.add(prUrl)
-      logDryRun('orphan_pr', `${prUrl} on ${task.id} — task done ${msToMinutes(completedAge)}m ago`)
+      logDryRun('orphan_pr', `${prUrl} on ${task.id} — task cancelled ${msToMinutes(completedAge)}m ago`)
     }
   }
 
@@ -780,6 +779,8 @@ async function escalateViolations(violations: SweepViolation[]): Promise<void> {
   if (violations.length === 0) return
 
   // Digest-level dedupe: don't re-emit the same digest repeatedly while unchanged.
+  // Scope: process-local/in-memory only. The suppression window survives repeated
+  // sweeps in the same runtime, but resets on process restart.
   const now = Date.now()
   pruneDigestFingerprints(now)
   const fingerprint = computeDigestFingerprint(violations)
@@ -845,6 +846,10 @@ async function escalateViolations(violations: SweepViolation[]): Promise<void> {
 
 export function _resetSweeperDigestSuppressionForTest(): void {
   recentDigestFingerprints.clear()
+}
+
+export function _computeDigestFingerprintForTest(violations: SweepViolation[]): string {
+  return computeDigestFingerprint(violations)
 }
 
 export async function _escalateViolationsForTest(violations: SweepViolation[]): Promise<void> {

--- a/tests/execution-sweeper.test.ts
+++ b/tests/execution-sweeper.test.ts
@@ -223,6 +223,65 @@ describe('Orphan PR detection accuracy', () => {
     nowSpy.mockRestore()
   })
 
+  it('cancelled tasks with cancel_reason or duplicate_of are excluded from orphan PR scan', async () => {
+    const cancelledRes = await app.inject({
+      method: 'POST',
+      url: '/tasks',
+      payload: {
+        title: 'Cancelled task with explicit reason',
+        description: 'Intentional cancellation should not page the sweeper',
+        status: 'cancelled',
+        assignee: 'link',
+        reviewer: 'sage',
+        priority: 'P2',
+        createdBy: 'test',
+        eta: '1h',
+        done_criteria: ['N/A'],
+        metadata: {
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/99998',
+          cancel_reason: 'duplicate',
+        },
+      },
+    })
+    expect(cancelledRes.statusCode).toBe(200)
+    const cancelledTask = JSON.parse(cancelledRes.body).task
+
+    const duplicateRes = await app.inject({
+      method: 'POST',
+      url: '/tasks',
+      payload: {
+        title: 'Cancelled task linked to canonical duplicate',
+        description: 'Duplicate cancellation should also be ignored',
+        status: 'cancelled',
+        assignee: 'echo',
+        reviewer: 'sage',
+        priority: 'P2',
+        createdBy: 'test',
+        eta: '1h',
+        done_criteria: ['N/A'],
+        metadata: {
+          pr_url: 'https://github.com/reflectt/reflectt-node/pull/99997',
+          duplicate_of: 'task-1772973048702-xih4ypuy3',
+        },
+      },
+    })
+    expect(duplicateRes.statusCode).toBe(200)
+    const duplicateTask = JSON.parse(duplicateRes.body).task
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(cancelledTask.updatedAt + 3 * 60 * 60 * 1000)
+
+    const { sweepValidatingQueue } = await import('../src/executionSweeper.js')
+    const result = await sweepValidatingQueue()
+    const orphanTaskIds = new Set(
+      result.violations.filter(v => v.type === 'orphan_pr').map(v => v.taskId),
+    )
+
+    expect(orphanTaskIds.has(cancelledTask.id)).toBe(false)
+    expect(orphanTaskIds.has(duplicateTask.id)).toBe(false)
+
+    nowSpy.mockRestore()
+  })
+
   it('orphan alert includes @assignee and @reviewer mentions', async () => {
     const { sweepValidatingQueue } = await import('../src/executionSweeper.js')
     const result = await sweepValidatingQueue()

--- a/tests/sweeper-digest-dedupe.test.ts
+++ b/tests/sweeper-digest-dedupe.test.ts
@@ -50,12 +50,23 @@ vi.mock('child_process', () => ({
 }))
 
 import {
+  _computeDigestFingerprintForTest,
   _escalateViolationsForTest,
   _resetSweeperDigestSuppressionForTest,
   type SweepViolation,
 } from '../src/executionSweeper.js'
 
 describe('Sweeper Digest dedupe/suppression', () => {
+  const baseViolation = (): SweepViolation => ({
+    taskId: 'task-1',
+    title: 'Test task',
+    assignee: 'harmony',
+    reviewer: 'sage',
+    type: 'orphan_pr',
+    age_minutes: 120,
+    message: 'orphan',
+  })
+
   beforeEach(() => {
     _resetSweeperDigestSuppressionForTest()
     sendMessage.mockClear()
@@ -67,18 +78,57 @@ describe('Sweeper Digest dedupe/suppression', () => {
     vi.useRealTimers()
   })
 
-  it('suppresses repeated identical digests within suppression window', async () => {
-    const violations: SweepViolation[] = [
+  it('computes a stable fingerprint from violation identity only', () => {
+    const base = [baseViolation()]
+    const reorderedWithChurn: SweepViolation[] = [
       {
-        taskId: 'task-1',
-        title: 'Test task',
-        assignee: 'harmony',
+        ...baseViolation(),
+        title: 'Renamed task title should not matter',
+        age_minutes: 999,
+        message: 'different rendered copy should not matter',
+      },
+      {
+        taskId: 'task-2',
+        title: 'Second task',
+        assignee: 'echo',
         reviewer: 'sage',
-        type: 'orphan_pr',
-        age_minutes: 120,
-        message: 'orphan',
+        type: 'validating_sla',
+        age_minutes: 15,
+        message: 'warning',
       },
     ]
+    const canonical: SweepViolation[] = [
+      {
+        taskId: 'task-2',
+        title: 'Another title entirely',
+        assignee: 'echo',
+        reviewer: 'sage',
+        type: 'validating_sla',
+        age_minutes: 16,
+        message: 'same issue, different copy',
+      },
+      baseViolation(),
+    ]
+
+    expect(_computeDigestFingerprintForTest(reorderedWithChurn)).toBe(
+      _computeDigestFingerprintForTest(canonical),
+    )
+
+    expect(_computeDigestFingerprintForTest(canonical)).not.toBe(
+      _computeDigestFingerprintForTest([...canonical, {
+        taskId: 'task-3',
+        title: 'New issue',
+        assignee: 'link',
+        reviewer: 'sage',
+        type: 'pr_drift',
+        age_minutes: 200,
+        message: 'new violation changes fingerprint',
+      }]),
+    )
+  })
+
+  it('suppresses repeated identical digests within suppression window', async () => {
+    const violations: SweepViolation[] = [baseViolation()]
 
     await _escalateViolationsForTest(violations)
     await _escalateViolationsForTest(violations)
@@ -87,17 +137,7 @@ describe('Sweeper Digest dedupe/suppression', () => {
   })
 
   it('re-emits digest after suppression window elapses', async () => {
-    const violations: SweepViolation[] = [
-      {
-        taskId: 'task-1',
-        title: 'Test task',
-        assignee: 'harmony',
-        reviewer: 'sage',
-        type: 'orphan_pr',
-        age_minutes: 120,
-        message: 'orphan',
-      },
-    ]
+    const violations: SweepViolation[] = [baseViolation()]
 
     await _escalateViolationsForTest(violations)
 
@@ -110,17 +150,7 @@ describe('Sweeper Digest dedupe/suppression', () => {
   })
 
   it('does not suppress when violation set changes (new fingerprint)', async () => {
-    const v1: SweepViolation[] = [
-      {
-        taskId: 'task-1',
-        title: 'Test task',
-        assignee: 'harmony',
-        reviewer: 'sage',
-        type: 'orphan_pr',
-        age_minutes: 120,
-        message: 'orphan',
-      },
-    ]
+    const v1: SweepViolation[] = [baseViolation()]
 
     const v2: SweepViolation[] = [
       ...v1,


### PR DESCRIPTION
## Summary
- add deterministic sweeper digest fingerprint coverage
- add regression coverage for cancelled tasks with `cancel_reason` / `duplicate_of` being excluded from orphan-PR scan
- document `DIGEST_SUPPRESSION_MS` semantics and correct cancelled-task orphan wording

## Test Proof
- npm test -- --run tests/sweeper-digest-dedupe.test.ts tests/execution-sweeper.test.ts

## Artifact
- process/TASK-xih4ypuy3.md

## Task
- task-1772973048702-xih4ypuy3
