### PR TITLE
fix(P1): startup grace period prevents mass-unassignment on restart

### DIFF
--- a/src/todoHoardingGuard.ts
+++ b/src/todoHoardingGuard.ts
@@ -24,6 +24,23 @@ export const TODO_CAP = 3
 /** Agent must be idle for this long (no doing tasks + no activity) before unassign */
 export const IDLE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes
 
+/**
+ * Startup grace period: skip auto-unassignment for this long after server start.
+ *
+ * Root cause of the "gateway restart clears assignees" bug:
+ * After a server/gateway restart, all agents are temporarily disconnected.
+ * The hoarding sweep uses task.updatedAt for idle detection — if tasks were
+ * last updated >30m ago, agents appear idle immediately on startup. The sweep
+ * then mass-unassigns their overflow todos before agents can reconnect.
+ *
+ * Fix: suppress Rule A (auto-unassign) during the grace period so agents have
+ * time to reconnect and resume work. Rule B (orphan tagging) still runs.
+ */
+export const STARTUP_GRACE_MS = 10 * 60 * 1000 // 10 minutes
+
+/** Timestamp when this module was first loaded (proxy for server start) */
+const moduleLoadedAt = Date.now()
+
 /** Priority ordering (lower index = higher priority, kept first) */
 const PRIORITY_ORDER = ['P0', 'P1', 'P2', 'P3']
 
@@ -78,10 +95,22 @@ function getAgentLastActivity(agent: string, allTasks: Task[]): number {
 /**
  * Run the hoarding sweep. Returns actions taken (or would be taken in dry-run).
  */
-export async function sweepTodoHoarding(opts: { dryRun?: boolean } = {}): Promise<HoardingSweepResult> {
-  const { dryRun = false } = opts
-  const now = Date.now()
+export async function sweepTodoHoarding(opts: {
+  dryRun?: boolean
+  /** @internal test-only: override Date.now() */
+  _nowOverride?: number
+  /** @internal test-only: override moduleLoadedAt */
+  _moduleLoadedAtOverride?: number
+} = {}): Promise<HoardingSweepResult> {
+  const { dryRun = false, _nowOverride, _moduleLoadedAtOverride } = opts
+  const now = _nowOverride ?? Date.now()
+  const effectiveModuleLoadedAt = _moduleLoadedAtOverride ?? moduleLoadedAt
   const allTasks = taskManager.listTasks() as Task[]
+
+  // Startup grace period: suppress auto-unassignment (Rule A) while agents reconnect.
+  // Rule B (orphan detection) is read-only and safe to run immediately.
+  const uptimeMs = now - effectiveModuleLoadedAt
+  const inGracePeriod = uptimeMs < STARTUP_GRACE_MS
 
   // Group by assignee
   const byAssignee = new Map<string, { todo: Task[]; doing: Task[] }>()
@@ -116,6 +145,8 @@ export async function sweepTodoHoarding(opts: { dryRun?: boolean } = {}): Promis
     }
 
     // Rule A: auto-unassign overflow
+    // Skip during startup grace period — agents may not have reconnected yet
+    if (inGracePeriod) continue
     // Skip agents actively doing work
     if (doing.length > 0) continue
     // Skip agents with todo at or below cap

--- a/tests/todo-hoarding-guard.test.ts
+++ b/tests/todo-hoarding-guard.test.ts
@@ -5,6 +5,7 @@ import {
   claimTask,
   TODO_CAP,
   IDLE_THRESHOLD_MS,
+  STARTUP_GRACE_MS,
 } from '../src/todoHoardingGuard.js'
 import { taskManager } from '../src/tasks.js'
 
@@ -124,6 +125,90 @@ describe('todoHoardingGuard', () => {
         t.assignee?.toLowerCase() === 'dryagent',
       )
       expect(tasks).toHaveLength(5)
+    })
+  })
+
+  describe('Startup grace period', () => {
+    it('suppresses auto-unassign during grace period even when agent appears idle', async () => {
+      const now = Date.now()
+      // Create 5 todos with old updatedAt (agent appears idle for >30m)
+      for (let i = 0; i < 5; i++) {
+        const task = await taskManager.createTask({
+          title: `Grace task ${i}`,
+          assignee: 'graceAgent',
+          status: 'todo',
+          priority: 'P2',
+          done_criteria: ['test'],
+          createdBy: 'test',
+        })
+        // Force old updatedAt via direct DB
+        const { getDb } = await import('../src/db.js')
+        const db = getDb()
+        db.prepare('UPDATE tasks SET updated_at = ? WHERE id = ?')
+          .run(now - IDLE_THRESHOLD_MS - 60_000, task.id)
+      }
+
+      // Simulate: server just started (moduleLoadedAt = now), so we're in grace period
+      const result = await sweepTodoHoarding({
+        _nowOverride: now,
+        _moduleLoadedAtOverride: now - 1000, // 1s uptime — well within grace
+      })
+
+      // Rule A should NOT fire during grace period
+      expect(result.unassigned).toHaveLength(0)
+    })
+
+    it('allows auto-unassign after grace period expires', async () => {
+      const now = Date.now()
+      for (let i = 0; i < 5; i++) {
+        const task = await taskManager.createTask({
+          title: `Post-grace task ${i}`,
+          assignee: 'postGraceAgent',
+          status: 'todo',
+          priority: 'P2',
+          done_criteria: ['test'],
+          createdBy: 'test',
+        })
+        const { getDb } = await import('../src/db.js')
+        const db = getDb()
+        db.prepare('UPDATE tasks SET updated_at = ? WHERE id = ?')
+          .run(now - IDLE_THRESHOLD_MS - 60_000, task.id)
+      }
+
+      // Simulate: server started long ago (moduleLoadedAt = 20m ago), grace expired
+      const result = await sweepTodoHoarding({
+        _nowOverride: now,
+        _moduleLoadedAtOverride: now - STARTUP_GRACE_MS - 60_000, // well past grace
+      })
+
+      // Rule A SHOULD fire now — 5 todos, 0 doing, idle, past grace
+      expect(result.unassigned.length).toBeGreaterThan(0)
+      expect(result.unassigned.length).toBe(5 - TODO_CAP) // unassign overflow
+    })
+
+    it('still detects orphans during grace period (Rule B is read-only)', async () => {
+      const now = Date.now()
+      const task = await taskManager.createTask({
+        title: 'Orphan during grace',
+        assignee: 'orphanAgent',
+        status: 'todo',
+        priority: 'P2',
+        done_criteria: ['test'],
+        createdBy: 'test',
+      })
+      const { getDb } = await import('../src/db.js')
+      const db = getDb()
+      db.prepare('UPDATE tasks SET updated_at = ? WHERE id = ?')
+        .run(now - IDLE_THRESHOLD_MS - 60_000, task.id)
+
+      const result = await sweepTodoHoarding({
+        _nowOverride: now,
+        _moduleLoadedAtOverride: now - 1000, // in grace period
+      })
+
+      // Rule B (orphan detection) should still fire
+      const orphans = result.orphaned.filter(o => o.assignee === 'orphanagent')
+      expect(orphans).toHaveLength(1)
     })
   })
 


