### PR TITLE
fix: centralize reviewer SLA precedence

### DIFF
--- a/src/boardHealthWorker.ts
+++ b/src/boardHealthWorker.ts
@@ -23,6 +23,7 @@ import { suggestReviewer, getAgentRoles } from './assignment.js'
 import type { Task } from './types.js'
 import { isTestHarnessTask } from './test-task-filter.js'
 import { recordSystemLoopTick } from './system-loop-state.js'
+import { isWaitingOnAuthor } from './review-state.js'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -723,12 +724,9 @@ export class BoardHealthWorker {
       const meta = (task.metadata || {}) as Record<string, unknown>
 
       // ── Skip tasks where reviewer has already acted ──
-      // If review_state is 'needs_author', the ball is with the assignee, not the reviewer.
-      // If reviewer_decision exists, the reviewer has already made a decision (approved/rejected).
-      // In either case, SLA breach should not page the reviewer.
-      const reviewState = typeof meta.review_state === 'string' ? meta.review_state : ''
-      const reviewerDecision = meta.reviewer_decision
-      if (reviewState === 'needs_author' || reviewerDecision != null) continue
+      // Canonical precedence rule: reviewer_decision suppresses reviewer-facing
+      // SLA paging even when review_state was not populated.
+      if (isWaitingOnAuthor(meta)) continue
 
       const reviewEnteredAt = normalizeEpochMs((meta as any).entered_validating_at) || (task.updatedAt ?? task.createdAt)
       const reviewLastActivityAt = normalizeEpochMs((meta as any).review_last_activity_at) || reviewEnteredAt

--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -43,6 +43,7 @@ async function sendAlertWithPreflight(
 }
 import { msToMinutes, formatDuration } from './format-duration.js'
 import { suggestReviewer } from './assignment.js'
+import { isWaitingOnAuthor } from './review-state.js'
 import { getDuplicateClosureCanonicalRefError } from './duplicateClosureGuard.js'
 
 // ── Live PR State Check ────────────────────────────────────────────────────
@@ -438,9 +439,9 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
     }
 
     // Skip tasks where reviewer has already acted — ball is with the author.
-    // If review_state is 'needs_author' or reviewer_decision exists, the reviewer
-    // has done their part. SLA alerts/reassignment should not target the reviewer.
-    if (reviewState === 'needs_author' || meta.reviewer_decision != null) continue
+    // Once reviewer_decision exists, reviewer-facing SLA paging stops even if
+    // review_state was not set by the caller.
+    if (isWaitingOnAuthor(meta)) continue
 
     const enteredAt = (meta.entered_validating_at as number) || task.updatedAt
     const lastActivity = (meta.review_last_activity_at as number) || enteredAt
