### PR TITLE
fix: use branch-based attribution for GitHub webhook @mentions

### DIFF
--- a/src/github-webhook-chat.ts
+++ b/src/github-webhook-chat.ts
@@ -12,7 +12,16 @@
 
 import { remapGitHubMentions } from './github-webhook-attribution.js'
 
-interface GitHubEvent {
+// Extended interface to support enriched payloads with _reflectt_attribution
+interface ReflecttAttribution {
+  agent: string | null
+  githubUser: string | null
+  remapped: boolean
+  source: string
+}
+
+interface GitHubEvent extends Record<string, unknown> {
+  _reflectt_attribution?: ReflecttAttribution
   action?: string
   sender?: { login?: string }
   repository?: { full_name?: string; name?: string }
@@ -65,7 +74,13 @@ interface GitHubEvent {
  */
 export function formatGitHubEvent(eventType: string, payload: GitHubEvent): string | null {
   const repo = payload.repository?.name || payload.repository?.full_name || 'unknown'
-  const sender = payload.sender?.login || 'unknown'
+  const rawSender = payload.sender?.login || 'unknown'
+
+  // Prefer branch-resolved agent name from enriched payload attribution.
+  // Falls back to remapped GitHub username (e.g. @itskaidev → @kai).
+  // This ensures PR events from `link/feature-x` mention @link, not @kai.
+  const resolvedAgent = payload._reflectt_attribution?.agent
+  const sender = resolvedAgent ?? remapGitHubMentions(rawSender) ?? rawSender
 
   let message: string | null = null
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -12440,10 +12440,12 @@ If your heartbeat shows **no active task** and **no next task**:
       events.push(event)
     }
 
-    // Post GitHub events to the 'github' chat channel with remapped mentions
+    // Post GitHub events to the 'github' chat channel with remapped mentions.
+    // Pass enrichedBody (not body) so formatGitHubEvent has access to
+    // _reflectt_attribution and can mention the correct agent (@link not @kai).
     if (provider === 'github') {
       const ghEventType = (request.headers['x-github-event'] as string) || eventType
-      const chatMessage = formatGitHubEvent(ghEventType, body)
+      const chatMessage = formatGitHubEvent(ghEventType, enrichedBody as any)
       if (chatMessage) {
         chatManager.sendMessage({
           from: 'github',

--- a/tests/github-webhook-attribution.test.ts
+++ b/tests/github-webhook-attribution.test.ts
@@ -176,3 +176,69 @@ describe('github-webhook-attribution', () => {
     })
   })
 })
+
+import { formatGitHubEvent } from '../src/github-webhook-chat.js'
+
+describe('formatGitHubEvent — branch-based agent attribution', () => {
+  beforeEach(() => {
+    setupRoles()
+  })
+
+  it('mentions branch-resolved agent, not GitHub sender, for PR opened', () => {
+    const payload = {
+      action: 'opened',
+      sender: { login: 'itskaidev' },
+      repository: { name: 'reflectt-node' },
+      pull_request: {
+        number: 847,
+        title: 'fix: watchdog restart',
+        html_url: 'https://github.com/reflectt/reflectt-node/pull/847',
+        head: { ref: 'link/c8-coverage' },
+      },
+      _reflectt_attribution: { agent: 'link', githubUser: 'itskaidev', remapped: true, source: 'branch' },
+    }
+    const msg = formatGitHubEvent('pull_request', payload as any)
+    expect(msg).not.toBeNull()
+    expect(msg).toContain('@link')
+    expect(msg).not.toContain('@kai')
+    expect(msg).not.toContain('@itskaidev')
+  })
+
+  it('mentions @kai when attribution falls back (no branch info)', () => {
+    const payload = {
+      action: 'closed',
+      sender: { login: 'itskaidev' },
+      repository: { name: 'reflectt-node' },
+      pull_request: {
+        number: 123,
+        title: 'some PR',
+        html_url: 'https://github.com/reflectt/reflectt-node/pull/123',
+        merged: true,
+      },
+      _reflectt_attribution: { agent: 'kai', githubUser: 'itskaidev', remapped: true, source: 'fallback' },
+    }
+    const msg = formatGitHubEvent('pull_request', payload as any)
+    expect(msg).not.toBeNull()
+    expect(msg).toContain('@kai')
+    expect(msg).not.toContain('@itskaidev')
+  })
+
+  it('mentions agent directly when no attribution field (unenriched payload fallback)', () => {
+    // Without _reflectt_attribution, falls back to remapGitHubMentions(rawSender)
+    const payload = {
+      action: 'opened',
+      sender: { login: 'itskaidev' },
+      repository: { name: 'reflectt-node' },
+      pull_request: {
+        number: 10,
+        title: 'legacy payload',
+        html_url: 'https://github.com/reflectt/reflectt-node/pull/10',
+      },
+    }
+    const msg = formatGitHubEvent('pull_request', payload as any)
+    expect(msg).not.toBeNull()
+    // itskaidev remapped to kai by remapGitHubMentions
+    expect(msg).not.toContain('@itskaidev')
+    expect(msg).toContain('@kai')
+  })
+})


### PR DESCRIPTION
## Problem

GitHub webhook notifications were @mentioning the shared GitHub account (@itskaidev) instead of the agent who owns the PR branch. `remapGitHubMentions` only handled the direct username fallback (itskaidev → kai), but never applied the existing branch-based attribution — so `link/c8-coverage` PRs mentioned `@kai` instead of `@link`.

Root cause: `formatGitHubEvent` was building messages with `@${sender.login}` (raw GitHub username), and `server.ts` was passing the unenriched `body` to it instead of `enrichedBody`.

## Fix

1. **`github-webhook-chat.ts`**: Read `_reflectt_attribution.agent` from the enriched payload. Use the resolved agent for the `@mention`. Falls back to `remapGitHubMentions(rawSender)` for unenriched payloads.

2. **`server.ts`**: Pass `enrichedBody` (not `body`) to `formatGitHubEvent` so attribution computed by `enrichWebhookPayload` is available at format time.

## Priority order (unchanged from attribution module)

1. PR branch name → resolved agent (`link/c8-coverage` → `@link`)
2. Shared account fallback → `@kai`
3. Direct agent name match (sender already an agent)
4. Unknown sender → null

## Tests

3 new fixture tests:
- PR from `link/...` branch → message mentions `@link`, not `@kai`/`@itskaidev`
- Fallback attribution → message mentions `@kai`
- Unenriched payload (no `_reflectt_attribution`) → `remapGitHubMentions` fallback still works

155/155 test files, 1851 tests passing.

Task: task-1773014938700-8icjaduhe