### PR TITLE
docs: fix P0 install drop-offs — yarn PATH + curl installer prereq gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Open **[http://localhost:4445/dashboard](http://localhost:4445/dashboard)** — 
 
 > Just want to try it first? `npx reflectt-node` starts immediately, no install required.
 
+> **Using yarn?** `yarn global add reflectt-node` works, but run `yarn global bin` and add it to your `$PATH` if you get `reflectt: command not found`.
+
+> **Have OpenClaw?** ⚡ `curl -fsSL https://www.reflectt.ai/install.sh | bash` — automated install, build, and health-check. Requires OpenClaw pre-installed.
+
 **More docs:**
 - Full guide: [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md)
 - Copy/paste bootstrap: [docs/bootstrap-first-5-minutes.md](docs/bootstrap-first-5-minutes.md)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -27,6 +27,18 @@ Pick one:
 npm install -g reflectt-node
 ```
 
+> **Using yarn?** `yarn global add reflectt-node` works, but yarn's global bin is often not in your PATH by default. If you get `reflectt: command not found`, run `yarn global bin` and add that path to your `$PATH`. For simplicity, npm global install is recommended.
+
+### curl installer (automated, requires OpenClaw)
+
+> ⚡ **Requires [OpenClaw](https://openclaw.ai) to be installed first.** The installer will exit with an error if OpenClaw is missing — install it before running this.
+
+```bash
+curl -fsSL https://www.reflectt.ai/install.sh | bash
+```
+
+This clones the repo, builds it, starts the server, and verifies `/health` automatically.
+
 ### npx (try without installing)
 
 ```bash


### PR DESCRIPTION
## What

Two P0 install drop-offs from bootstrap flow analysis (task-1773016959979-1qq5p2izb):

**1. Yarn global PATH** — `yarn global add reflectt-node` works but yarn's global bin is often not in `$PATH` by default. Users get `reflectt: command not found` with no guidance. Fix: yarn PATH note added to README and GETTING-STARTED.md.

**2. curl installer prereq gate** — `install.sh` requires OpenClaw but prereq wasn't surfaced before the command in README or GETTING-STARTED.md. Fix: added prereq callout.

Note: port conflict, .env.example, and reflectt doctor changes were already merged into main via other branches during rebase.

## Files
- `README.md`
- `docs/GETTING-STARTED.md`

## Task
task-1773108807295-87zzp1osq