### PR TITLE
feat: include request metrics in cloud heartbeat payload

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -25,6 +25,7 @@ import { listInsights } from './insights.js'
 import { readFileSync, existsSync, watch, type FSWatcher } from 'fs'
 import { join } from 'path'
 import { REFLECTT_HOME } from './config.js'
+import { getRequestMetrics } from './request-tracker.js'
 
 /**
  * Docker identity guard: detect when a container has inherited cloud
@@ -689,6 +690,20 @@ async function sendHeartbeat(): Promise<void> {
       priority: t.priority || undefined,
       updatedAt: t.updatedAt || Date.now(),
     })),
+    metrics: (() => {
+      const m = getRequestMetrics()
+      return {
+        totalRequests: m.total,
+        totalErrors: m.errors,
+        rps: m.rps,
+        rolling: {
+          requests: m.rolling.requests,
+          errors: m.rolling.errors,
+          errorRate: m.rolling.errorRate,
+          windowMinutes: m.rolling.windowMinutes,
+        },
+      }
+    })(),
     source: {
       hostId: state.hostId,
       hostName: config.hostName,


### PR DESCRIPTION
## What
Adds a `metrics` field to the cloud heartbeat payload with:
- `totalRequests`, `totalErrors`, `rps` (lifetime)
- `rolling`: `requests`, `errors`, `errorRate`, `windowMinutes` (rolling window)

## Why
Unblocks 4 blocked tasks that depend on the heartbeat contract including request/error metrics:
- task-1772926476680-7bao6k7fb (@rhythm) — store host request_counts/errors in cloud
- Cross-host error aggregation, predictive SLA alerts, cross-fleet routing

## Payload shape
```json
{
  "metrics": {
    "totalRequests": 12345,
    "totalErrors": 42,
    "rps": 2.5,
    "rolling": {
      "requests": 450,
      "errors": 3,
      "errorRate": 0.67,
      "windowMinutes": 5
    }
  }
}
```

## Testing
- `npm run build` passes
- Uses existing `getRequestMetrics()` from `request-tracker.ts` — well-tested