### PR TITLE
fix: gateway restart quiet window — suppress idle alerts after reconnect

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -554,6 +554,7 @@ Multi-host management: remote hosts register via heartbeat and are tracked by st
 | POST | `/board-health/rollback/:actionId` | Rollback an automated action within the rollback window. Body: `{ by? }`. |
 | PATCH | `/board-health/config` | Update worker config at runtime. Fields: enabled, intervalMs, staleDoingThresholdMin, suggestCloseThresholdMin, rollbackWindowMs, digestIntervalMs, digestChannel, quietHoursStart, quietHoursEnd, dryRun, maxActionsPerTick. |
 | POST | `/board-health/prune` | Prune old audit log entries. Query: `?maxAgeDays=7`. |
+| POST | `/board-health/quiet-window` | Reset the quiet window — suppresses ready-queue alerts for `restartQuietWindowMs` (default 5 min). Call after gateway restart/reconnect. |
 | GET | `/feed/:agent` | Since-last-seen change feed. Query: `?since=timestamp&limit=100&kinds=task_status_changed,mention&includeGlobal=true`. Returns unified timeline of task changes, comments, mentions, PRs, deploys relevant to agent. |
 | GET | `/policy` | Get unified policy config (quiet hours, idle nudge, cadence watchdog, board health, escalation thresholds). |
 | PATCH | `/policy` | Update policy config at runtime (deep-merged, persisted to ~/.reflectt/policy.json). Propagates to running workers. |

--- a/src/boardHealthWorker.ts
+++ b/src/boardHealthWorker.ts
@@ -174,6 +174,16 @@ export class BoardHealthWorker {
     }
   }
 
