### PR TITLE
fix: remap shared GitHub @mentions in cloud-relayed messages

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -17,6 +17,7 @@ import { presenceManager } from './presence.js'
 import { getAgentRoles } from './assignment.js'
 import { taskManager } from './tasks.js'
 import { chatManager } from './chat.js'
+import { remapGitHubMentions } from './github-webhook-attribution.js'
 import { slotManager } from './canvas-slots.js'
 import { getDb } from './db.js'
 import { getUsageSummary, getUsageByAgent, getUsageByModel, listCaps, checkCaps, getRoutingSuggestions } from './usage-tracking.js'
@@ -1033,9 +1034,16 @@ async function syncChat(): Promise<void> {
       for (const msg of result.data.pending) {
         // Inject into local chat as if the user posted it
         try {
+          // GitHub relay messages from the cloud use raw GitHub sender logins (e.g. @itskaidev)
+          // instead of agent names. Remap shared GitHub accounts to their agent equivalents
+          // before injecting so @mentions resolve correctly.
+          const content = msg.from === 'github'
+            ? remapGitHubMentions(msg.content)
+            : msg.content
+
           await chatManager.sendMessage({
             from: msg.from,
-            content: msg.content,
+            content,
             channel: msg.channel || 'general',
             metadata: { source: 'cloud-relay', cloudMessageId: msg.id },
           })

--- a/src/github-webhook-attribution.ts
+++ b/src/github-webhook-attribution.ts
@@ -88,6 +88,26 @@ export function resolveWebhookAttribution(payload: Record<string, unknown>): Git
 }
 
 /**
+ * Remap shared GitHub @mentions in a pre-formatted message string.
+ *
+ * Used for cloud-relayed GitHub event messages where the cloud has already
+ * formatted the message content (e.g. "@itskaidev\n✅ **PR merged** #828...")
+ * but used the raw GitHub sender login instead of the real agent name.
+ *
+ * Replaces any `@<sharedUsername>` occurrences with `@<fallbackAgent>`.
+ * Does NOT perform branch-based lookup (branch info is unavailable at this stage).
+ */
+export function remapGitHubMentions(text: string): string {
+  if (!text || typeof text !== 'string') return text
+  let result = text
+  for (const username of SHARED_GITHUB_USERNAMES) {
+    // Match @username at word boundary (avoid partial matches like @itskaidev123)
+    result = result.replace(new RegExp(`@${username}\\b`, 'gi'), `@${FALLBACK_AGENT}`)
+  }
+  return result
+}
+
+/**
  * Enrich a GitHub webhook payload with agent attribution metadata.
  * Adds `_reflectt_attribution` to the payload (non-destructive).
  */

--- a/tests/github-webhook-attribution.test.ts
+++ b/tests/github-webhook-attribution.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { extractAgentFromBranch, resolveWebhookAttribution, enrichWebhookPayload } from '../src/github-webhook-attribution.js'
+import { extractAgentFromBranch, resolveWebhookAttribution, enrichWebhookPayload, remapGitHubMentions } from '../src/github-webhook-attribution.js'
 import { loadAgentRoles } from '../src/assignment.js'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -134,6 +134,45 @@ describe('github-webhook-attribution', () => {
       const enriched = enrichWebhookPayload(payload)
       expect(enriched.action).toBe('closed')
       expect(enriched.number).toBe(42)
+    })
+  })
+
+  describe('remapGitHubMentions', () => {
+    it('remaps @itskaidev to @kai at start of message', () => {
+      const input = '@itskaidev\n✅ **PR merged** #828: [fix: branch guard crash]'
+      expect(remapGitHubMentions(input)).toBe('@kai\n✅ **PR merged** #828: [fix: branch guard crash]')
+    })
+
+    it('remaps @itskaidev inline in message body', () => {
+      const input = '💬 **Comment by @supabase[bot]** on PR #686 — review by @itskaidev requested'
+      expect(remapGitHubMentions(input)).toContain('@kai')
+      expect(remapGitHubMentions(input)).not.toContain('@itskaidev')
+    })
+
+    it('remaps multiple occurrences', () => {
+      const input = '@itskaidev opened PR and @itskaidev requested review'
+      const result = remapGitHubMentions(input)
+      expect(result).toBe('@kai opened PR and @kai requested review')
+    })
+
+    it('is case-insensitive for the GitHub username', () => {
+      const input = '@ITSKAIDEV merged the PR'
+      expect(remapGitHubMentions(input)).toBe('@kai merged the PR')
+    })
+
+    it('does not remap non-shared GitHub usernames', () => {
+      const input = '@ryancampbell requested a review'
+      expect(remapGitHubMentions(input)).toBe('@ryancampbell requested a review')
+    })
+
+    it('does not partial-match (e.g. @itskaidev123 is left alone)', () => {
+      const input = 'mentioned @itskaidev123 in a comment'
+      expect(remapGitHubMentions(input)).toBe('mentioned @itskaidev123 in a comment')
+    })
+
+    it('handles empty or non-string input gracefully', () => {
+      expect(remapGitHubMentions('')).toBe('')
+      expect(remapGitHubMentions(null as any)).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Problem

PR #825 fixed attribution for webhooks received locally at `/webhooks/incoming/github`. But GitHub events arriving via the **cloud sync path** (`cloud.ts`) bypassed this entirely — the cloud formats messages with the raw GitHub sender login (e.g. `@itskaidev`) and delivers them as pre-formatted strings. The local node injected them verbatim.

This is why `@itskaidev` was still showing up in `#general` after #825 merged.

## Fix

Adds `remapGitHubMentions(text: string): string` to `github-webhook-attribution.ts` and calls it in `cloud.ts` when injecting cloud-relayed messages with `from === 'github'`.

Replaces `@itskaidev` (and any other shared accounts in `SHARED_GITHUB_USERNAMES`) with `@kai` (the fallback agent). Case-insensitive, respects word boundaries — `@itskaidev123` is not touched.

## Changes

- `src/github-webhook-attribution.ts`: add `remapGitHubMentions()`
- `src/cloud.ts`: apply remap before injecting cloud-relayed GitHub messages
- `tests/github-webhook-attribution.test.ts`: 7 new tests (22 total, all passing)

## Tests

```
✓ tests/github-webhook-attribution.test.ts (22 tests) 137ms
```

Closes task-1773014909275-q0i243u9w