### PR TITLE
feat: canvas_render SSE — agent→surface state transitions for Presence Layer

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1096,6 +1096,9 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | POST | `/workflows/:id/run` | Execute a workflow. Body: `{ agentId?, teamId?, objective?, taskId?, reviewer?, prUrl?, title?, urgency?, nextOwner?, summary? }`. Returns step-by-step results with timing. Currently available: `pr-review` (6 steps: create → work → review → approve → handoff → complete). |
 | POST | `/canvas/input` | Human→agent control seam for Presence Layer. Body: `{ action: "decision"\|"interrupt"\|"pause"\|"resume"\|"mute"\|"unmute", actor (required), targetRunId?, decisionId?, choice?: "approve"\|"deny"\|"defer", comment? }`. Emits canvas_input SSE event. |
 | GET | `/canvas/input/schema` | Discovery: lists valid actions and field descriptions for canvas input. |
+| POST | `/canvas/state` | Agent emits Presence Layer state transition. Body: `{ state: "floor"\|"listening"\|"thinking"\|"rendering"\|"ambient"\|"decision"\|"urgent"\|"handoff", sensors: null\|"mic"\|"camera"\|"mic+camera", agentId (required), payload?: { text?, media?, decision?: { question, decisionId, expiresAt?, autoAction? }, agents?: [{ name, state, task? }], summary?: { headline, items?, cost?, duration? } } }`. Emits canvas_render SSE event. |
+| GET | `/canvas/state` | Current Presence Layer state for agents. Params: `agentId?` (single agent) or all agents. |
+| GET | `/canvas/states` | Discovery: valid states, sensors, and payload schema. |
 | POST | `/email/send` | Send email via cloud relay. Body: `{ from, to, subject, html/text (required), replyTo?, cc?, bcc?, agentId?, teamId? }`. Requires cloud connection. |
 | POST | `/sms/send` | Send SMS via cloud relay. Body: `{ to, body (required), from?, agentId?, teamId? }`. Requires cloud connection. |
 

