### PR TITLE
fix: add gpt-5.4 pricing + improve provider-prefix model lookup

### DIFF
--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -65,10 +65,13 @@ export interface CapStatus {
 // ── Model Pricing (estimated, per 1M tokens) ──
 
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  // Anthropic
   'claude-opus-4': { input: 15.0, output: 75.0 },
   'claude-opus-4-6': { input: 15.0, output: 75.0 },
   'claude-sonnet-4': { input: 3.0, output: 15.0 },
   'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
+  // OpenAI
+  'gpt-5.4': { input: 2.5, output: 10.0 },
   'gpt-5.3': { input: 2.0, output: 8.0 },
   'gpt-5.3-codex': { input: 2.0, output: 8.0 },
   'gpt-4o-mini': { input: 0.15, output: 0.60 },
@@ -76,9 +79,15 @@ const MODEL_PRICING: Record<string, { input: number; output: number }> = {
 }
 
 export function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
-  // Try exact match, then prefix match
+  // Try exact match first
   let pricing = MODEL_PRICING[model]
   if (!pricing) {
+    // Strip provider prefix (e.g., "openai-codex/gpt-5.4" → "gpt-5.4")
+    const stripped = model.includes('/') ? model.split('/').pop()! : model
+    pricing = MODEL_PRICING[stripped]
+  }
+  if (!pricing) {
+    // Fuzzy: check if any pricing key is contained in the model string
     const key = Object.keys(MODEL_PRICING).find(k => model.includes(k))
     pricing = key ? MODEL_PRICING[key] : { input: 5.0, output: 20.0 } // conservative default
   }

--- a/tests/usage-tracking.test.ts
+++ b/tests/usage-tracking.test.ts
@@ -1,6 +1,38 @@
 // Tests for usage tracking + cost guardrails
 import { describe, it, expect, beforeAll } from 'vitest'
 import Fastify from 'fastify'
+import { estimateCost } from '../src/usage-tracking.js'
+
+describe('estimateCost', () => {
+  it('prices gpt-5.4 correctly', () => {
+    const cost = estimateCost('gpt-5.4', 1_000_000, 1_000_000)
+    expect(cost).toBeCloseTo(2.5 + 10.0, 2)
+  })
+
+  it('prices provider-prefixed gpt-5.4', () => {
+    const cost = estimateCost('openai-codex/gpt-5.4', 1_000_000, 0)
+    expect(cost).toBeCloseTo(2.5, 2)
+  })
+
+  it('prices claude-sonnet-4-6 correctly', () => {
+    const cost = estimateCost('claude-sonnet-4-6', 1_000_000, 1_000_000)
+    expect(cost).toBeCloseTo(3.0 + 15.0, 2)
+  })
+
+  it('prices provider-prefixed anthropic model', () => {
+    const cost = estimateCost('anthropic/claude-opus-4-6', 1_000_000, 0)
+    expect(cost).toBeCloseTo(15.0, 2)
+  })
+
+  it('uses conservative default for unknown model', () => {
+    const cost = estimateCost('totally-unknown-model', 1_000_000, 1_000_000)
+    expect(cost).toBeCloseTo(5.0 + 20.0, 2)
+  })
+
+  it('returns 0 for zero tokens', () => {
+    expect(estimateCost('gpt-5.4', 0, 0)).toBe(0)
+  })
+})
 
 describe('Usage Tracking API', () => {
   let app: ReturnType<typeof Fastify>


### PR DESCRIPTION
## What
Fixes #679 (CRITICAL) — gpt-5.4 model usage was untracked in the cloud cost dashboard.

## Root Cause
`MODEL_PRICING` in `src/usage-tracking.ts` had no entry for `gpt-5.4`. The `estimateCost()` fuzzy match (`model.includes(key)`) also failed because provider-prefixed names like `openai-codex/gpt-5.4` don't contain a bare `gpt-5.3` substring.

## Fix
1. **Added `gpt-5.4` to MODEL_PRICING** — $2.50 input / $10.00 output per 1M tokens
2. **Improved `estimateCost()`** — now strips provider prefix (e.g., `openai-codex/gpt-5.4` → `gpt-5.4`) before lookup, with fuzzy match as final fallback

## Tests
6 new unit tests for `estimateCost`:
- Exact match (`gpt-5.4`)
- Provider-prefixed (`openai-codex/gpt-5.4`, `anthropic/claude-opus-4-6`)
- Unknown model → conservative default
- Zero tokens → $0

Full suite: 149 files, 1795 passed, 0 failed.

## Note
This fixes the pricing lookup. However, if OpenClaw gateway isn't pushing usage events for gpt-5.4 sessions to the `/usage/report` endpoint at all, those agents will still show $0 — that's a separate OpenClaw-side issue.