@@ -654,8 +655,7 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
   for (const task of validating) {
     const meta = (task.metadata || {}) as Record<string, unknown>
     // Skip tasks where reviewer already acted — ball is with author, not a drift issue
-    const driftReviewState = meta.review_state as string | undefined
-    if (driftReviewState === 'needs_author' || meta.reviewer_decision != null) continue
+    if (isWaitingOnAuthor(meta)) continue
 
     if (meta.pr_merged && task.status === 'validating') {
       const mergedAt = (meta.pr_merged_at as number) || task.updatedAt
@@ -927,7 +927,7 @@ export function generateDriftReport(): DriftReport {
 
     // Skip tasks where reviewer has already acted — these are waiting on author, not reviewer.
     const reviewState = meta.review_state as string | undefined
-    if (reviewState === 'needs_author' || meta.reviewer_decision != null) {
+    if (isWaitingOnAuthor(meta)) {
       cleanCount++
       validatingEntries.push({
         taskId: task.id,

--- a/src/review-state.ts
+++ b/src/review-state.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+export function getReviewState(meta: Record<string, unknown>): string {
+  return typeof meta.review_state === 'string' ? meta.review_state : ''
+}
+
+export function hasReviewerDecision(meta: Record<string, unknown>): boolean {
+  return meta.reviewer_decision != null
+}
+
+/**
+ * Canonical reviewer-SLA precedence rule:
+ * once a reviewer decision exists, reviewer-facing SLA paging stops.
+ * Tasks in needs_author are also waiting on the assignee/author, not the reviewer.
+ */
+export function isWaitingOnAuthor(meta: Record<string, unknown>): boolean {
+  return getReviewState(meta) === 'needs_author' || hasReviewerDecision(meta)
+}

--- a/tests/execution-sweeper.test.ts
+++ b/tests/execution-sweeper.test.ts
@@ -282,6 +282,81 @@ describe('Orphan PR detection accuracy', () => {
     nowSpy.mockRestore()
   })
 
+  it('does not emit validating_sla when reviewer_decision exists, even if review_state is missing', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/tasks',
+      payload: {
+        title: 'Reviewer acted already',
+        description: 'Regression: reviewer_decision must suppress reviewer SLA paging',
+        status: 'todo',
+        assignee: 'link',
+        reviewer: 'sage',
+        priority: 'P2',
+        createdBy: 'test',
+        eta: '1h',
+        done_criteria: ['Done'],
+      },
+    })
+    expect(createRes.statusCode).toBe(200)
+    const task = JSON.parse(createRes.body).task
+
+    await app.inject({
+      method: 'PATCH',
+      url: `/tasks/${task.id}`,
+      payload: { status: 'doing', metadata: { eta: '1h', wip_override: 'test isolation' } },
+    })
+
+    await app.inject({
+      method: 'PATCH',
+      url: `/tasks/${task.id}`,
+      payload: {
+        status: 'validating',
+        metadata: {
+          artifact_path: 'process/test-reviewer-decision.md',
+          review_handoff: {
+            task_id: task.id,
+            artifact_path: 'process/test-reviewer-decision.md',
+            test_proof: 'pass',
+            known_caveats: 'test only',
+            doc_only: true,
+          },
+          qa_bundle: {
+            lane: 'test',
+            summary: 'Regression test',
+            changed_files: ['process/test-reviewer-decision.md'],
+            artifact_links: ['process/test-reviewer-decision.md'],
+            checks: ['lint:pass'],
+            screenshot_proof: ['n/a'],
+            review_packet: {
+              task_id: task.id,
+              artifact_path: 'process/test-reviewer-decision.md',
+            },
+          },
+        },
+      },
+    })
+
+    const { taskManager } = await import('../src/tasks.js')
+    const staleAt = Date.now() - 3 * 60 * 60 * 1000
+    taskManager.patchTaskMetadata(task.id, {
+      entered_validating_at: staleAt,
+      review_last_activity_at: staleAt,
+      reviewer_decision: {
+        decision: 'rejected',
+        reviewer: 'sage',
+        decidedAt: staleAt,
+        comment: 'Missing proof',
+      },
+      review_state: undefined,
+    })
+
+    const { sweepValidatingQueue } = await import('../src/executionSweeper.js')
+    const result = await sweepValidatingQueue()
+    const violations = result.violations.filter(v => v.taskId === task.id && v.type === 'validating_sla')
+    expect(violations).toHaveLength(0)
+  })
+
   it('orphan alert includes @assignee and @reviewer mentions', async () => {
     const { sweepValidatingQueue } = await import('../src/executionSweeper.js')
     const result = await sweepValidatingQueue()

--- a/tests/review-reassignment.test.ts
+++ b/tests/review-reassignment.test.ts
@@ -12,6 +12,7 @@ function seedTask(overrides: {
   assignee?: string
   reviewer?: string
   entered_validating_at?: number
+  metadata?: Record<string, unknown>
 } = {}) {
   const db = getDb()
   const id = overrides.id || uid()
@@ -21,6 +22,7 @@ function seedTask(overrides: {
     entered_validating_at: enteredAt,
     artifact_path: 'process/test-artifact.md', // required by validating lifecycle gate
     eta: '~1h',
+    ...(overrides.metadata || {}),
   })
   const doneCriteria = JSON.stringify(['Test criteria'])
 
@@ -72,6 +74,32 @@ describe('Review SLA auto-reassignment', () => {
 
     const after = taskManager.getTask(taskId)
     expect(after?.reviewer).not.toBe('sage')
+    cleanupTask(taskId)
+  })
+
+  it('does not reassign when reviewer_decision exists, even if review_state is missing', async () => {
+    const taskId = seedTask({
+      reviewer: 'sage',
+      assignee: 'link',
+      metadata: {
+        reviewer_decision: {
+          decision: 'rejected',
+          reviewer: 'sage',
+          decidedAt: Date.now() - 9 * 60 * 60 * 1000,
+          comment: 'Needs changes',
+        },
+      },
+    })
+    createdIds.push(taskId)
+
+    presenceManager.updatePresence('agent-3', 'idle')
+
+    const result = await worker.tick({ dryRun: false, force: true })
+    const actions = result.actions.filter(a => a.kind === 'review-reassign' && a.taskId === taskId)
+    expect(actions.length).toBe(0)
+
+    const after = taskManager.getTask(taskId)
+    expect(after?.reviewer).toBe('sage')
     cleanupTask(taskId)
   })
 


### PR DESCRIPTION
## Summary
- centralize the reviewer-SLA suppression rule in a single `isWaitingOnAuthor()` helper
- apply the same precedence in execution sweeper and board-health review reassignment
- add regressions proving `reviewer_decision` suppresses reviewer paging even when `review_state` is missing

## Why
We paged reviewers for tasks where the reviewer had already acted. The canonical rule is: if `reviewer_decision` exists, do not emit reviewer-facing SLA alerts or auto-reassignments.

## Tests
- `npx vitest run tests/review-reassignment.test.ts tests/execution-sweeper.test.ts tests/review-sla-false-positive.test.ts`