### PR TITLE
Fix: task deletion writes canonical tombstone + deleted audit event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/
 
 # Task artifacts
 process/*
+!process/TASK-7xyi88v7x.md
 # Allow committing specific task artifacts needed for review/proof
 !process/TASK-47sxe374r.md
 !process/TASK-iwphjvsrl.md

--- a/docs/task-audit-semantics.md
+++ b/docs/task-audit-semantics.md
@@ -1,0 +1,34 @@
+# Task audit semantics
+
+Reflectt-node uses **SQLite as the source of truth** for live task state.
+
+JSONL files remain as **append-only audit streams** for debugging, migration, and offline inspection:
+
+- `data/tasks.jsonl`
+  - appends task snapshots on create/update
+  - appends a **tombstone** on delete:
+    - `{ id, deleted: true, deletedAt, deletedBy }`
+  - guarantee: grep/debug consumers can distinguish deleted tasks from live snapshots
+- `data/tasks.history.jsonl`
+  - appends lifecycle events (`created`, `assigned`, `status_changed`, `commented`, `lane_transition`, `deleted`)
+  - guarantee: task deletion writes a `deleted` event instead of silently erasing lifecycle history
+- `data/tasks.comments.jsonl`
+  - append-only task comment audit log
+
+## Delete semantics
+
+When `DELETE /tasks/:id` succeeds:
+1. a `deleted` event is written to SQLite `task_history`
+2. the same `deleted` event is appended to `tasks.history.jsonl`
+3. a tombstone record is appended to `tasks.jsonl`
+4. the live row is removed from SQLite `tasks`
+
+The audit trail is intentionally retained even after the live task row is removed.
+
+## Import / migration semantics
+
+On one-time JSONL → SQLite import:
+- task snapshot records create/update the live task row
+- task tombstones (`deleted: true`) delete the live row from SQLite
+
+This preserves append-only JSONL semantics without rehydrating deleted tasks as live rows.

--- a/process/TASK-7xyi88v7x.md
+++ b/process/TASK-7xyi88v7x.md
@@ -1,0 +1,64 @@
+# TASK-7xyi88v7x — Fix task deletion audit semantics
+
+**Task:** task-1772979825736-7xyi88v7x
+
+## Problem
+Deleting a task removed the live SQLite row but did **not** write a canonical delete audit trail:
+- no `deleted` lifecycle event was guaranteed in `task_history`
+- no tombstone was appended to `tasks.jsonl`
+- JSONL import could not distinguish a deleted task from a stale earlier snapshot
+
+That made grep/debug consumers vulnerable to phantom-task interpretation and left delete semantics inconsistent between SQLite and JSONL.
+
+## Changes
+### 1) Add explicit `deleted` lifecycle event
+- Extended `TaskHistoryEventType` with `deleted`.
+- `deleteTask()` now writes a `deleted` event into SQLite `task_history` with:
+  - `deletedAt`
+  - `deletedBy`
+  - `previousStatus`
+  - `title`
+- The same event is appended to `tasks.history.jsonl`.
+
+### 2) Append canonical tombstone to `tasks.jsonl`
+On successful delete, we now append:
+```json
+{ "id": "task-...", "deleted": true, "deletedAt": 123, "deletedBy": "system" }
+```
+This gives append-only JSONL a stable “this task is deleted” record instead of relying on absence.
+
+### 3) Preserve audit rows; remove only live task row
+Delete semantics now:
+- remove from live `tasks` table
+- keep `task_history` / `task_comments` as audit
+- append delete history JSONL
+- append task tombstone JSONL
+
+This keeps SQLite as source of truth for current state while preserving append-only audit history.
+
+### 4) Import tombstones correctly
+`importTasks()` now recognizes `{ deleted: true }` task records and deletes the live row during JSONL→SQLite import instead of rehydrating stale snapshots as active tasks.
+
+### 5) Document semantics
+Added `docs/task-audit-semantics.md` to make the contract explicit:
+- SQLite = live source of truth
+- JSONL = append-only audit stream
+- deletes write both history + tombstone records
+
+## Regression / correctness note
+I also adjusted delete ordering so the live-row removal becomes visible immediately even if a caller forgets to `await deleteTask()`. That avoided a ready-queue test regression caused by temporarily lingering deleted tasks during async cleanup.
+
+## Test proof
+`npm test --silent`
+- **1736 passed, 1 skipped**
+
+## Files changed
+- `src/tasks.ts`
+- `src/types.ts`
+- `tests/api.test.ts`
+- `docs/task-audit-semantics.md`
+- `process/TASK-7xyi88v7x.md`
+
+## Caveats
+- Delete actor is still `system` on the current HTTP delete path; if we later add authenticated task mutation actors, this can be threaded through the route cleanly.
+- Deleted-task comments/history remain as audit and are not exposed as live tasks.

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -34,9 +34,16 @@ function importTasks(db: Database.Database, records: unknown[]): number {
       tags, metadata, team_id, comment_count, due_at, scheduled_for
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
+  const del = db.prepare('DELETE FROM tasks WHERE id = ?')
 
   const insertMany = db.transaction((tasks: unknown[]) => {
     for (const record of tasks) {
+      const tombstone = record as { id?: string; deleted?: boolean }
+      if (tombstone?.deleted === true && typeof tombstone.id === 'string' && tombstone.id.trim()) {
+        del.run(tombstone.id)
+        continue
+      }
+
       const task = record as Task
       insert.run(
         task.id,
@@ -496,12 +503,17 @@ class TaskManager {
         event.timestamp,
         safeJsonStringify(event.data)
       )
+    } catch (err) {
+      console.error('[Tasks] Failed to append task history (DB):', err)
+      throw err
+    }
 
+    try {
       // Append to JSONL (audit log)
       await fs.mkdir(DATA_DIR, { recursive: true })
       await fs.appendFile(TASK_HISTORY_FILE, `${JSON.stringify(event)}\n`, 'utf-8')
     } catch (err) {
-      console.error('[Tasks] Failed to append task history:', err)
+      console.error('[Tasks] Failed to append task history (JSONL):', err)
     }
   }
 
@@ -748,6 +760,20 @@ class TaskManager {
     }
 
     return { created, skipped }
+  }
+
+  private async appendTaskTombstone(task: Task, deletedBy: string, deletedAt: number): Promise<void> {
+    try {
+      await fs.mkdir(DATA_DIR, { recursive: true })
+      await fs.appendFile(TASKS_FILE, `${JSON.stringify({
+        id: task.id,
+        deleted: true,
+        deletedAt,
+        deletedBy,
+      })}\n`, 'utf-8')
+    } catch (err) {
+      console.error('[Tasks] Failed to append task tombstone:', err)
+    }
   }
 
   /** Write a single task to SQLite + JSONL audit */
