### PR TITLE
Fix restart continuity for doing-task presence

### DIFF
--- a/process/TASK-ewolky1no.md
+++ b/process/TASK-ewolky1no.md
@@ -1,0 +1,25 @@
+# TASK ewolky1no — restart continuity fix
+
+Canonical QA artifact for task-1773092448539-ewolky1no.
+
+## Boundary
+- fixed: restart continuity / active-work presence hydration
+- fixed: routine presence updates wiping the active task pointer
+- not proven: DB-level deletion or auto-close of doing rows on restart
+
+## PR
+- PR #866 — https://github.com/reflectt/reflectt-node/pull/866
+- Commit: fac341c
+
+## Changed files
+- `src/presence.ts`
+- `src/server.ts`
+- `tests/presence-restart-continuity.test.ts`
+- `process/TASK-task-1773092448539-ewolky1no-restart-continuity-fix.md` (full writeup)
+
+## Verification
+- Passed: `npm test -- --run tests/presence-restart-continuity.test.ts tests/presence-seed.test.ts tests/presence-stale-state.test.ts`
+- Known unrelated baseline issue: `npm run build` still fails on external dependency/type setup (`@browserbasehq/stagehand`, `@fastify/multipart`).
+
+## Summary
+This task should be reviewed as a **restart continuity fix**. If someone still wants the stronger claim investigated, DB-level deletion / auto-close on restart should be separate follow-up work with its own reproducer and evidence trail.

--- a/process/TASK-task-1773092448539-ewolky1no-restart-continuity-fix.md
+++ b/process/TASK-task-1773092448539-ewolky1no-restart-continuity-fix.md
@@ -1,0 +1,67 @@
+# TASK task-1773092448539-ewolky1no — restart continuity fix
+
+## Scope boundary
+
+What this change proves and fixes:
+- **Validated:** restart continuity / resume-path failure for active work.
+- **Fixed:** presence hydration + routine presence updates could make an in-flight `doing` task lose its task pointer after restart or wake-up.
+- **Not proven:** DB-level deletion or auto-close of `doing` task rows on restart.
+
+This artifact should be read as a **restart continuity fix**, not as proof that restart deletes task rows.
+
+## Root cause
+
+Two continuity gaps were enough to create the observed "dropped work" symptom:
+
+1. **Cold start presence seeding only marked agents idle**
+   - `src/presence.ts` previously seeded from recent activity but did not restore the active `doing` task pointer from SQLite.
+   - After restart, an agent with a live `doing` row could come back as generic idle/empty presence until they posted again.
+
+2. **Routine presence updates could clobber the task pointer**
+   - `updatePresence(agent, 'working')` overwrote `task` with `undefined`.
+   - That meant normal wake/heartbeat/task-status updates could erase the active-task pointer even when the `doing` row still existed in SQLite.
+
+## Fix shipped
+
+### `src/presence.ts`
+- Exported `PresenceManager` so restart behavior can be tested directly.
+- Added task-aware startup hydration:
+  - latest local `doing` row per assignee is now seeded into presence as `status: working` + `task: <id>`.
+  - local active task rows no longer depend on TEAM-ROLES roster sync to survive restart.
+- Added task-aware lookup during presence updates:
+  - `task: string` sets the pointer explicitly.
+  - `task: null` clears it explicitly.
+  - omitted `task` preserves existing pointer and hydrates from the board when needed.
+- Added `clearAll()` test helper.
+
+### `src/server.ts`
+- Task lifecycle presence updates now pass explicit task intent:
+  - `doing` → `updatePresence(..., 'working', task.id)`
+  - `blocked` → `updatePresence(..., 'blocked', task.id)`
+  - `validating` → `updatePresence(..., 'reviewing', task.id)`
+  - `done` → `updatePresence(..., 'working', null)` to clear the pointer intentionally
+- `/presence/:agent` now accepts `task: null` as an explicit clear.
+
+## Evidence
+
+### Tests added
+- `tests/presence-restart-continuity.test.ts`
+  - hydrates a `doing` task from SQLite on cold start
+  - proves routine `updatePresence(..., 'working')` no longer wipes the task pointer
+  - proves explicit `null` still clears the pointer when work is actually finished
+
+### Tests run
+```bash
+npm test -- --run tests/presence-restart-continuity.test.ts tests/presence-seed.test.ts tests/presence-stale-state.test.ts
+```
+
+Result: **pass** (`8 passed`)
+
+### Notes
+- `npm run build` still fails on unrelated baseline dependency/type issues in this branch (`@browserbasehq/stagehand`, `@fastify/multipart` typing). Not caused by this fix.
+
+## Conclusion
+
+This closes the narrow failure mode where restart/wake behavior made active work look dropped or idle-unsafe.
+
+It does **not** establish that restart deletes `doing` rows from the DB. If that stronger claim still matters, it should stay open as separate follow-up work with its own reproducer and evidence trail.

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -60,7 +60,7 @@ interface DailyActivity {
   session_ends: number[]
 }
 
