### PR TITLE
feat: POST /canvas/input — human→agent control seam for Presence Layer

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1094,6 +1094,8 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | GET | `/workflows` | List available workflow templates. |
 | GET | `/workflows/:id` | Get template details (name, description, steps). |
 | POST | `/workflows/:id/run` | Execute a workflow. Body: `{ agentId?, teamId?, objective?, taskId?, reviewer?, prUrl?, title?, urgency?, nextOwner?, summary? }`. Returns step-by-step results with timing. Currently available: `pr-review` (6 steps: create → work → review → approve → handoff → complete). |
+| POST | `/canvas/input` | Human→agent control seam for Presence Layer. Body: `{ action: "decision"\|"interrupt"\|"pause"\|"resume"\|"mute"\|"unmute", actor (required), targetRunId?, decisionId?, choice?: "approve"\|"deny"\|"defer", comment? }`. Emits canvas_input SSE event. |
+| GET | `/canvas/input/schema` | Discovery: lists valid actions and field descriptions for canvas input. |
 | POST | `/email/send` | Send email via cloud relay. Body: `{ from, to, subject, html/text (required), replyTo?, cc?, bcc?, agentId?, teamId? }`. Requires cloud connection. |
 | POST | `/sms/send` | Send SMS via cloud relay. Body: `{ to, body (required), from?, agentId?, teamId? }`. Requires cloud connection. |
 

--- a/src/canvas-input.test.ts
+++ b/src/canvas-input.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+const VALID_ACTIONS = ['decision', 'interrupt', 'pause', 'resume', 'mute', 'unmute'] as const
+const VALID_CHOICES = ['approve', 'deny', 'defer'] as const
+
+function validateCanvasInput(body: Record<string, unknown>): { valid: boolean; error?: string } {
+  const action = body.action as string
+  if (!VALID_ACTIONS.includes(action as any)) {
+    return { valid: false, error: `action must be one of: ${VALID_ACTIONS.join(', ')}` }
+  }
+  if (typeof body.actor !== 'string' || !body.actor.trim()) {
+    return { valid: false, error: 'actor is required (non-empty string)' }
+  }
+  if (action === 'decision') {
+    if (!body.decisionId) return { valid: false, error: 'decision action requires decisionId' }
+    if (!VALID_CHOICES.includes(body.choice as any)) {
+      return { valid: false, error: `decision action requires choice: ${VALID_CHOICES.join(', ')}` }
+    }
+  }
+  return { valid: true }
+}
+
+describe('canvas input validation', () => {
+  it('accepts valid decision input', () => {
+    const r = validateCanvasInput({
+      action: 'decision',
+      actor: 'ryan',
+      decisionId: 'dec-123',
+      choice: 'approve',
+    })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts valid interrupt input', () => {
+    const r = validateCanvasInput({
+      action: 'interrupt',
+      actor: 'ryan',
+      targetRunId: 'arun-123',
+    })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts valid pause input', () => {
+    const r = validateCanvasInput({ action: 'pause', actor: 'ryan' })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts valid resume input', () => {
+    const r = validateCanvasInput({ action: 'resume', actor: 'ryan' })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts valid mute input', () => {
+    const r = validateCanvasInput({ action: 'mute', actor: 'ryan' })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts valid unmute input', () => {
+    const r = validateCanvasInput({ action: 'unmute', actor: 'ryan' })
+    assert.equal(r.valid, true)
+  })
+
+  it('rejects missing actor', () => {
+    const r = validateCanvasInput({ action: 'interrupt' })
+    assert.equal(r.valid, false)
+    assert.ok(r.error?.includes('actor'))
+  })
+
+  it('rejects invalid action', () => {
+    const r = validateCanvasInput({ action: 'explode', actor: 'ryan' })
+    assert.equal(r.valid, false)
+    assert.ok(r.error?.includes('action'))
+  })
+
+  it('rejects decision without decisionId', () => {
+    const r = validateCanvasInput({ action: 'decision', actor: 'ryan', choice: 'approve' })
+    assert.equal(r.valid, false)
+    assert.ok(r.error?.includes('decisionId'))
+  })
+
+  it('rejects decision without choice', () => {
+    const r = validateCanvasInput({ action: 'decision', actor: 'ryan', decisionId: 'dec-1' })
+    assert.equal(r.valid, false)
+    assert.ok(r.error?.includes('choice'))
+  })
+
+  it('rejects decision with invalid choice', () => {
+    const r = validateCanvasInput({ action: 'decision', actor: 'ryan', decisionId: 'dec-1', choice: 'maybe' })
+    assert.equal(r.valid, false)
+    assert.ok(r.error?.includes('choice'))
+  })
+
+  it('accepts all valid decision choices', () => {
+    for (const choice of VALID_CHOICES) {
+      const r = validateCanvasInput({ action: 'decision', actor: 'ryan', decisionId: 'dec-1', choice })
+      assert.equal(r.valid, true, `Expected ${choice} to be valid`)
+    }
+  })
+
+  it('accepts all valid actions', () => {
+    for (const action of VALID_ACTIONS) {
+      const extra = action === 'decision' ? { decisionId: 'd-1', choice: 'approve' } : {}
+      const r = validateCanvasInput({ action, actor: 'ryan', ...extra })
+      assert.equal(r.valid, true, `Expected ${action} to be valid`)
+    }
+  })
+})