--- a/src/canvas-render.test.ts
+++ b/src/canvas-render.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+const CANVAS_STATES = ['floor', 'listening', 'thinking', 'rendering', 'ambient', 'decision', 'urgent', 'handoff'] as const
+const SENSOR_VALUES = [null, 'mic', 'camera', 'mic+camera'] as const
+
+function validateCanvasRender(body: Record<string, unknown>): { valid: boolean; error?: string } {
+  if (!CANVAS_STATES.includes(body.state as any)) {
+    return { valid: false, error: `state must be one of: ${CANVAS_STATES.join(', ')}` }
+  }
+  if (body.sensors !== undefined && body.sensors !== null && !['mic', 'camera', 'mic+camera'].includes(body.sensors as string)) {
+    return { valid: false, error: 'sensors must be null, mic, camera, or mic+camera' }
+  }
+  if (typeof body.agentId !== 'string' || !body.agentId) {
+    return { valid: false, error: 'agentId is required' }
+  }
+  // Validate decision payload if state is decision
+  if (body.state === 'decision' && body.payload) {
+    const p = body.payload as any
+    if (p.decision && (!p.decision.question || !p.decision.decisionId)) {
+      return { valid: false, error: 'decision payload requires question and decisionId' }
+    }
+  }
+  return { valid: true }
+}
+
+describe('canvas render state validation', () => {
+  it('accepts all 8 valid states', () => {
+    for (const state of CANVAS_STATES) {
+      const r = validateCanvasRender({ state, agentId: 'link', sensors: null })
+      assert.equal(r.valid, true, `${state} should be valid`)
+    }
+  })
+
+  it('rejects invalid state', () => {
+    const r = validateCanvasRender({ state: 'exploding', agentId: 'link' })
+    assert.equal(r.valid, false)
+  })
+
+  it('accepts all valid sensor values', () => {
+    for (const s of SENSOR_VALUES) {
+      const r = validateCanvasRender({ state: 'floor', agentId: 'link', sensors: s })
+      assert.equal(r.valid, true, `sensor ${s} should be valid`)
+    }
+  })
+
+  it('rejects invalid sensor', () => {
+    const r = validateCanvasRender({ state: 'floor', agentId: 'link', sensors: 'lidar' })
+    assert.equal(r.valid, false)
+  })
+
+  it('requires agentId', () => {
+    const r = validateCanvasRender({ state: 'floor' })
+    assert.equal(r.valid, false)
+    assert.ok(r.error?.includes('agentId'))
+  })
+
+  it('accepts floor with empty payload', () => {
+    const r = validateCanvasRender({ state: 'floor', agentId: 'link', sensors: null, payload: {} })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts thinking with text payload', () => {
+    const r = validateCanvasRender({ state: 'thinking', agentId: 'link', sensors: null, payload: { text: 'Working on PR...' } })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts decision with full decision payload', () => {
+    const r = validateCanvasRender({
+      state: 'decision', agentId: 'link', sensors: null,
+      payload: { decision: { question: 'Deploy?', decisionId: 'dec-1', expiresAt: Date.now() + 60000, autoAction: 'defer' } },
+    })
+    assert.equal(r.valid, true)
+  })
+
+  it('rejects decision payload missing question', () => {
+    const r = validateCanvasRender({
+      state: 'decision', agentId: 'link', sensors: null,
+      payload: { decision: { decisionId: 'dec-1' } },
+    })
+    assert.equal(r.valid, false)
+  })
+
+  it('accepts handoff with summary payload', () => {
+    const r = validateCanvasRender({
+      state: 'handoff', agentId: 'link', sensors: null,
+      payload: { summary: { headline: 'Session complete', items: ['3 PRs merged'], cost: '$0.42', duration: '2h' } },
+    })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts ambient with agents list', () => {
+    const r = validateCanvasRender({
+      state: 'ambient', agentId: 'link', sensors: null,
+      payload: { agents: [{ name: 'link', state: 'idle' }, { name: 'pixel', state: 'working', task: 'UX flow' }] },
+    })
+    assert.equal(r.valid, true)
+  })
+
+  it('accepts urgent with mic sensor', () => {
+    const r = validateCanvasRender({
+      state: 'urgent', agentId: 'link', sensors: 'mic',
+      payload: { text: 'Server down!' },
+    })
+    assert.equal(r.valid, true)
+  })
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -8691,6 +8691,100 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
+  // ── Presence Layer canvas state ─────────────────────────────────────
+  // Agent emits canvas_render state transitions for the Presence Layer.
+  // Deterministic event types. No "AI can emit anything" protocol.
+
+  const CANVAS_STATES = ['floor', 'listening', 'thinking', 'rendering', 'ambient', 'decision', 'urgent', 'handoff'] as const
+  type CanvasState = typeof CANVAS_STATES[number]
+  const SENSOR_VALUES = [null, 'mic', 'camera', 'mic+camera'] as const
+
+  const CanvasRenderSchema = z.object({
+    state: z.enum(CANVAS_STATES),
+    sensors: z.enum(['mic', 'camera', 'mic+camera']).nullable().default(null),
+    agentId: z.string().min(1),
+    payload: z.object({
+      text: z.string().optional(),
+      media: z.unknown().optional(),
+      decision: z.object({
+        question: z.string(),
+        context: z.string().optional(),
+        decisionId: z.string(),
+        expiresAt: z.number().optional(),
+        autoAction: z.string().optional(),
+      }).optional(),
+      agents: z.array(z.object({
+        name: z.string(),
+        state: z.string(),
+        task: z.string().optional(),
+      })).optional(),
+      summary: z.object({
+        headline: z.string(),
+        items: z.array(z.string()).optional(),
+        cost: z.string().optional(),
+        duration: z.string().optional(),
+      }).optional(),
+    }).default({}),
+  })
+
+  // Current state per agent — in-memory, not persisted
+  const canvasStateMap = new Map<string, { state: CanvasState; sensors: string | null; payload: unknown; updatedAt: number }>()
+
+  // POST /canvas/state — agent emits a state transition
+  app.post('/canvas/state', async (request, reply) => {
+    const result = CanvasRenderSchema.safeParse(request.body)
+    if (!result.success) {
+      reply.code(422)
+      return {
+        error: `Invalid canvas state: ${result.error.issues.map(i => i.message).join(', ')}`,
+        hint: `state must be one of: ${CANVAS_STATES.join(', ')}`,
+        validStates: CANVAS_STATES,
+      }
+    }
+
+    const { state, sensors, agentId, payload } = result.data
+    const now = Date.now()
+
+    // Store current state
+    canvasStateMap.set(agentId, { state, sensors, payload, updatedAt: now })
+
+    // Emit canvas_render event over SSE
+    eventBus.emit({
+      id: `crender-${now}-${Math.random().toString(36).slice(2, 8)}`,
+      type: 'canvas_render' as const,
+      timestamp: now,
+      data: { state, sensors, agentId, payload },
+    })
+
+    return { success: true, state, agentId, timestamp: now }
+  })
+
+  // GET /canvas/state — current state for all agents (or one)
+  app.get('/canvas/state', async (request) => {
+    const query = request.query as { agentId?: string }
+    if (query.agentId) {
+      const entry = canvasStateMap.get(query.agentId)
+      return entry ?? { state: 'floor', sensors: null, payload: {}, updatedAt: null }
+    }
+    const all: Record<string, unknown> = {}
+    for (const [id, entry] of canvasStateMap) {
+      all[id] = entry
+    }
+    return { agents: all, count: canvasStateMap.size }
+  })
+
+  // GET /canvas/states — valid state + sensor values (discovery)
+  app.get('/canvas/states', async () => ({
+    states: CANVAS_STATES,
+    sensors: SENSOR_VALUES,
+    schema: {
+      state: 'floor | listening | thinking | rendering | ambient | decision | urgent | handoff',
+      sensors: 'null | mic | camera | mic+camera (non-dismissable trust indicator)',
+      agentId: 'required — which agent is driving the canvas',
+      payload: 'optional — text, media, decision, agents, summary',
+    },
+  }))
+
   // GET /canvas/slots — current active slots
   app.get('/canvas/slots', async () => {
     return {


### PR DESCRIPTION
## What
Output half of the Presence Layer control loop. Agents emit state transitions, canvas surfaces receive them via SSE.

### The complete loop
| Direction | Endpoint | PR |
|-----------|----------|----|
| Human → Agent | `POST /canvas/input` | #879 |
| Agent → Surface | `POST /canvas/state` | **this PR** |

### 8 deterministic states
floor, listening, thinking, rendering, ambient, decision, urgent, handoff

### Trust indicator (non-dismissable)
`sensors: null | 'mic' | 'camera' | 'mic+camera'`

### Endpoints
- `POST /canvas/state` — agent emits state transition + payload
- `GET /canvas/state` — current state per agent (or all)
- `GET /canvas/states` — discovery endpoint

### Fallback
If stream drops, `GET /canvas/state` provides current state. No stale UI.

12 tests. Route-docs: 458/458.

Task: task-1773265209542-yfzu9sqoq