-class PresenceManager {
+export class PresenceManager {
   private presence = new Map<string, AgentPresence>()
   private activity = new Map<string, DailyActivity>() // agent -> today's activity
   private expiryCheckInterval?: NodeJS.Timeout
@@ -140,10 +140,47 @@ class PresenceManager {
     }
   }
 
+  private lookupTaskForStatus(agent: string, status: PresenceStatus): { id: string; activityAt: number } | null {
+    if (!agent) return null
+
+    const taskStatus = status === 'blocked'
+      ? 'blocked'
+      : status === 'reviewing'
+        ? 'validating'
+        : status === 'working'
+          ? 'doing'
+          : null
+
+    if (!taskStatus) return null
+
+    try {
+      const db = getDb()
+      const row = db.prepare(
+        `SELECT id, updated_at, created_at
+         FROM tasks
+         WHERE assignee = ? AND status = ?
+         ORDER BY COALESCE(updated_at, created_at, 0) DESC
+         LIMIT 1`
+      ).get(agent, taskStatus) as { id: string; updated_at?: number | null; created_at?: number | null } | undefined
+
+      if (!row?.id) return null
+      return {
+        id: row.id,
+        activityAt: Number(row.updated_at || row.created_at || Date.now()),
+      }
+    } catch {
+      return null
+    }
+  }
+
   /**
    * Seed presence from recent chat/task activity on startup.
    * Prevents the cold-start problem where heartbeat sends empty agents
    * to cloud, making the sidebar show "No agents online".
+   *
+   * Important: if an agent already has a doing task in SQLite, hydrate that
+   * task into presence immediately so restart does not make active work look
+   * dropped/idle before the agent posts again.
    */
   private seedPresenceFromRecentActivity(): void {
     try {
@@ -156,37 +193,72 @@ class PresenceManager {
         'SELECT DISTINCT "from" as agent FROM chat_messages WHERE timestamp > ? AND "from" NOT IN (\'system\', \'user\')'
       ).all(now - recentWindow) as Array<{ agent: string }>
 
-      // Agents with recent task updates (assignees of doing tasks)
-      const taskAgents = db.prepare(
-        'SELECT DISTINCT assignee as agent FROM tasks WHERE status = \'doing\' AND assignee IS NOT NULL AND assignee != \'\''
-      ).all() as Array<{ agent: string }>
+      // Latest doing task per assignee — source of truth for active work continuity.
+      const doingTaskRows = db.prepare(
+        `SELECT assignee as agent, id, updated_at, created_at
+         FROM tasks
+         WHERE status = 'doing' AND assignee IS NOT NULL AND assignee != ''
+         ORDER BY COALESCE(updated_at, created_at, 0) DESC`
+      ).all() as Array<{ agent: string; id: string; updated_at?: number | null; created_at?: number | null }>
 
       // Build set of known agents from TEAM-ROLES registry to prevent cross-node leakage
       const knownAgents = new Set(getAgentRoles().map(r => r.name.toLowerCase()))
 
-      const agents = new Set<string>()
-      for (const row of [...chatAgents, ...taskAgents]) {
+      const hasKnownAgent = (name: string): boolean => {
+        return knownAgents.size === 0 || knownAgents.has(name)
+      }
+
+      const taskSeedByAgent = new Map<string, { id: string; activityAt: number }>()
+      for (const row of doingTaskRows) {
         const name = (row.agent || '').toLowerCase().trim()
-        // Skip system/email senders, empty names, and agents not in registry
-        if (name && !name.startsWith('email:') && name !== 'system' && name !== 'user') {
-          // Only seed agents known to this node's TEAM-ROLES registry
-          if (knownAgents.size === 0 || knownAgents.has(name)) {
-            agents.add(name)
-          }
+        // Active task rows are already local node state. Keep the system/email
+        // guards, but do not require TEAM-ROLES membership here or restart
+        // continuity breaks for valid assignees before roster sync catches up.
+        if (!name || name.startsWith('email:') || name === 'system' || name === 'user') {
+          continue
         }
+        if (!taskSeedByAgent.has(name)) {
+          taskSeedByAgent.set(name, {
+            id: row.id,
+            activityAt: Number(row.updated_at || row.created_at || now),
+          })
+        }
+      }
+
+      const agents = new Set<string>()
+      for (const row of chatAgents) {
+        const name = (row.agent || '').toLowerCase().trim()
+        if (name && !name.startsWith('email:') && name !== 'system' && name !== 'user' && hasKnownAgent(name)) {
+          agents.add(name)
+        }
+      }
+      for (const agent of taskSeedByAgent.keys()) {
+        agents.add(agent)
       }
 
       let seeded = 0
       for (const agent of agents) {
-        if (!this.presence.has(agent)) {
+        if (this.presence.has(agent)) continue
+
+        const activeTask = taskSeedByAgent.get(agent)
+        if (activeTask) {
+          this.presence.set(agent, {
+            agent,
+            status: 'working',
+            task: activeTask.id,
+            since: activeTask.activityAt,
+            lastUpdate: activeTask.activityAt,
+            last_active: activeTask.activityAt,
+          })
+        } else {
           this.presence.set(agent, {
             agent,
             status: 'idle',
             since: now,
             lastUpdate: now,
           })
-          seeded++
         }
+        seeded++
       }
 
       if (seeded > 0) {
@@ -294,19 +366,35 @@ class PresenceManager {
   }
 
   /**
-   * Update agent presence
+   * Update agent presence.
+   *
+   * task semantics:
+   * - string => set explicit task pointer
+   * - null   => clear task pointer
+   * - undefined => preserve existing task pointer; if none exists and the new
+   *   status implies active work, hydrate from the current board row
    */
-  updatePresence(agent: string, status: PresenceStatus, task?: string, since?: number, updateActivity = true): AgentPresence {
+  updatePresence(agent: string, status: PresenceStatus, task?: string | null, since?: number, updateActivity = true): AgentPresence {
     const now = Date.now()
     const existing = this.presence.get(agent)
-    
+    const explicitTask = typeof task === 'string' ? task.trim() : task
+    const hydratedTask = explicitTask === undefined && !existing?.task
+      ? this.lookupTaskForStatus(agent, status)
+      : null
+
+    const resolvedTask = explicitTask === null
+      ? undefined
+      : explicitTask && explicitTask.length > 0
+        ? explicitTask
+        : existing?.task || hydratedTask?.id
+
     const presence: AgentPresence = {
       agent,
       status,
-      task,
-      since: since || now,
+      task: resolvedTask,
+      since: since || existing?.since || hydratedTask?.activityAt || now,
       lastUpdate: now,
-      last_active: existing?.last_active || now,
+      last_active: existing?.last_active || hydratedTask?.activityAt || now,
     }
 
     this.presence.set(agent, presence)
@@ -527,6 +615,11 @@ class PresenceManager {
     }
     
     return activities.sort((a, b) => b.last_active - a.last_active)
+  }
+
+  clearAll(): void {
+    this.presence.clear()
+    this.activity.clear()
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -7691,14 +7691,14 @@ export async function createServer(): Promise<FastifyInstance> {
       if (task.assignee) {
         if (parsed.status === 'done') {
           presenceManager.recordActivity(task.assignee, 'task_completed')
-          presenceManager.updatePresence(task.assignee, 'working')
+          presenceManager.updatePresence(task.assignee, 'working', null)
           trackTaskEvent('completed')
         } else if (parsed.status === 'doing') {
-          presenceManager.updatePresence(task.assignee, 'working')
+          presenceManager.updatePresence(task.assignee, 'working', task.id)
         } else if (parsed.status === 'blocked') {
-          presenceManager.updatePresence(task.assignee, 'blocked')
+          presenceManager.updatePresence(task.assignee, 'blocked', task.id)
         } else if (parsed.status === 'validating') {
-          presenceManager.updatePresence(task.assignee, 'reviewing')
+          presenceManager.updatePresence(task.assignee, 'reviewing', task.id)
         }
       }
 
@@ -11101,7 +11101,7 @@ If your heartbeat shows **no active task** and **no next task**:
   // Update agent presence
   app.post<{ Params: { agent: string } }>('/presence/:agent', async (request) => {
     try {
-      const body = request.body as { status: PresenceStatus; task?: string; since?: number }
+      const body = request.body as { status: PresenceStatus; task?: string | null; since?: number }
       
       if (!body.status) {
         return { success: false, error: 'status is required' }

--- a/tests/presence-restart-continuity.test.ts
+++ b/tests/presence-restart-continuity.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getDb } from '../src/db.js'
+import { PresenceManager } from '../src/presence.js'
+
+const db = getDb()
+
+describe('Presence restart continuity', () => {
+  let manager: PresenceManager | null = null
+
+  beforeEach(() => {
+    db.prepare("DELETE FROM tasks WHERE assignee IN ('link', 'sage', 'pixel')").run()
+  })
+
+  afterEach(() => {
+    manager?.destroy()
+    manager = null
+    db.prepare("DELETE FROM tasks WHERE assignee IN ('link', 'sage', 'pixel')").run()
+  })
+
+  it('hydrates doing-task continuity from SQLite on cold start', () => {
+    const now = Date.now()
+    db.prepare(
+      `INSERT INTO tasks (id, title, status, assignee, reviewer, done_criteria, created_at, updated_at, priority, created_by, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'task-restart-continuity',
+      'Restart continuity task',
+      'doing',
+      'link',
+      'reviewer',
+      JSON.stringify(['survives restart']),
+      now - 60_000,
+      now - 30_000,
+      'P2',
+      'test',
+      JSON.stringify({ eta: '30m' }),
+    )
+
+    manager = new PresenceManager()
+    const presence = manager.getPresence('link')
+
+    expect(presence).toBeTruthy()
+    expect(presence?.status).toBe('working')
+    expect(presence?.task).toBe('task-restart-continuity')
+  })
+
+  it('does not let routine wake/update calls wipe an active doing-task pointer', () => {
+    const now = Date.now()
+    db.prepare(
+      `INSERT INTO tasks (id, title, status, assignee, reviewer, done_criteria, created_at, updated_at, priority, created_by, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'task-wake-continuity',
+      'Wake continuity task',
+      'doing',
+      'sage',
+      'reviewer',
+      JSON.stringify(['pointer survives auto-wake']),
+      now - 60_000,
+      now - 30_000,
+      'P2',
+      'test',
+      JSON.stringify({ eta: '30m' }),
+    )
+
+    manager = new PresenceManager()
+    manager.clearAll()
+
+    const presence = manager.updatePresence('sage', 'working')
+
+    expect(presence.task).toBe('task-wake-continuity')
+    expect(manager.getPresence('sage')?.task).toBe('task-wake-continuity')
+  })
+
+  it('allows explicit task clearing when active work is actually done', () => {
+    manager = new PresenceManager()
+    manager.updatePresence('pixel', 'working', 'task-finished')
+
+    const cleared = manager.updatePresence('pixel', 'working', null)
+
+    expect(cleared.task).toBeUndefined()
+    expect(manager.getPresence('pixel')?.task).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- hydrate local doing-task presence from SQLite on cold start
- preserve the active task pointer on routine presence updates unless explicitly cleared
- pass explicit task intent through task lifecycle presence updates and cover the restart path with tests

## Why
This fixes the narrow continuity failure where restart/wake behavior could make active work look dropped or idle-unsafe.

## Scope boundary
- Fixed: restart continuity / presence-task hydration for active work
- Fixed: routine presence updates clobbering the task pointer
- Not proven here: DB-level deletion or auto-close of doing-task rows on restart

## Evidence
- Added `tests/presence-restart-continuity.test.ts`
- Ran:
  - `npm test -- --run tests/presence-restart-continuity.test.ts tests/presence-seed.test.ts tests/presence-stale-state.test.ts`
- Artifact: `process/TASK-task-1773092448539-ewolky1no-restart-continuity-fix.md`

## Notes
- `npm run build` still fails on unrelated baseline dependency/type issues in this branch (`@browserbasehq/stagehand`, `@fastify/multipart` typing).