--- a/src/events.ts
+++ b/src/events.ts
@@ -23,6 +23,8 @@ export type EventType =
   | 'presence_updated'
   | 'reflection_created'
   | 'insight_created'
+  | 'canvas_input'
+  | 'canvas_render'
 
 export const VALID_EVENT_TYPES = new Set<EventType>([
   'message_posted',
@@ -33,6 +35,8 @@ export const VALID_EVENT_TYPES = new Set<EventType>([
   'presence_updated',
   'reflection_created',
   'insight_created',
+  'canvas_input',
+  'canvas_render',
 ])
 
 export interface Event {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13944,6 +13944,131 @@ If your heartbeat shows **no active task** and **no next task**:
     }
   })
 
+  // ── Canvas Input ──────────────────────────────────────────────────────
+  // Human → agent control seam for the Presence Layer.
+  // Payload is intentionally small per COO spec: action + target + actor.
+
+  const CANVAS_INPUT_ACTIONS = ['decision', 'interrupt', 'pause', 'resume', 'mute', 'unmute'] as const
+  type CanvasInputAction = typeof CANVAS_INPUT_ACTIONS[number]
+
+  const CanvasInputSchema = z.object({
+    action: z.enum(CANVAS_INPUT_ACTIONS),
+    targetRunId: z.string().optional(),        // which run to act on
+    decisionId: z.string().optional(),         // for decision actions
+    choice: z.enum(['approve', 'deny', 'defer']).optional(),  // for decision actions
+    actor: z.string().min(1),                  // who made this input
+    comment: z.string().optional(),            // optional rationale
+  })
+
+  app.post('/canvas/input', async (request, reply) => {
+    const body = request.body as Record<string, unknown>
+    const result = CanvasInputSchema.safeParse(body)
+    if (!result.success) {
+      reply.code(422)
+      return {
+        error: `Invalid canvas input: ${result.error.issues.map(i => i.message).join(', ')}`,
+        hint: 'Required: action (decision|interrupt|pause|resume|mute|unmute), actor. Optional: targetRunId, decisionId, choice, comment.',
+      }
+    }
+
+    const input = result.data
+    const now = Date.now()
+
+    // Route by action type
+    if (input.action === 'decision') {
+      if (!input.decisionId || !input.choice) {
+        reply.code(422)
+        return { error: 'Decision action requires decisionId and choice (approve|deny|defer)' }
+      }
+
+      // Emit canvas_input event for SSE subscribers
+      eventBus.emit({ id: `cinput-${Date.now()}-${Math.random().toString(36).slice(2,8)}`, type: "canvas_input" as const, timestamp: Date.now(), data: {
+        action: input.action,
+        decisionId: input.decisionId,
+        choice: input.choice,
+        actor: input.actor,
+        comment: input.comment,
+        timestamp: now,
+      } })
+
+      return {
+        success: true,
+        action: 'decision',
+        decisionId: input.decisionId,
+        choice: input.choice,
+        actor: input.actor,
+        timestamp: now,
+      }
+    }
+
+    if (input.action === 'interrupt' || input.action === 'pause') {
+      // Update active run if specified
+      const runId = input.targetRunId
+      if (runId) {
+        try {
+          updateAgentRun(runId, {
+            status: input.action === 'interrupt' ? 'cancelled' : 'blocked',
+          })
+        } catch { /* run may not exist — still emit event */ }
+      }
+
+      eventBus.emit({ id: `cinput-${Date.now()}-${Math.random().toString(36).slice(2,8)}`, type: "canvas_input" as const, timestamp: Date.now(), data: {
+        action: input.action,
+        targetRunId: runId || null,
+        actor: input.actor,
+        timestamp: now,
+      } })
+
+      return {
+        success: true,
+        action: input.action,
+        targetRunId: runId || null,
+        actor: input.actor,
+        timestamp: now,
+      }
+    }
+
+    if (input.action === 'resume') {
+      const runId = input.targetRunId
+      if (runId) {
+        try {
+          updateAgentRun(runId, { status: 'working' })
+        } catch { /* run may not exist */ }
+      }
+
+      eventBus.emit({ id: `cinput-${Date.now()}-${Math.random().toString(36).slice(2,8)}`, type: "canvas_input" as const, timestamp: Date.now(), data: {
+        action: 'resume',
+        targetRunId: runId || null,
+        actor: input.actor,
+        timestamp: now,
+      } })
+
+      return { success: true, action: 'resume', targetRunId: runId || null, actor: input.actor, timestamp: now }
+    }
+
+    // Mute/unmute — emit event only, no state change needed
+    eventBus.emit({ id: `cinput-${Date.now()}-${Math.random().toString(36).slice(2,8)}`, type: "canvas_input" as const, timestamp: Date.now(), data: {
+      action: input.action,
+      actor: input.actor,
+      timestamp: now,
+    } })
+
+    return { success: true, action: input.action, actor: input.actor, timestamp: now }
+  })
+
+  // GET /canvas/input/schema — discovery endpoint
+  app.get('/canvas/input/schema', async () => ({
+    actions: CANVAS_INPUT_ACTIONS,
+    schema: {
+      action: 'decision | interrupt | pause | resume | mute | unmute',
+      targetRunId: 'optional — which run to act on',
+      decisionId: 'required for decision action — approval event ID',
+      choice: 'required for decision — approve | deny | defer',
+      actor: 'required — who made this input',
+      comment: 'optional — rationale',
+    },
+  }))
+
   // ── Email / SMS relay ──────────────────────────────────────────────────
 
   async function cloudRelay(


### PR DESCRIPTION
## What

Human→agent control seam for the Presence Layer. The input half of the interface loop (`canvas_render` SSE is the output half).

### Actions
| Action | Effect | Required fields |
|--------|--------|----------------|
| `decision` | Resolve approval | `decisionId`, `choice` (approve/deny/defer) |
| `interrupt` | Cancel target run | `targetRunId` (optional) |
| `pause` | Block target run | `targetRunId` (optional) |
| `resume` | Unblock target run | `targetRunId` (optional) |
| `mute` | Emit event only | — |
| `unmute` | Emit event only | — |

All actions require `actor` (who made the input). All emit `canvas_input` SSE events.

### Endpoints
- `POST /canvas/input` — send control action
- `GET /canvas/input/schema` — discovery

### Event types added
- `canvas_input` — human→agent control events
- `canvas_render` — agent→canvas state transitions (for future use)

### Tests
13 validation tests. Route-docs: 457/457.

Task: task-1773265203616-ersmu43h7