### PR TITLE
Fix reviewer SLA emitter precedence

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1803,6 +1803,18 @@ function normalizeEpochMs(v) {
   return v;
 }
 
+function hasReviewerDecision(task) {
+  const meta = task && task.metadata && typeof task.metadata === 'object' ? task.metadata : null;
+  const decision = meta && meta.reviewer_decision && typeof meta.reviewer_decision === 'object'
+    ? meta.reviewer_decision
+    : null;
+  return !!decision;
+}
+
+function shouldEscalateReviewerSla(task) {
+  return task && task.slaState === 'breach' && !hasReviewerDecision(task);
+}
+
 function renderReviewQueue() {
   const panel = document.getElementById('review-queue-panel');
   const body = document.getElementById('review-queue-body');
@@ -1910,8 +1922,9 @@ function renderReviewQueue() {
   bindTaskLinkHandlers(body);
 
   // SLA breach escalation: split reviewer-wait vs author-wait so we page the right person.
+  // shouldEscalateReviewerSla() suppresses escalation when reviewer_decision already exists.
   if (reviewerBreachCount > 0) {
-    escalateReviewerBreaches(reviewerQueue.filter(t => t.slaState === 'breach'));
+    escalateReviewerBreaches(reviewerQueue.filter(shouldEscalateReviewerSla));
   }
   if (authorBreachCount > 0) {
     escalateAuthorBreaches(authorQueue.filter(t => t.slaState === 'breach'));

--- a/tests/reviewer-sla-emitter.test.ts
+++ b/tests/reviewer-sla-emitter.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function loadReviewSlaHelpers() {
+  const source = readFileSync(join(process.cwd(), 'public/dashboard.js'), 'utf8')
+  const match = source.match(/function hasReviewerDecision\(task\) \{[\s\S]*?function shouldEscalateReviewerSla\(task\) \{[\s\S]*?\n\}/)
+  if (!match) {
+    throw new Error('Failed to locate reviewer SLA helpers in public/dashboard.js')
+  }
+
+  const factory = new Function(`${match[0]}; return { hasReviewerDecision, shouldEscalateReviewerSla };`)
+  return factory() as {
+    hasReviewerDecision: (task: Record<string, unknown>) => boolean
+    shouldEscalateReviewerSla: (task: Record<string, unknown>) => boolean
+  }
+}
+
+describe('reviewer SLA emitter precedence', () => {
+  it('suppresses reviewer paging when reviewer_decision already exists', () => {
+    const { hasReviewerDecision, shouldEscalateReviewerSla } = loadReviewSlaHelpers()
+
+    const task = {
+      status: 'validating',
+      slaState: 'breach',
+      metadata: {
+        review_state: 'needs_author',
+        reviewer_decision: {
+          decision: 'changes_requested',
+          reviewer: 'sage',
+          decidedAt: Date.now(),
+        },
+      },
+    }
+
+    expect(hasReviewerDecision(task)).toBe(true)
+    expect(shouldEscalateReviewerSla(task)).toBe(false)
+  })
+
+  it('still escalates true reviewer wait breaches without reviewer_decision', () => {
+    const { shouldEscalateReviewerSla } = loadReviewSlaHelpers()
+
+    const task = {
+      status: 'validating',
+      slaState: 'breach',
+      metadata: {
+        review_state: 'queued',
+      },
+    }
+
+    expect(shouldEscalateReviewerSla(task)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary\n- suppress dashboard reviewer-SLA escalations when a reviewer_decision already exists\n- keep reviewer breach count aligned with the same precedence rule\n- add a regression test covering needs_author + reviewer_decision => no reviewer page\n\n## Testing\n- npm test -- --run tests/reviewer-sla-emitter.test.ts tests/dashboard-internal-mode.test.ts