### PR TITLE
cos: add 13 missing agents to defaults/TEAM-ROLES.yaml + security lane

### DIFF
--- a/defaults/TEAM-ROLES.yaml
+++ b/defaults/TEAM-ROLES.yaml
@@ -236,6 +236,284 @@ agents:
       - brand-copy
     wipCap: 1
 
+  - name: cos
+    role: chief-of-staff
+    description: Alignment and escalation router. Maintains decision log, tracks who owes what by when, packages escalations, prevents thrash. No final product/design decisions.
+    affinityTags:
+      - alignment
+      - escalation
+      - decisions
+      - process
+      - coordination
+      - strategy
+    routingMode: opt-in
+    neverRouteUnlessLane: alignment
+    alwaysRoute:
+      - alignment
+      - escalation
+      - process
+    neverRoute:
+      - backend
+      - frontend
+      - ui
+      - design
+      - security-review
+      - code-review
+    wipCap: 2
+
+  - name: coo
+    role: operations
+    description: Board execution, lane health, and ops monitoring. Owns board hygiene, task gate enforcement, EOD signal generation, SOUL.md patch cycle.
+    affinityTags:
+      - ops
+      - board-health
+      - lane-health
+      - monitoring
+      - execution
+      - watchdog
+    routingMode: opt-in
+    neverRouteUnlessLane: ops
+    alwaysRoute:
+      - ops
+      - board-health
+      - execution
+    neverRoute:
+      - backend
+      - frontend
+      - ui
+      - design
+    wipCap: 2
+
+  - name: pm
+    role: product-manager
+    description: Product spec, acceptance criteria, lane metrics, and shipping reports. Translates business goals into scoped tasks.
+    affinityTags:
+      - product
+      - spec
+      - ac
+      - reporting
+      - metrics
+      - prioritization
+    routingMode: opt-in
+    neverRouteUnlessLane: product
+    alwaysRoute:
+      - product
+      - spec
+      - reporting
+    neverRoute:
+      - backend
+      - ui
+      - security-review
+    wipCap: 2
+
+  - name: qa
+    role: quality
+    description: Regression testing, audit checklists, mobile QA, and test coverage validation.
+    affinityTags:
+      - qa
+      - testing
+      - regression
+      - audit
+      - checklist
+      - coverage
+      - mobile-qa
+    alwaysRoute:
+      - qa
+      - testing
+      - regression
+    neverRoute:
+      - brand-copy
+      - marketing
+    wipCap: 2
+
+  - name: swift
+    role: ios-engineer
+    description: iOS app development — Swift/SwiftUI, TestFlight pipeline, Apple Watch companion, App Store submission.
+    affinityTags:
+      - ios
+      - swift
+      - swiftui
+      - testflight
+      - apple
+      - watchos
+      - mobile
+    alwaysRoute:
+      - ios
+      - swift
+      - apple
+    neverRoute:
+      - android
+      - backend
+      - design
+    wipCap: 2
+
+  - name: kotlin
+    role: android-engineer
+    description: Android app development — Kotlin, Play Store submission, Firebase integration, CI/CD pipeline.
+    affinityTags:
+      - android
+      - kotlin
+      - play-store
+      - firebase
+      - mobile
+      - gradle
+    alwaysRoute:
+      - android
+      - kotlin
+      - play-store
+    neverRoute:
+      - ios
+      - backend
+      - design
+    wipCap: 2
+
+  - name: shield
+    role: security
+    description: Security audits — RLS policy review, IDOR checks, rate limiting, env var hygiene, Vercel config.
+    affinityTags:
+      - security
+      - rls
+      - audit
+      - idor
+      - rate-limiting
+      - env
+      - compliance
+    alwaysRoute:
+      - security
+      - rls
+      - security-review
+    neverRoute:
+      - brand-copy
+      - marketing
+      - design
+    protectedDomains:
+      - security
+    wipCap: 1
+
+  - name: artdirector
+    role: art-director
+    description: Visual design direction — host detail pages, design specs, screenshot audits, mobile layout direction.
+    affinityTags:
+      - design
+      - visual
+      - layout
+      - art-direction
+      - spec
+      - mockup
+    routingMode: opt-in
+    neverRouteUnlessLane: design
+    alwaysRoute:
+      - art-direction
+      - design-spec
+    neverRoute:
+      - backend
+      - security-review
+      - code-review
+    wipCap: 1
+
+  - name: uipolish
+    role: ui-polisher
+    description: Frontend polish — mobile layout fixes, density improvements, empty states, scroll affordances, visual regressions.
+    affinityTags:
+      - ui
+      - polish
+      - mobile
+      - css
+      - layout
+      - visual
+      - frontend
+    alwaysRoute:
+      - ui-polish
+      - visual-polish
+      - mobile
+    neverRoute:
+      - backend
+      - security-review
+      - api
+    wipCap: 2
+
+  - name: kindling
+    role: community
+    description: Community engagement — Discord posts, UTM tracking, community onboarding content.
+    affinityTags:
+      - community
+      - discord
+      - utm
+      - onboarding-content
+      - social
+    routingMode: opt-in
+    neverRouteUnlessLane: community
+    alwaysRoute:
+      - community
+      - discord
+    neverRoute:
+      - backend
+      - security-review
+      - code-review
+    wipCap: 1
+
+  - name: quill
+    role: writer
+    description: Long-form content — dev.to articles, changelogs, shipping summaries, community posts.
+    affinityTags:
+      - writing
+      - content
+      - changelog
+      - blog
+      - devto
+      - community-post
+    routingMode: opt-in
+    neverRouteUnlessLane: content
+    alwaysRoute:
+      - writing
+      - changelog
+      - blog
+    neverRoute:
+      - backend
+      - security-review
+      - code-review
+      - ui
+    wipCap: 1
+
+  - name: funnel
+    role: growth-funnel
+    description: Conversion funnel optimization — install drop-off fixes, onboarding UX, PATH guidance, curl installer.
+    affinityTags:
+      - funnel
+      - conversion
+      - install
+      - onboarding
+      - growth
+      - drop-off
+    alwaysRoute:
+      - funnel
+      - install
+      - onboarding-ux
+    neverRoute:
+      - security-review
+      - backend-infra
+    wipCap: 1
+
+  - name: attribution
+    role: analytics
+    description: Cost and attribution analytics — cost dashboards, spend alerts, model effectiveness tracking, UTM attribution.
+    affinityTags:
+      - analytics
+      - cost
+      - attribution
+      - spend
+      - reporting
+      - dashboard
+      - metrics
+    alwaysRoute:
+      - analytics
+      - cost-tracking
+      - attribution
+    neverRoute:
+      - security-review
+      - brand-copy
+    wipCap: 1
+
   # Removed agent-1/2/3 fallback entries — were leaking into dashboard as ghost agents
 
 # Decision authority — what the team owns vs. what requires a human
