### PR TITLE
docs: expand .env.example with all supported env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,91 @@
-# Server Configuration
+# reflectt-node environment variables
+# Copy to .env and edit as needed (or export in your shell/systemd unit).
+# All variables are optional — defaults work for local development.
+
+# ─── Server ──────────────────────────────────────────────────────────────────
+
+# Port the server listens on. Default: 4445
 PORT=4445
-HOST=127.0.0.1
 
-# OpenClaw Gateway
-OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789
-OPENCLAW_GATEWAY_TOKEN=your_gateway_token_here
+# Host/address to bind. Default: 0.0.0.0 (all interfaces).
+# Use 127.0.0.1 to restrict to localhost only.
+HOST=0.0.0.0
 
-# Node Configuration
-NODE_ENV=development
+# Enable CORS. Default: true. Set to "false" to disable.
+CORS_ENABLED=true
 
-# Default model used when a task enters `doing` without metadata.model.
-# Can be an alias (gpt, gpt-codex, sonnet, opus) or provider/model.
-# DEFAULT_MODEL=gpt-codex
+# ─── Directories ─────────────────────────────────────────────────────────────
+
+# Root directory for reflectt config and data. Default: ~/.reflectt
+REFLECTT_HOME=~/.reflectt
+
+# Override data directory. Default: $REFLECTT_HOME/data
+# REFLECTT_DATA_DIR=~/.reflectt/data
+
+# ─── AI / LLM ────────────────────────────────────────────────────────────────
+
+# Default model for agent tasks. Uses OpenClaw model routing if not set.
+# Example: "anthropic/claude-sonnet-4-5" or "openai/gpt-4o"
+# DEFAULT_MODEL=
+
+# API keys (if not managed by OpenClaw)
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+
+# ─── OpenClaw integration ────────────────────────────────────────────────────
+
+# Gateway URL for OpenClaw message routing (WebSocket endpoint).
+# Typically auto-configured by OpenClaw. Override for custom gateway setups.
+# OPENCLAW_GATEWAY_URL=ws://localhost:18789
+
+# Gateway auth token. Run: openclaw config get gateway.auth.token
+# OPENCLAW_GATEWAY_TOKEN=
+
+# Agent identity as registered with OpenClaw.
+# OPENCLAW_AGENT_ID=
+
+# ─── Cloud / hosted ──────────────────────────────────────────────────────────
+
+# Reflectt cloud URL. Only needed if connecting to a hosted cloud instance.
+# REFLECTT_CLOUD_URL=https://app.reflectt.ai
+
+# Host token for cloud node registration (from app.reflectt.ai).
+# REFLECTT_HOST_TOKEN=
+
+# ─── GitHub integration ──────────────────────────────────────────────────────
+
+# Token for GitHub API calls (PR status, webhook attribution).
+# REFLECTT_GITHUB_APPROVAL_TOKEN=
+
+# GitHub identity mode: "agent" | "user" | "app". Default: "agent"
+# REFLECTT_GITHUB_IDENTITY_MODE=agent
+
+# ─── Debug ───────────────────────────────────────────────────────────────────
+
+# Enable debug logging. Set to any truthy value.
+# REFLECTT_DEBUG=true
+
+# NODE_ENV: "production" (default) | "development"
+# In development mode, the server refuses to run on port 4445 (production port).
+NODE_ENV=production
+
+# ─── Advanced / ops tuning ───────────────────────────────────────────────────
+# The following are for advanced deployments. Defaults are fine for most setups.
+
+# Board health worker
+# BOARD_HEALTH_ENABLED=true
+# BOARD_HEALTH_INTERVAL_MS=60000
+# BOARD_HEALTH_STALE_DOING_MIN=240
+# BOARD_HEALTH_QUIET_START=23        # quiet hours start (hour, 24h)
+# BOARD_HEALTH_QUIET_END=8           # quiet hours end (hour, 24h)
+
+# Idle nudge (watchdog)
+# CADENCE_WATCHDOG_ENABLED=true
+# IDLE_NUDGE_ENABLED=true
+# IDLE_NUDGE_WARN_MIN=15
+# IDLE_NUDGE_COOLDOWN_MIN=30
+
+# Chat sync
+# REFLECTT_CHAT_SYNC_MS=5000
+# REFLECTT_CHAT_SYNC_MIN_INTERVAL_MS=2000
+# REFLECTT_CHAT_SYNC_MAX_BACKOFF_MS=30000

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -66,6 +66,13 @@ cd reflectt-node
 npm install && npm run build
 ```
 
+Copy `.env.example` to `.env` to configure the server (port, directories, API keys, OpenClaw integration). All variables have defaults — you only need to set what you want to change.
+
+```bash
+cp .env.example .env
+# Edit .env as needed, then:
+```
+
 ---
 
 ## Initialize and start


### PR DESCRIPTION
## What

The existing `.env.example` was minimal (5 lines from initial bootstrap). Source-mode users cloning the repo had no visibility into what env vars the server supports or what the defaults are.

## Changes

- `.env.example`: expanded from 5 lines to comprehensive reference covering:
  - Server (PORT, HOST, CORS_ENABLED)
  - Directories (REFLECTT_HOME, REFLECTT_DATA_DIR)  
  - AI/LLM (DEFAULT_MODEL, ANTHROPIC_API_KEY, OPENAI_API_KEY)
  - OpenClaw (OPENCLAW_GATEWAY_URL/TOKEN/AGENT_ID)
  - Cloud (REFLECTT_CLOUD_URL, REFLECTT_HOST_TOKEN)
  - GitHub (REFLECTT_GITHUB_APPROVAL_TOKEN, identity mode)
  - Debug (REFLECTT_DEBUG, NODE_ENV)
  - Advanced ops: board health, idle nudge, chat sync (commented, defaults fine)

- `docs/GETTING-STARTED.md`: from-source section now references `.env.example` with `cp .env.example .env`

## Task
task-1773097433904-s7ncc5fdv