### PR DESCRIPTION
## Problem

After a server/gateway restart, the todo hoarding guard would immediately mass-unassign tasks from agents. The guard uses `task.updatedAt` for idle detection — if tasks were last updated >30m ago, agents appear idle on startup. The sweep then unassigns overflow todos before agents can reconnect.

**Observed Mar 9**: every gateway restart re-orphaned todo tasks (assignee resets to unassigned). PM re-routed the same 10+ tasks multiple times. Agents got false idle alerts.

## Root Cause

`todoHoardingGuard.ts` Rule A auto-unassigns when:
- Agent has >3 todo tasks
- Agent has 0 doing tasks  
- Agent idle >30m (based on `task.updatedAt`)

After restart, all agents have 0 doing tasks and their `updatedAt` timestamps are stale → mass unassignment on first sweep (5s after startup).

## Fix

Added a **10-minute startup grace period** (`STARTUP_GRACE_MS`):
- Rule A (auto-unassign) is suppressed during the grace period
- Rule B (orphan detection, read-only) still runs immediately
- Test overrides (`_nowOverride`, `_moduleLoadedAtOverride`) allow deterministic testing

## Changed Files
- `src/todoHoardingGuard.ts` — grace period constant + check in sweep loop
- `tests/todo-hoarding-guard.test.ts` — 3 new tests for grace period behavior

## Task
task-1773101142350-kzeene6t9