### PR TITLE
feat: boot context in heartbeat — memories + active run

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -197,7 +197,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | DELETE | `/tasks/:id` | Delete task |
 | GET | `/tasks/next` | Pull-based assignment. Query: `agent`, `compact`, `claim=1` (auto-transitions todo→doing on pull) |
 | GET | `/tasks/active` | Get active (doing) task for agent. Query: `agent`, `compact`. Returns null if no doing tasks. |
-| GET | `/heartbeat/:agent` | Single compact heartbeat payload (~200 tokens). Returns active task, next task, slim inbox, queue counts, and suggested action. Replaces 3 separate API calls. |
+| GET | `/heartbeat/:agent` | Single compact heartbeat payload (~200 tokens). Returns active task, next task, slim inbox, queue counts, suggested action, boot context (recent memories top 5, active agent_run). Replaces 3+ separate API calls. |
 | GET | `/bootstrap/heartbeat/:agent` | Generate optimal HEARTBEAT.md content for agent. References best endpoints. Includes version stamp and content hash for change detection. |
 | POST | `/bootstrap/team` | Returns TEAM-ROLES.yaml schema, constraints, well-formed examples, and save endpoint. The calling agent composes the team itself. Body: `{ useCase?, maxAgents? }`. Returns `{ schema, constraints, examples[], saveEndpoint, nextSteps[] }`. |
 | GET | `/manage/status` | Remote management: unified status (version + health + uptime). Auth: `x-manage-token` header or `Authorization: Bearer`. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -10433,6 +10433,25 @@ export async function createServer(): Promise<FastifyInstance> {
 
     const focusSummary = getFocusSummary()
 
+    // Boot context: recent memories + active run (survives restart)
+    let bootMemories: Array<{ key: string; content: string; namespace: string; updatedAt: number }> = []
+    let activeRun: { id: string; objective: string; status: string; startedAt: number } | null = null
+    try {
+      const { listMemories } = await import('./agent-memories.js')
+      const memories = listMemories({ agentId: agent, limit: 5 })
+      bootMemories = memories.map(m => ({
+        key: m.key, content: m.content.slice(0, 200),
+        namespace: m.namespace, updatedAt: m.updatedAt,
+      }))
+    } catch { /* agent-memories not available */ }
+    try {
+      const { getActiveAgentRun } = await import('./agent-runs.js')
+      const run = getActiveAgentRun(agent, 'default')
+      if (run) {
+        activeRun = { id: run.id, objective: run.objective, status: run.status, startedAt: run.startedAt }
+      }
+    } catch { /* agent-runs not available */ }
+
     return {
       agent, ts: Date.now(),
       active: slim(activeTask), next: pauseStatus.paused ? null : slim(nextTask),
@@ -10442,6 +10461,8 @@ export async function createServer(): Promise<FastifyInstance> {
       ...(focusSummary ? { focus: focusSummary } : {}),
       ...(agentDrops ? { drops: { total: agentDrops.total, rolling_1h: agentDrops.rolling_1h } } : {}),
       ...(pauseStatus.paused ? { paused: true, pauseMessage: pauseStatus.message, resumesAt: pauseStatus.entry?.pausedUntil ?? null } : {}),
+      ...(bootMemories.length > 0 ? { memories: bootMemories } : {}),
+      ...(activeRun ? { run: activeRun } : {}),
       action: pauseStatus.paused ? `PAUSED: ${pauseStatus.message}`
         : activeTask ? `Continue ${activeTask.id}`
         : nextTask ? `Claim ${nextTask.id}`


### PR DESCRIPTION
## What

Adds boot context to `GET /heartbeat/:agent` so agents wake up with context injected.

### New fields in heartbeat response
- `memories`: top 5 recent memories (key, content preview ≤200 chars, namespace, updatedAt)
- `run`: active agent_run if one exists (id, objective, status, startedAt)

### Why
Agents currently rely on reading files (MEMORY.md, etc.) to get context on startup. This injects the same context from SQLite — survives restarts, no file-read ritual.

### Done criteria
- ✅ GET /heartbeat/:agent includes agent memories (top 5 by recency)
- ✅ GET /heartbeat/:agent includes active run if one exists
- ✅ Agent wakes up with context injected
- ✅ Boot context survives node restart (SQLite-backed)

### Changes
- `src/server.ts`: 21 lines added to heartbeat handler (lazy imports, try/catch)
- `public/docs.md`: updated heartbeat description
- Route-docs contract: 450/450
- 1878 tests passing, 0 failures

Task: task-1773257650005-rran0uh39