### PR TITLE
feat: validate structured rationale in agent events

### DIFF
--- a/src/agent-runs.test.ts
+++ b/src/agent-runs.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import Database from 'better-sqlite3'
+import { validateRationale } from './agent-runs.js'
 
 // Inline DB setup — avoids importing db.ts which reads config
 function createTestDb(): Database.Database {
@@ -129,6 +130,27 @@ describe('agent_runs schema', () => {
   })
 })
 
+describe('agent_events rationale validation', () => {
+  it('accepts structured rationale', () => {
+    const parsed = validateRationale({
+      choice: 'approved PR #826',
+      considered: ['CSS-only, no logic changes', 'CI green'],
+      constraint: 'manual merge within scope',
+    })
+    assert.equal(parsed.choice, 'approved PR #826')
+    assert.equal(parsed.considered?.length, 2)
+    assert.equal(parsed.constraint, 'manual merge within scope')
+  })
+
+  it('rejects rationale without choice', () => {
+    assert.throws(() => validateRationale({ considered: ['missing choice'] }), /rationale\.choice is required/)
+  })
+
+  it('rejects non-string considered entries', () => {
+    assert.throws(() => validateRationale({ choice: 'x', considered: ['ok', 42] }), /rationale\.considered must be an array of non-empty strings/)
+  })
+})
+
 describe('agent_events schema (append-only)', () => {
   let db: Database.Database
 
@@ -220,6 +242,11 @@ describe('agent_events schema (append-only)', () => {
       task_id: 'task-123',
       decision: 'approved',
       next_action: 'merge and deploy',
+      rationale: {
+        choice: 'approved PR #826',
+        considered: ['CSS-only, no logic changes', 'CI green'],
+        constraint: 'manual merge within scope'
+      }
     })
     const now = Date.now()
     db.prepare(`INSERT INTO agent_events (id, run_id, agent_id, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)`).run('aevt-1', 'arun-1', 'link', 'handed_off', payload, now)
@@ -255,14 +282,14 @@ describe('PR review handoff workflow (release gate)', () => {
 
     // 3. Review requested
     db.prepare(`INSERT INTO agent_events (id, run_id, agent_id, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)`)
-      .run('aevt-4', 'arun-pr', 'link', 'review_requested', JSON.stringify({ pr_url: 'https://github.com/reflectt/reflectt-node/pull/830', target_agent: 'sage' }), now + 300)
+      .run('aevt-4', 'arun-pr', 'link', 'review_requested', JSON.stringify({ pr_url: 'https://github.com/reflectt/reflectt-node/pull/830', target_agent: 'sage', rationale: { choice: 'request review from sage', considered: ['schema touches persistence', 'needs second set of eyes'], constraint: 'review required before merge' } }), now + 300)
 
     // Update run to waiting_review
     db.prepare('UPDATE agent_runs SET status = ?, updated_at = ? WHERE id = ?').run('waiting_review', now + 300, 'arun-pr')
 
     // 4. Review approved (by second agent)
     db.prepare(`INSERT INTO agent_events (id, run_id, agent_id, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)`)
-      .run('aevt-5', 'arun-pr', 'sage', 'review_approved', JSON.stringify({ pr_url: 'https://github.com/reflectt/reflectt-node/pull/830', reviewer: 'sage', comment: 'LGTM' }), now + 500)
+      .run('aevt-5', 'arun-pr', 'sage', 'review_approved', JSON.stringify({ pr_url: 'https://github.com/reflectt/reflectt-node/pull/830', reviewer: 'sage', comment: 'LGTM', rationale: { choice: 'approve PR #830', considered: ['tests pass', 'schema is minimal'], constraint: 'within current sprint scope' } }), now + 500)
 
     // 5. Handoff + completion
     db.prepare(`INSERT INTO agent_events (id, run_id, agent_id, event_type, payload, created_at) VALUES (?, ?, ?, ?, ?, ?)`)

--- a/src/agent-runs.ts
+++ b/src/agent-runs.ts
@@ -58,6 +58,12 @@ export interface AgentRun {
   completedAt: number | null
 }
 
+export interface EventRationale {
+  choice: string
+  considered?: string[]
+  constraint?: string
+}
+
 export interface AgentEvent {
   id: string
   runId: string | null
@@ -126,6 +132,33 @@ function rowToEvent(row: EventRow): AgentEvent {
     eventType: row.event_type as AgentEventType,
     payload: safeJsonParse<Record<string, unknown>>(row.payload) ?? {},
     createdAt: row.created_at,
+  }
+}
+
+function isDecisionEventType(eventType: string): boolean {
+  return ['review_requested', 'review_approved', 'review_rejected', 'handed_off'].includes(eventType)
+}
+
+export function validateRationale(rationale: unknown): EventRationale {
+  if (!rationale || typeof rationale !== 'object' || Array.isArray(rationale)) {
+    throw new Error('rationale must be an object with choice, considered[], constraint')
+  }
+  const r = rationale as Record<string, unknown>
+  if (typeof r.choice !== 'string' || r.choice.trim().length === 0) {
+    throw new Error('rationale.choice is required')
+  }
+  if (r.considered !== undefined) {
+    if (!Array.isArray(r.considered) || !r.considered.every(v => typeof v === 'string' && v.trim().length > 0)) {
+      throw new Error('rationale.considered must be an array of non-empty strings')
+    }
+  }
+  if (r.constraint !== undefined && typeof r.constraint !== 'string') {
+    throw new Error('rationale.constraint must be a string')
+  }
+  return {
+    choice: r.choice.trim(),
+    ...(r.considered ? { considered: (r.considered as string[]).map(v => v.trim()) } : {}),
+    ...(typeof r.constraint === 'string' ? { constraint: r.constraint.trim() } : {}),
   }
 }
 
@@ -328,7 +361,16 @@ export function appendAgentEvent(event: {
   const db = getDb()
   const id = generateEventId()
   const now = Date.now()
-  const payload = event.payload ?? {}
+  const payload = { ...(event.payload ?? {}) }
+
+  if (isDecisionEventType(event.eventType)) {
+    if (payload.rationale === undefined) {
+      throw new Error(`rationale is required for ${event.eventType}`)
+    }
+    payload.rationale = validateRationale(payload.rationale)
+  } else if (payload.rationale !== undefined) {
+    payload.rationale = validateRationale(payload.rationale)
+  }
 
   // Enforce routing semantics for actionable events
   const enforce = event.enforceRouting !== false
@@ -590,6 +632,7 @@ export function submitApprovalDecision(opts: {
   decision: 'approve' | 'reject'
   reviewer: string
   comment?: string
+  rationale?: EventRationale
 }): { event: AgentEvent; runUnblocked: boolean } {
   const db = getDb()
 
@@ -611,6 +654,7 @@ export function submitApprovalDecision(opts: {
       original_event_id: opts.eventId,
       reviewer: opts.reviewer,
       ...(opts.comment ? { comment: opts.comment } : {}),
+      rationale: opts.rationale,
     },
   })
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13917,7 +13917,11 @@ If your heartbeat shows **no active task** and **no next task**:
         return reply.code(422).send({ error: err.message, hint: 'Actionable events require: action_required (string), urgency (low|normal|high|critical), owner (string). Optional: expires_at (number).' })
       }
       return reply.code(500).send({ error: err.message })
-    }
+      const message = String(err?.message || err)
+      if (message.includes('rationale')) {
+        return reply.code(400).send({ error: message })
+      }
+      return reply.code(500).send({ error: message })    }
   })
 
   // List agent events
@@ -14279,7 +14283,12 @@ If your heartbeat shows **no active task** and **no next task**:
   // Submit approval decision
   app.post<{ Params: { eventId: string } }>('/approvals/:eventId/decide', async (request, reply) => {
     const { eventId } = request.params
-    const body = request.body as { decision?: string; reviewer?: string; comment?: string }
+    const body = request.body as {
+      decision?: string
+      reviewer?: string
+      comment?: string
+      rationale?: { choice?: string; considered?: string[]; constraint?: string }
+    }
     if (!body?.decision || !['approve', 'reject'].includes(body.decision)) {
       return reply.code(400).send({ error: 'decision must be "approve" or "reject"' })
     }
@@ -14292,6 +14301,7 @@ If your heartbeat shows **no active task** and **no next task**:
         decision: body.decision as 'approve' | 'reject',
         reviewer: body.reviewer,
         comment: body.comment,
+        rationale: body.rationale as any,
       })
       return result
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- require structured rationale for decision-bearing agent events (`review_requested`, `review_approved`, `review_rejected`, `handed_off`)
- validate rationale shape on event writes and approval decisions
- cover the rationale contract in `agent-runs` tests and thread it through a real review flow

## Why
This lands `task-1773257642802-qpk0q7xdx` by making decision logs trustworthy instead of opaque activity blobs.

## Validation
- `./node_modules/.bin/tsx --test src/agent-runs.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false`