@@ -273,17 +551,17 @@ decision_authority:
 # wipLimit   — max simultaneous doing tasks per agent (/tasks/next enforces this)
 lanes:
   - name: engineering
-    agents: [link]
+    agents: [link, swift, kotlin]
     readyFloor: 2
     wipLimit: 2
 
   - name: design
-    agents: [pixel]
+    agents: [pixel, artdirector, uipolish]
     readyFloor: 1
     wipLimit: 1
 
   - name: operations
-    agents: [sage, rhythm]
+    agents: [sage, rhythm, coo, cos, pm, qa]
     readyFloor: 1
     wipLimit: 1
 
@@ -293,11 +571,16 @@ lanes:
     wipLimit: 1
 
   - name: growth
-    agents: [spark]
+    agents: [spark, funnel, attribution]
     readyFloor: 1
     wipLimit: 1
 
   - name: content
-    agents: [echo]
+    agents: [echo, quill, kindling]
+    readyFloor: 1
+    wipLimit: 1
+
+  - name: security
+    agents: [shield]
     readyFloor: 1
     wipLimit: 1


### PR DESCRIPTION
## What
Add 13 missing agents to `defaults/TEAM-ROLES.yaml` so new installs get the full team roster:

cos, coo, pm, qa, swift, kotlin, shield, artdirector, uipolish, kindling, quill, funnel, attribution

Also adds a `security` lane for `shield`.

## Why
New installs were missing routing config for most of the active team. Only 8 agents were in the defaults file; the team has 21+. Cold-starting nodes would get an incomplete team composition.

## Changes
- 13 agent entries with role, description, affinityTags, routing rules, wipCap
- 3 lanes updated (engineering, design, operations, growth, content) + 1 new (security)
- decision_authority block (from prior commit 1b2bad2)

## Contract
Verified against live `~/.reflectt/team-roles.yaml` which already has these agents. This brings the default into sync.