### PR TITLE
docs: refresh bootstrap-first-5-minutes (install + health + first task)

### DIFF
--- a/docs/bootstrap-first-5-minutes.md
+++ b/docs/bootstrap-first-5-minutes.md
@@ -1,14 +1,26 @@
 # Bootstrap: first 5 minutes (copy/paste)
 
-This gets you from **zero → running dashboard + self-serve doctor output**.
+Goal: **zero → running dashboard + health check + your first “next task” call**.
 
-Assumptions:
-- You have Docker installed **or** Node.js 22+.
-- You’re using the official image: `ghcr.io/reflectt/reflectt-node:latest` (public).
+Pick one install path:
+
+- **Docker** (fastest / most reliable)
+- **npm** (if you already have Node.js)
+- **curl installer** (automated; requires OpenClaw)
 
 ---
 
-## 1) Start reflectt-node (fastest: Docker)
+## 0) Pick a port (optional)
+
+Default is **4445**.
+
+If you already have something on 4445, pick another port (example: 5555). Replace `4445` below.
+
+---
+
+## 1) Start reflectt-node
+
+### Option A — Docker (recommended)
 
 ```bash
 docker run -d --name reflectt-node \
@@ -17,25 +29,63 @@ docker run -d --name reflectt-node \
   ghcr.io/reflectt/reflectt-node:latest
 ```
 
-Sanity check:
+### Option B — npm (CLI)
+
+Prereq: Node.js **20+**.
+
 ```bash
-curl -s http://127.0.0.1:4445/health | jq
+npm install -g reflectt-node
+reflectt init     # one-time: creates ~/.reflectt/
+reflectt start
 ```
 
-## 2) Open the dashboard URL
+### Option C — curl installer (automated)
 
-- Local: **http://localhost:4445/dashboard**
-- Remote VPS: **http://YOUR_SERVER_IP:4445/dashboard**
+Prereq: **OpenClaw installed** (this installer refuses to install OpenClaw for you).
 
-## 3) Run doctor (self-serve diagnostics)
+```bash
+curl -fsSL https://www.reflectt.ai/install.sh | bash
+```
+
+What it does: clone → `npm install` → build → start → verify `/health` + core endpoints.
+
+---
+
+## 2) Verify health (must be green)
+
+```bash
+curl -fsS http://127.0.0.1:4445/health
+```
+
+Expected:
+
+```json
+{ "status": "ok" }
+```
+
+If that fails:
+
+- Docker: `docker logs reflectt-node --tail 200`
+- npm: re-run `reflectt start` and read the output
+
+---
+
+## 3) Open the dashboard
+
+- Local: http://localhost:4445/dashboard
+- Remote VPS: http://YOUR_SERVER_IP:4445/dashboard
+
+---
+
+## 4) Doctor (self-serve diagnostics)
 
 ### Option A — HTTP (works everywhere)
 
 ```bash
-curl -s http://127.0.0.1:4445/health/team/doctor | jq
+curl -fsS http://127.0.0.1:4445/health/team/doctor
 ```
 
-### Option B — CLI (if you installed reflectt-node from source/npm)
+### Option B — CLI
 
 ```bash
 reflectt doctor --url http://127.0.0.1:4445
@@ -43,7 +93,43 @@ reflectt doctor --url http://127.0.0.1:4445
 
 You want **overall=pass** (or at least clear “next action” hints).
 
-## 4) (Optional) Connect OpenClaw + a chat channel
+---
+
+## 5) First agent call (prove tasks API works)
+
+> zsh users: keep the URL in quotes so `?agent=...` isn’t treated as a glob.
+
+```bash
+curl -fsS "http://127.0.0.1:4445/tasks/next?agent=builder&compact=true"
+```
+
+If you get `{ "task": null }`, that’s fine — it means there’s no ready task.
+
+---
+
+## 6) Discover what else exists (capabilities)
+
+```bash
+curl -fsS http://127.0.0.1:4445/capabilities
+```
+
+Tip: add `?compact=true` to many GET endpoints to reduce response size.
+
+---
+
+## 7) (Optional) Agent bootstrap + heartbeat
+
+```bash
+# Generate an optimal HEARTBEAT.md for an agent
+curl -fsS http://127.0.0.1:4445/bootstrap/heartbeat/builder
+
+# Single compact heartbeat (~200 tokens)
+curl -fsS http://127.0.0.1:4445/heartbeat/builder
+```
+
+---
+
+## 8) (Optional) Connect OpenClaw + a chat channel
 
 If you want agents to message you (Telegram/Discord/Signal/etc.), set up OpenClaw:
 
@@ -86,6 +172,7 @@ docker pull ghcr.io/reflectt/reflectt-node:latest
 ```
 
 Or build locally:
+
 ```bash
 git clone https://github.com/reflectt/reflectt-node.git
 cd reflectt-node
@@ -102,6 +189,7 @@ curl -v http://127.0.0.1:4445/health
 ```
 
 Common fixes:
+
 - Port in use: `lsof -i :4445` → stop the other process or change the port mapping (e.g. `-p 5555:4445`).
 - Container not running: `docker logs reflectt-node --tail 200`
 
@@ -110,17 +198,18 @@ Common fixes:
 This is normal if you only started reflectt-node.
 
 Fix:
+
 - Run `openclaw setup` then `openclaw gateway start`
-- If reflectt-node is in Docker, pass `OPENCLAW_GATEWAY_URL` + `OPENCLAW_GATEWAY_TOKEN` (see step 4)
+- If reflectt-node is in Docker, pass `OPENCLAW_GATEWAY_URL` + `OPENCLAW_GATEWAY_TOKEN` (see step 8)
 - Re-run:
-  ```bash
-  curl -s http://127.0.0.1:4445/health/team/doctor | jq
-  ```
+
+```bash
+curl -fsS http://127.0.0.1:4445/health/team/doctor
+```
 
 ---
 
-## What “good” looks like
+## Reference
 
-- `/health` returns `{ "status": "ok" }`
-- Dashboard loads at `/dashboard`
-- `/health/team/doctor` returns a single actionable report (no mystery failures)
+- Canonical full guide: `docs/GETTING-STARTED.md`
+- Install flow map (what each install option does): `docs/INSTALL-FLOW.md`


### PR DESCRIPTION
Improves the copy/paste onboarding path to get a new user to first success fast.

### Changes
- Adds **curl installer** option (automated; requires OpenClaw): `curl -fsSL https://www.reflectt.ai/install.sh | bash`
- Aligns Node prereq with canonical Getting Started: **Node 20+**
- Adds hard checkpoints:
  - `/health` must return `{ "status": "ok" }`
  - First `/tasks/next?agent=...&compact=true` call
- Adds links/next steps:
  - `/capabilities`
  - `/bootstrap/heartbeat/<agent>` + `/heartbeat/<agent>`
  - reference: `docs/INSTALL-FLOW.md`

This is intended to be the best single pasteable doc for Kindling/X replies + new users.