### PR TITLE
Fix listener zombie: exit on unhandled errors / http server close

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -957,12 +957,12 @@ async function syncChat(): Promise<void> {
 
   chatSyncInFlight = true
 
-  // Enforce minimum sync interval + active backoff window
-  const now = Date.now()
-  if (now < chatSyncNextAllowedAt) {
-    chatSyncInFlight = false
-    return
-  }
+  try {
+    // Enforce minimum sync interval + active backoff window
+    const now = Date.now()
+    if (now < chatSyncNextAllowedAt) {
+      return
+    }
 
   // Get recent messages since last sync, excluding cloud-relayed messages
   // to prevent echo: cloud→node→cloud sync loop.
@@ -1042,8 +1042,17 @@ async function syncChat(): Promise<void> {
       console.warn(`☁️  [Chat] Sync failed (${chatSyncErrors}): ${result.error}; next attempt in ~${chatSyncBackoffMs}ms`)
     }
   }
-
-  chatSyncInFlight = false
+  } catch (err: any) {
+    // Ensure token expiry / network errors never wedge the sync loop
+    chatSyncErrors++
+    chatSyncBackoffMs = computeBackoffWithJitter(chatSyncBackoffMs)
+    chatSyncNextAllowedAt = Date.now() + Math.max(chatSyncBackoffMs, chatSyncMinIntervalMs)
+    if (chatSyncErrors <= 3 || chatSyncErrors % 20 === 0) {
+      console.warn(`☁️  [Chat] Sync threw (${chatSyncErrors}): ${err?.message || err}; next attempt in ~${chatSyncBackoffMs}ms`)
+    }
+  } finally {
+    chatSyncInFlight = false
+  }
 }
 
 // ---- Canvas sync ----

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,22 @@ async function main() {
     console.log(`   Resolved ${lockResult.portConflictPids.length} port conflict(s)`)
   }
 
+  // Crash hard on unhandled errors so supervisors (launchd/systemd) can restart cleanly
+  // Prevents the "listener died but process tree lives" zombie state.
+  let shuttingDown = false
+  const fatal = (label: string, err: any) => {
+    try {
+      console.error(`\n🚨 [FATAL] ${label}:`, err)
+    } catch {}
+    try {
+      releasePidLock(pidPath)
+    } catch {}
+    // Exit non-zero so launchd restarts
+    process.exit(1)
+  }
+  process.on('uncaughtException', err => fatal('uncaughtException', err))
+  process.on('unhandledRejection', err => fatal('unhandledRejection', err))
+
   try {
     // Initialize SQLite database (WAL mode, auto-migration from JSONL)
     const db = getDb()
@@ -253,6 +269,22 @@ async function main() {
       port: serverConfig.port,
       host: serverConfig.host,
     })
+
+    // If the underlying HTTP server closes unexpectedly, crash so the supervisor restarts us.
+    // NOTE: shutdown() sets shuttingDown=true so intentional closes don't trigger fatal exit.
+    try {
+      const srv: any = (app as any).server
+      if (srv && typeof srv.on === 'function') {
+        srv.on('close', () => {
+          if (shuttingDown) return
+          fatal('http_server_close', new Error('HTTP listener closed unexpectedly'))
+        })
+        srv.on('error', (err: any) => {
+          if (shuttingDown) return
+          fatal('http_server_error', err)
+        })
+      }
+    } catch {}
 
     const baseUrl = `http://${serverConfig.host}:${serverConfig.port}`
 
@@ -528,6 +560,7 @@ async function main() {
 
     // Graceful shutdown
     const shutdown = async (signal: string) => {
+      shuttingDown = true
       console.log(`\n${signal} received, shutting down...`)
       stopConfigWatch()
       stopConfigWatcher()


### PR DESCRIPTION
### What
- Exit non-zero on uncaughtException/unhandledRejection so launchd restarts cleanly
- Exit non-zero if underlying HTTP server closes/errors unexpectedly (unless intentional shutdown)
- Harden cloud chat sync: always clear chatSyncInFlight with try/finally

### Why
Observed: HTTP listener died while process tree stayed alive; required kill -9 across npx/tsx/node tree. This makes failures crash hard so supervisors recover.

### Proof
- Tests: npm test
- Notes: process/TASK-6tokr7jjt.md

### Caveats
Recommend launchd run compiled JS (node dist/index.js) rather than npx tsx.