+  /**
+   * Reset the quiet window — suppresses ready-queue alerts for
+   * `restartQuietWindowMs` from now. Call when a gateway restart or
+   * reconnection is detected so agents have time to re-establish presence
+   * before idle alerts fire.
+   */
+  resetQuietWindow(): void {
+    this.lastQuietReset = Date.now()
+  }
+
   updateConfig(patch: Partial<BoardHealthWorkerConfig>): void {
     const wasEnabled = this.config.enabled
     this.config = { ...this.config, ...patch }
@@ -495,16 +505,19 @@ export class BoardHealthWorker {
   private idleQueueSince: Record<string, number> = {}
 
   /**
-   * Process start timestamp — used to enforce a post-restart quiet window.
-   * For the first `restartQuietWindowMs` after startup, ready-queue alerts are
-   * suppressed so the continuity loop has time to replenish queues before any
-   * watchdog fires. Prevents thundering-herd: without this, all agents with
-   * expired cooldowns (lastAlertAt = 0) fire simultaneously on the first sweep.
+   * Quiet-window anchor — used to enforce a post-restart quiet window.
+   * For the first `restartQuietWindowMs` after this timestamp, ready-queue
+   * alerts are suppressed so agents have time to reconnect and replenish queues.
+   *
+   * Initially set to process start (node restart). Also reset by
+   * `resetQuietWindow()` when an external event (e.g. gateway restart)
+   * warrants a fresh suppression window.
    *
    * Tests that need immediate breach detection should set restartQuietWindowMs: 0
    * in the constructor config.
    */
   private readonly startedAt = Date.now()
+  private lastQuietReset = Date.now()
 
   private async checkReadyQueueFloor(now: number, dryRun: boolean): Promise<PolicyAction[]> {
     const policy = policyManager.get()
@@ -554,7 +567,10 @@ export class BoardHealthWorker {
       // Prevents thundering-herd — all agents with no prior alert record (lastAlertAt=0)
       // would otherwise fire simultaneously on the first post-restart sweep.
       // restartQuietWindowMs can be set to 0 in tests for immediate breach detection.
-      const inStartupQuiet = lastAlert === 0 && (now - this.startedAt) < this.config.restartQuietWindowMs
+      // Quiet window: suppress alerts shortly after any restart (node start OR gateway reconnect).
+      // Uses the most recent of startedAt and lastQuietReset as the anchor.
+      const quietAnchor = Math.max(this.startedAt, this.lastQuietReset)
+      const inStartupQuiet = lastAlert === 0 && (now - quietAnchor) < this.config.restartQuietWindowMs
 
       if (belowFloor && now - lastAlert > cooldownMs && !inStartupQuiet) {
         const deficit = rqf.minReady - readyCount

--- a/src/server.ts
+++ b/src/server.ts
@@ -6842,6 +6842,15 @@ export async function createServer(): Promise<FastifyInstance> {
     },
   )
 
+  app.post('/board-health/quiet-window', async () => {
+    boardHealthWorker.resetQuietWindow()
+    return {
+      success: true,
+      quietUntil: Date.now() + (boardHealthWorker.getStatus().config?.restartQuietWindowMs ?? 300_000),
+      message: 'Quiet window reset — ready-queue alerts suppressed for restart window',
+    }
+  })
+
   // ── Agent change feed ─────────────────────────────────────────────────
 
   app.get<{ Params: { agent: string }; Querystring: { since?: string; limit?: string; kinds?: string; includeGlobal?: string } }>(

--- a/tests/gateway-restart-quiet-window.test.ts
+++ b/tests/gateway-restart-quiet-window.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { taskManager } from '../src/tasks.js'
+import { policyManager } from '../src/policy.js'
+import { BoardHealthWorker } from '../src/boardHealthWorker.js'
+
+const TEST_AGENT = 'gw-restart-tester'
+const TITLE_PREFIX = 'TEST: gw-restart-quiet'
+
+describe('Gateway restart quiet window', () => {
+  let originalReadyQueueFloor: any
+
+  beforeEach(() => {
+    originalReadyQueueFloor = policyManager.get().readyQueueFloor
+
+    policyManager.patch({
+      readyQueueFloor: {
+        ...originalReadyQueueFloor,
+        enabled: true,
+        agents: [TEST_AGENT],
+        minReady: 2,
+        cooldownMin: 0,
+        escalateAfterMin: 9999,
+        channel: 'general',
+      },
+    } as any)
+  })
+
+  afterEach(() => {
+    const tasks = taskManager.listTasks({ includeTest: true })
+    for (const t of tasks) {
+      if (t.title.startsWith(TITLE_PREFIX)) {
+        taskManager.deleteTask(t.id)
+      }
+    }
+    policyManager.patch({ readyQueueFloor: originalReadyQueueFloor } as any)
+  })
+
+  it('resetQuietWindow() suppresses alerts for agents with no prior alert record', async () => {
+    // No tasks → agent is below floor (minReady=2), no active work → breach
+    const worker = new BoardHealthWorker({ maxActionsPerTick: 0, restartQuietWindowMs: 5_000 })
+
+    // Simulate gateway restart → reset quiet window
+    worker.resetQuietWindow()
+
+    // Tick should NOT produce ready-queue-floor breach actions during quiet window
+    const result = await worker.tick({ dryRun: true, force: true })
+    const rqfActions = result.actions.filter(a => a.kind === 'ready-queue-warning' && a.agent === TEST_AGENT)
+    expect(rqfActions.length).toBe(0)
+    worker.stop()
+  })
+
+  it('alerts fire after quiet window expires', async () => {
+    // 1ms quiet window → expires almost immediately
+    const worker = new BoardHealthWorker({ maxActionsPerTick: 0, restartQuietWindowMs: 1 })
+
+    worker.resetQuietWindow()
+    await new Promise(r => setTimeout(r, 10))
+
+    // Quiet window expired, no tasks → breach alert should fire
+    // Note: dryRun=false because breach actions only push to actions[] in isBreach path
+    // and readyQueueLastAlertAt needs to be set for the action to be recorded
+    const result = await worker.tick({ force: true })
+    const rqfActions = result.actions.filter(a => a.kind === 'ready-queue-warning' && a.agent === TEST_AGENT)
+    expect(rqfActions.length).toBeGreaterThan(0)
+    worker.stop()
+  })
+
+  it('resetQuietWindow() can be called multiple times (re-suppresses)', async () => {
+    const worker = new BoardHealthWorker({ maxActionsPerTick: 0, restartQuietWindowMs: 5_000 })
+
+    worker.resetQuietWindow()
+    let result = await worker.tick({ dryRun: true, force: true })
+    let rqfActions = result.actions.filter(a => a.kind === 'ready-queue-warning' && a.agent === TEST_AGENT)
+    expect(rqfActions.length).toBe(0)
+
+    // Second reset
+    worker.resetQuietWindow()
+    result = await worker.tick({ dryRun: true, force: true })
+    rqfActions = result.actions.filter(a => a.kind === 'ready-queue-warning' && a.agent === TEST_AGENT)
+    expect(rqfActions.length).toBe(0)
+
+    worker.stop()
+  })
+})


### PR DESCRIPTION
## Problem

When the OpenClaw gateway restarts, all agent sessions reconnect but the reflectt-node process stays running. The boardHealthWorker would fire ready-queue idle alerts for every agent because their `lastAlertAt` was 0 (fresh session) while the startup quiet window (based on `startedAt`) had long expired. This caused team-wide idle alert spikes after every gateway restart.

## Fix

- Add `resetQuietWindow()` method to `BoardHealthWorker` that resets the suppression anchor timestamp
- Add `POST /board-health/quiet-window` API endpoint so the channel plugin or external tools can trigger it on gateway reconnect
- The quiet window now uses `max(startedAt, lastQuietReset)` as the anchor, covering both node restarts and gateway restarts

## Changes

- `src/boardHealthWorker.ts`: Add `lastQuietReset` field and `resetQuietWindow()` method; update quiet window check to use `max(startedAt, lastQuietReset)`
- `src/server.ts`: Add `POST /board-health/quiet-window` endpoint
- `public/docs.md`: Document new endpoint
- `tests/gateway-restart-quiet-window.test.ts`: 3 tests for quiet window suppression, expiry, and re-suppression

## Testing

- 1859 tests pass (0 failures)
- Route-docs contract check passes (429/429)
- 3 new tests cover: suppression during window, alerts after expiry, multiple resets

Fixes: task-1773101142350-kzeene6t9