### PR TITLE
fix: enrich startup broadcast with node name, version, timestamp + 60s dedup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -540,19 +540,44 @@ async function main() {
       const { getAgentRoles } = await import('./assignment.js')
       const { chatManager } = await import('./chat.js')
       const { presenceManager } = await import('./presence.js')
+      const { getDb } = await import('./db.js')
       const agents = getAgentRoles()
       if (agents.length > 0) {
-        // Seed presence so idle-nudge system has agents to evaluate
-        for (const agent of agents) {
-          presenceManager.updatePresence(agent.name, 'idle')
+        // 60-second dedup guard: skip if a broadcast was sent within the last 60s
+        const BROADCAST_DEDUP_WINDOW_MS = 60_000
+        const db = getDb()
+        const recentBroadcast = db.prepare(
+          "SELECT 1 FROM chat_messages WHERE sender = 'system' AND content LIKE '%Server restarted%' AND timestamp > ? LIMIT 1",
+        ).get(Date.now() - BROADCAST_DEDUP_WINDOW_MS)
+        if (recentBroadcast) {
+          console.log('🔔 Auto-wake: skipped (duplicate within 60s)')
+        } else {
+          // Seed presence so idle-nudge system has agents to evaluate
+          for (const agent of agents) {
+            presenceManager.updatePresence(agent.name, 'idle')
+          }
+
+          // Read node identity for the broadcast
+          const pkg = await import('../package.json', { assert: { type: 'json' } }).catch(() => ({ default: { version: 'unknown' } }))
+          const version = pkg.default.version
+          let nodeName = process.env.REFLECTT_HOST_NAME || 'unknown'
+          try {
+            const cfgPath = join(REFLECTT_HOME, 'config.json')
+            if (existsSync(cfgPath)) {
+              const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+              nodeName = cfg?.cloud?.hostName || nodeName
+            }
+          } catch { /* non-blocking */ }
+
+          const ts = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC'
+          const mentions = agents.map(a => `@${a.name}`).join(' ')
+          await chatManager.sendMessage({
+            from: 'system',
+            content: `${mentions} Server restarted. Resume your work.\n📍 ${nodeName} · v${version} · ${ts}`,
+            channel: 'general',
+          })
+          console.log(`🔔 Auto-wake: seeded presence + pinged ${agents.length} agents (${nodeName} v${version})`)
         }
-        const mentions = agents.map(a => `@${a.name}`).join(' ')
-        await chatManager.sendMessage({
-          from: 'system',
-          content: `${mentions} Server restarted. Resume your work.`,
-          channel: 'general',
-        })
-        console.log(`🔔 Auto-wake: seeded presence + pinged ${agents.length} agents`)
       }
     } catch (err) {
       console.warn(`⚠️  Auto-wake failed: ${(err as Error)?.message || err}`)


### PR DESCRIPTION
## Problem

Startup broadcast only sent `@agents Server restarted. Resume your work.` — no node identity, version, or timestamp. No dedup guard for rapid restart cycles.

## Fix

- Broadcast now includes node name (from cloud config), version (from package.json), and UTC timestamp
- 60-second dedup guard: checks `chat_messages` for recent 'Server restarted' message, skips if found
- Example: `@kai @link ... Server restarted. Resume your work.\n📍 Mac Daddy (spark) · v0.1.8 · 2026-03-10 04:38:12 UTC`

## Testing

- 1862 tests pass (0 failures)
- Route-docs contract: 429/429

Fixes: task-1773087653413-27ddqqwxz