### PR TITLE
cos: BackOffice + EVI-Fly agents — bookkeeper, taxwatch, evi-scout, evi-content, evi-growth

### DIFF
--- a/defaults/TEAM-ROLES.yaml
+++ b/defaults/TEAM-ROLES.yaml
@@ -559,6 +559,31 @@ agents:
       - design
     wipCap: 1
 
+  - name: legal-counsel
+    role: legal-compliance
+    description: Legal review — privacy policies, terms of service, GDPR/CCPA, data retention, compliance PRs. Owns legal/compliance decisions autonomously; escalates to Kai only for major liability or vision conflicts. Never escalated to Ryan (investor, not approver).
+    affinityTags:
+      - legal
+      - compliance
+      - privacy
+      - terms
+      - gdpr
+      - ccpa
+      - data-retention
+    routingMode: opt-in
+    neverRouteUnlessLane: backoffice
+    alwaysRoute:
+      - legal
+      - privacy-policy
+      - terms-of-service
+      - compliance
+    neverRoute:
+      - backend
+      - frontend
+      - design
+      - security-review
+    wipCap: 1
+
   # EVI-Fly agents (enjoyvancouverisland.com)
   - name: evi-scout
     role: site-health
@@ -694,7 +719,7 @@ lanes:
     wipLimit: 1
 
   - name: backoffice
-    agents: [bookkeeper, taxwatch]
+    agents: [bookkeeper, taxwatch, legal-counsel]
     readyFloor: 1
     wipLimit: 1
 


### PR DESCRIPTION
## What
Adds 5 new agents and 2 new lanes to `defaults/TEAM-ROLES.yaml`:

**BackOffice lane:**
- `bookkeeper` — Stripe revenue tracking, MRR, invoices
- `taxwatch` — tax compliance, quarterly estimates

**EVI-Fly lane:**
- `evi-scout` — enjoyvancouverisland.com health, Supabase, crawler monitoring  
- `evi-content` — venue/event content quality, SEO
- `evi-growth` — traffic, analytics, distribution

## Why
E-002 and E-003 resolved (Ryan email 2026-03-09 18:50 PDT). BackOffice and EVI-Fly are now unblocked for activation. Workspaces created at `workspace-bookkeeper/` and `workspace-eviscout/`.