@@ -1585,20 +1611,59 @@ class TaskManager {
     return updated
   }
 
-  async deleteTask(id: string): Promise<boolean> {
+  async deleteTask(id: string, actor = 'system'): Promise<boolean> {
     const task = queryTask(id)
     if (!task) return false
 
-    // Delete from SQLite
-    try {
-      const db = getDb()
-      db.prepare('DELETE FROM tasks WHERE id = ?').run(id)
-      db.prepare('DELETE FROM task_comments WHERE task_id = ?').run(id)
-      db.prepare('DELETE FROM task_history WHERE task_id = ?').run(id)
-    } catch (err) {
-      console.error(`[Tasks] SQLite delete failed for ${id}:`, err)
+    const deletedAt = Date.now()
+    const event: TaskHistoryEvent = {
+      id: `thevt-${deletedAt}-${Math.random().toString(36).substr(2, 9)}`,
+      taskId: id,
+      type: 'deleted',
+      actor,
+      timestamp: deletedAt,
+      data: {
+        deletedAt,
+        deletedBy: actor,
+        previousStatus: task.status,
+        title: task.title,
+      },
     }
 
+    // Make the live-row delete visible immediately, even if a caller forgets to await deleteTask().
+    // Keep history/comments as audit.
+    try {
+      const db = getDb()
+      const insertHistory = db.prepare(`
+        INSERT INTO task_history (id, task_id, type, actor, timestamp, data)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `)
+      const delTask = db.prepare('DELETE FROM tasks WHERE id = ?')
+      const tx = db.transaction(() => {
+        insertHistory.run(
+          event.id,
+          event.taskId,
+          event.type,
+          event.actor,
+          event.timestamp,
+          safeJsonStringify(event.data),
+        )
+        delTask.run(id)
+      })
+      tx()
+    } catch (err) {
+      console.error(`[Tasks] SQLite delete failed for ${id}:`, err)
+      throw err
+    }
+
+    try {
+      await fs.mkdir(DATA_DIR, { recursive: true })
+      await fs.appendFile(TASK_HISTORY_FILE, `${JSON.stringify(event)}\n`, 'utf-8')
+    } catch (err) {
+      console.error('[Tasks] Failed to append delete history (JSONL):', err)
+    }
+
+    await this.appendTaskTombstone(task, actor, deletedAt)
     await this.syncTaskDeleteToCloud(id)
     this.notifySubscribers(task, 'deleted')
     return true

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface Task {
   scheduledFor?: number | null  // epoch ms — when work should start (null clears)
 }
 
-export type TaskHistoryEventType = 'created' | 'assigned' | 'status_changed' | 'commented' | 'lane_transition'
+export type TaskHistoryEventType = 'created' | 'assigned' | 'status_changed' | 'commented' | 'lane_transition' | 'deleted'
 
 export interface TaskComment {
   id: string

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -743,6 +743,46 @@ describe('Task CRUD', () => {
     expect(body2.error).toBe('Task not found')
   })
 
+  it('DELETE /tasks/:id writes deleted history + tombstone audit records', async () => {
+    const { body: created } = await req('POST', '/tasks', {
+      title: 'TEST: delete tombstone audit',
+      createdBy: 'test-runner',
+      assignee: 'test-agent',
+      reviewer: 'test-reviewer',
+      priority: 'P2',
+      done_criteria: ['Delete audit persists'],
+      eta: '1h',
+    })
+
+    const deleteTaskId = created.task.id
+
+    const del = await req('DELETE', `/tasks/${deleteTaskId}`)
+    expect(del.status).toBe(200)
+    expect(del.body.success).toBe(true)
+
+    const db = getDb()
+    const deletedEvents = db.prepare(`
+      SELECT * FROM task_history WHERE task_id = ? AND type = 'deleted' ORDER BY timestamp DESC
+    `).all(deleteTaskId) as Array<{ actor: string; data: string | null }>
+
+    expect(deletedEvents.length).toBeGreaterThan(0)
+    expect(deletedEvents[0].actor).toBe('system')
+    expect(JSON.parse(deletedEvents[0].data || '{}')).toMatchObject({
+      deletedBy: 'system',
+      previousStatus: 'todo',
+      title: 'TEST: delete tombstone audit',
+    })
+
+    const historyAudit = await fs.readFile(join(DATA_DIR, 'tasks.history.jsonl'), 'utf-8')
+    expect(historyAudit).toContain(`"taskId":"${deleteTaskId}"`)
+    expect(historyAudit).toContain('"type":"deleted"')
+
+    const taskAudit = await fs.readFile(join(DATA_DIR, 'tasks.jsonl'), 'utf-8')
+    expect(taskAudit).toContain(`"id":"${deleteTaskId}"`)
+    expect(taskAudit).toContain('"deleted":true')
+    expect(taskAudit).toContain('"deletedBy":"system"')
+  })
+
   it('GET /tasks/:id returns error for nonexistent', async () => {
     const { body } = await req('GET', '/tasks/nonexistent-id')
     expect(body.error).toBe('Task not found')


### PR DESCRIPTION
## Summary\nScoped to tombstone task only. Addresses Kai + Harmony review feedback: no ReviewHandoff gate changes, no TASK-qzvjlfy31.md carryover.\n\n### What changed\n- `deleteTask()` in `src/tasks.ts`: writes `deleted` lifecycle event to SQLite `task_history` + appends tombstone to `tasks.history.jsonl` + appends tombstone record to `tasks.jsonl`\n- `importTasks()`: skips tombstone records on bootstrap (no phantom rehydration)\n- `src/types.ts`: `TaskHistoryEventType` extended with `'deleted'`; `dueAt/scheduledFor` nullability kept (required by Zod schema, build breaks without)\n- `docs/task-audit-semantics.md`: documents JSONL guarantees and DB source-of-truth semantics\n- `tests/api.test.ts`: regression test covering SQLite history + JSONL audit for delete\n\n### What's NOT here\n- No ReviewHandoff gate changes\n- No comment_id stamping\n- No artifact retrievability gates\n- No TASK-qzvjlfy31.md\n\n### Proof\n- `tsc` clean ✅\n\nCloses `task-1772979825736-7xyi88v7x`