### PR TITLE
docs: add npx 60-second onboarding asset

### DIFF
--- a/docs/NPX-60-SECONDS.md
+++ b/docs/NPX-60-SECONDS.md
@@ -1,0 +1,138 @@
+# `npx reflectt-node` in 60 seconds
+
+A command-first onboarding/distribution asset for reflectt-node.
+
+**Canonical CTA:** README  
+**Primary link:** https://github.com/reflectt/reflectt-node
+
+---
+
+## 1) X / thread draft
+
+### Post 1
+If a multi-agent tool feels shaky in the first minute, people won’t trust the next hour.
+
+So the fastest way to judge `reflectt-node` is not a demo video. It’s this:
+
+```bash
+npx reflectt-node
+```
+
+Open the dashboard, watch the team board come alive, and see if it feels real.
+
+README: https://github.com/reflectt/reflectt-node
+
+### Post 2
+What you should be able to verify fast:
+- the server starts locally
+- the dashboard opens without setup theater
+- tasks, agents, and reviews are visible
+- the next step is obvious from the README
+
+That first minute matters more than a hype thread.
+
+### Post 3
+Recent cleanup helped this story hold together:
+- getting-started guide rewritten: PR #817
+- README now points to the right onboarding docs: PR #820
+- outreach templates keep distribution on one canonical CTA: PR #821
+
+Try it from the README, then see how quickly you can get one real team task running.
+
+---
+
+## 2) Single-post variant
+
+The fastest way to judge `reflectt-node` is not a long demo.
+It’s this:
+
+```bash
+npx reflectt-node
+```
+
+If the first minute works, you’ll know:
+- the server starts
+- the dashboard is live
+- the task board makes sense
+- the next step is clear
+
+README: https://github.com/reflectt/reflectt-node
+
+---
+
+## 3) Discord-ready version
+
+Want to see whether `reflectt-node` is real in under a minute?
+
+Run:
+
+```bash
+npx reflectt-node
+```
+
+Then open the dashboard and check three things:
+1. does the server come up cleanly?
+2. do tasks / agents / reviews make sense immediately?
+3. is the next step obvious from the README?
+
+Start here: https://github.com/reflectt/reflectt-node
+
+If the first minute feels shaky, nothing after that matters.
+
+---
+
+## 4) README snippet candidate
+
+### 60-second try
+
+```bash
+npx reflectt-node
+```
+
+Then open the dashboard URL printed in your terminal.
+
+If the first minute works, you should be able to see:
+- tasks
+- agents
+- reviews
+- the next onboarding step from the README links below
+
+---
+
+## 5) Distribution plan
+
+Use this in places where a command-first proof beats a feature list:
+
+1. **X post or mini-thread** — direct builders to the README
+2. **Discord team/community replies** — when someone asks how to evaluate it quickly
+3. **DM follow-up** — after someone shows interest in agent coordination, not cold
+4. **README support** — only if the current landing section still feels too wordy
+
+Rule: one clean CTA only — README first, then let README fan out to Getting Started / bootstrap / install flow.
+
+---
+
+## 6) Obvious product friction from telling this story
+
+These are the rough edges that show up immediately when trying to write honest command-first onboarding:
+
+1. **`npx` vs `npm install -g` is not fully settled in docs language**  
+   The README says both, but we should be explicit about when `npx reflectt-node` is enough versus when `reflectt init` / `reflectt start` is the better path.
+
+2. **The “60-second” proof is product-valid, but not yet one-click crisp**  
+   It is clear for technical users, but still asks them to interpret which path they are on: local preview, getting-started doc, bootstrap, or cloud preview.
+
+3. **The core promise is stronger than the command copy**  
+   The real proof is not “you installed software.” It is “you can see who is doing what, what is blocked, and what needs review quickly.” The dashboard proof should stay central.
+
+4. **CTA drift is a real risk**  
+   Without one canonical link hierarchy, content fragments fast. PR #820 and #821 help, but only if we keep enforcing README-first.
+
+---
+
+## 7) Proof links
+
+- README: https://github.com/reflectt/reflectt-node
+- Getting-started rewrite: https://github.com/reflectt/reflectt-node/pull/817
+- README onboarding links: https://github.com/reflectt/reflectt-node/pull/820
+- Outreach templates: https://github.com/reflectt/reflectt-node/pull/821


### PR DESCRIPTION
## Summary
- add a command-first onboarding/distribution asset for `npx reflectt-node`
- include X/thread copy, Discord-ready copy, a README snippet candidate, distribution plan, and product-friction notes
- keep one canonical CTA: the repo README

## Testing
- not applicable (docs/content only)

## Task
- task-1773016960007-kwjwscjkv