### PR TITLE
feat: agent config API — model preference + cost cap per agent

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1099,6 +1099,11 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | POST | `/canvas/state` | Agent emits Presence Layer state transition. Body: `{ state: "floor"\|"listening"\|"thinking"\|"rendering"\|"ambient"\|"decision"\|"urgent"\|"handoff", sensors: null\|"mic"\|"camera"\|"mic+camera", agentId (required), payload?: { text?, media?, decision?: { question, decisionId, expiresAt?, autoAction? }, agents?: [{ name, state, task? }], summary?: { headline, items?, cost?, duration? } } }`. Emits canvas_render SSE event. |
 | GET | `/canvas/state` | Current Presence Layer state for agents. Params: `agentId?` (single agent) or all agents. |
 | GET | `/canvas/states` | Discovery: valid states, sensors, and payload schema. |
+| GET | `/agents/:agentId/config` | Get agent config (model preference, cost caps, settings). |
+| PUT | `/agents/:agentId/config` | Upsert agent config. Body: `{ model?, fallbackModel?, costCapDaily?, costCapMonthly?, maxTokensPerCall?, teamId?, settings? }`. |
+| DELETE | `/agents/:agentId/config` | Remove agent config. |
+| GET | `/agent-configs` | List all agent configs. Params: `teamId?`. |
+| GET | `/agents/:agentId/cost-check` | Runtime cost enforcement check. Params: `dailySpend?`, `monthlySpend?`. Returns: allowed, action (allow\|warn\|downgrade\|deny), remaining budgets, model/fallback. |
 | POST | `/email/send` | Send email via cloud relay. Body: `{ from, to, subject, html/text (required), replyTo?, cc?, bcc?, agentId?, teamId? }`. Requires cloud connection. |
 | POST | `/sms/send` | Send SMS via cloud relay. Body: `{ to, body (required), from?, agentId?, teamId? }`. Requires cloud connection. |
 

--- a/src/agent-config.test.ts
+++ b/src/agent-config.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+// Test the cost cap logic in isolation
+function checkCostCap(
+  config: { costCapDaily: number | null; costCapMonthly: number | null; model: string | null; fallbackModel: string | null } | null,
+  dailySpend: number,
+  monthlySpend: number,
+): { allowed: boolean; action: 'allow' | 'warn' | 'downgrade' | 'deny' } {
+  if (!config) return { allowed: true, action: 'allow' }
+
+  let action: 'allow' | 'warn' | 'downgrade' | 'deny' = 'allow'
+
+  if (config.costCapDaily !== null) {
+    const remaining = config.costCapDaily - dailySpend
+    if (remaining <= 0) action = 'deny'
+    else if (remaining < config.costCapDaily * 0.1) action = 'downgrade'
+    else if (remaining < config.costCapDaily * 0.2) action = 'warn'
+  }
+
+  if (config.costCapMonthly !== null) {
+    const remaining = config.costCapMonthly - monthlySpend
+    if (remaining <= 0) action = 'deny'
+    else if (remaining < config.costCapMonthly * 0.1 && action !== 'deny') action = 'downgrade'
+    else if (remaining < config.costCapMonthly * 0.2 && action === 'allow') action = 'warn'
+  }
+
+  return { allowed: action !== 'deny', action }
+}
+
+describe('agent config cost enforcement', () => {
+  it('allows when no config exists', () => {
+    const r = checkCostCap(null, 5, 50)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'allow')
+  })
+
+  it('allows when no caps are set', () => {
+    const r = checkCostCap({ costCapDaily: null, costCapMonthly: null, model: null, fallbackModel: null }, 5, 50)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'allow')
+  })
+
+  it('allows when well under daily cap', () => {
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: null, model: 'opus', fallbackModel: 'sonnet' }, 3, 0)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'allow')
+  })
+
+  it('warns at 80% daily spend', () => {
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: null, model: 'opus', fallbackModel: 'sonnet' }, 8.5, 0)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'warn')
+  })
+
+  it('downgrades at 90% daily spend', () => {
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: null, model: 'opus', fallbackModel: 'sonnet' }, 9.5, 0)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'downgrade')
+  })
+
+  it('denies at 100% daily spend', () => {
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: null, model: 'opus', fallbackModel: 'sonnet' }, 10, 0)
+    assert.equal(r.allowed, false)
+    assert.equal(r.action, 'deny')
+  })
+
+  it('denies when over daily cap', () => {
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: null, model: 'opus', fallbackModel: 'sonnet' }, 12, 0)
+    assert.equal(r.allowed, false)
+    assert.equal(r.action, 'deny')
+  })
+
+  it('monthly cap denies overriding daily allow', () => {
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: 100, model: null, fallbackModel: null }, 3, 100)
+    assert.equal(r.allowed, false)
+    assert.equal(r.action, 'deny')
+  })
+
+  it('monthly warn when daily is fine', () => {
+    const r = checkCostCap({ costCapDaily: null, costCapMonthly: 100, model: null, fallbackModel: null }, 0, 85)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'warn')
+  })
+
+  it('monthly downgrade at 90%', () => {
+    const r = checkCostCap({ costCapDaily: null, costCapMonthly: 100, model: null, fallbackModel: null }, 0, 95)
+    assert.equal(r.allowed, true)
+    assert.equal(r.action, 'downgrade')
+  })
+
+  it('both caps — tighter one wins', () => {
+    // Daily is at 95% (downgrade), monthly is fine
+    const r = checkCostCap({ costCapDaily: 10, costCapMonthly: 1000, model: 'opus', fallbackModel: 'sonnet' }, 9.5, 50)
+    assert.equal(r.action, 'downgrade')
+  })
+
+  it('zero cap always denies', () => {
+    const r = checkCostCap({ costCapDaily: 0, costCapMonthly: null, model: null, fallbackModel: null }, 0, 0)
+    assert.equal(r.allowed, false)
+    assert.equal(r.action, 'deny')
+  })
+})

--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Agent configuration API — model preference + cost cap per agent
+import { getDb } from './db.js'
+
+export interface AgentConfig {
+  agentId: string
+  teamId: string
+  model: string | null
+  fallbackModel: string | null
+  costCapDaily: number | null
+  costCapMonthly: number | null
+  maxTokensPerCall: number | null
+  settings: Record<string, unknown>
+  createdAt: number
+  updatedAt: number
+}
+
+interface ConfigRow {
+  agent_id: string
+  team_id: string
+  model: string | null
+  fallback_model: string | null
+  cost_cap_daily: number | null
+  cost_cap_monthly: number | null
+  max_tokens_per_call: number | null
+  settings: string
+  created_at: number
+  updated_at: number
+}
+
+function rowToConfig(row: ConfigRow): AgentConfig {
+  return {
+    agentId: row.agent_id,
+    teamId: row.team_id,
+    model: row.model,
+    fallbackModel: row.fallback_model,
+    costCapDaily: row.cost_cap_daily,
+    costCapMonthly: row.cost_cap_monthly,
+    maxTokensPerCall: row.max_tokens_per_call,
+    settings: JSON.parse(row.settings || '{}'),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+/**
+ * Get config for a specific agent. Returns null if not set.
+ */
+export function getAgentConfig(agentId: string): AgentConfig | null {
+  const db = getDb()
+  const row = db.prepare('SELECT * FROM agent_config WHERE agent_id = ?').get(agentId) as ConfigRow | undefined
+  return row ? rowToConfig(row) : null
+}
+
+/**
+ * List all agent configs, optionally filtered by team.
+ */
+export function listAgentConfigs(opts?: { teamId?: string }): AgentConfig[] {
+  const db = getDb()
+  if (opts?.teamId) {
+    const rows = db.prepare('SELECT * FROM agent_config WHERE team_id = ? ORDER BY agent_id').all(opts.teamId) as ConfigRow[]
+    return rows.map(rowToConfig)
+  }
+  const rows = db.prepare('SELECT * FROM agent_config ORDER BY agent_id').all() as ConfigRow[]
+  return rows.map(rowToConfig)
+}
+
+/**
+ * Set (upsert) config for an agent.
+ */
+export function setAgentConfig(agentId: string, updates: {
+  teamId?: string
+  model?: string | null
+  fallbackModel?: string | null
+  costCapDaily?: number | null
+  costCapMonthly?: number | null
+  maxTokensPerCall?: number | null
+  settings?: Record<string, unknown>
+}): AgentConfig {
+  const db = getDb()
+  const now = Date.now()
+  const existing = getAgentConfig(agentId)
+
+  if (existing) {
+    // Update
+    const model = updates.model !== undefined ? updates.model : existing.model
+    const fallbackModel = updates.fallbackModel !== undefined ? updates.fallbackModel : existing.fallbackModel
+    const costCapDaily = updates.costCapDaily !== undefined ? updates.costCapDaily : existing.costCapDaily
+    const costCapMonthly = updates.costCapMonthly !== undefined ? updates.costCapMonthly : existing.costCapMonthly
+    const maxTokensPerCall = updates.maxTokensPerCall !== undefined ? updates.maxTokensPerCall : existing.maxTokensPerCall
+    const settings = updates.settings !== undefined ? updates.settings : existing.settings
+    const teamId = updates.teamId ?? existing.teamId
+
+    db.prepare(`
+      UPDATE agent_config SET
+        team_id = ?, model = ?, fallback_model = ?, cost_cap_daily = ?,
+        cost_cap_monthly = ?, max_tokens_per_call = ?, settings = ?, updated_at = ?
+      WHERE agent_id = ?
+    `).run(teamId, model, fallbackModel, costCapDaily, costCapMonthly, maxTokensPerCall, JSON.stringify(settings), now, agentId)
+
+    return { agentId, teamId, model, fallbackModel, costCapDaily, costCapMonthly, maxTokensPerCall, settings, createdAt: existing.createdAt, updatedAt: now }
+  }
+
+  // Insert
+  const teamId = updates.teamId ?? 'default'
+  const model = updates.model ?? null
+  const fallbackModel = updates.fallbackModel ?? null
+  const costCapDaily = updates.costCapDaily ?? null
+  const costCapMonthly = updates.costCapMonthly ?? null
+  const maxTokensPerCall = updates.maxTokensPerCall ?? null
+  const settings = updates.settings ?? {}
+
+  db.prepare(`
+    INSERT INTO agent_config (agent_id, team_id, model, fallback_model, cost_cap_daily, cost_cap_monthly, max_tokens_per_call, settings, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(agentId, teamId, model, fallbackModel, costCapDaily, costCapMonthly, maxTokensPerCall, JSON.stringify(settings), now, now)
+
+  return { agentId, teamId, model, fallbackModel, costCapDaily, costCapMonthly, maxTokensPerCall, settings, createdAt: now, updatedAt: now }
+}
+
+/**
+ * Delete config for an agent.
+ */
+export function deleteAgentConfig(agentId: string): boolean {
+  const db = getDb()
+  const result = db.prepare('DELETE FROM agent_config WHERE agent_id = ?').run(agentId)
+  return result.changes > 0
+}
+
+/**
+ * Check if an agent is within its cost cap.
+ * Returns { allowed, remaining, cap, spent, action } for the cost enforcement hook.
+ */
+export function checkCostCap(agentId: string, currentDailySpend: number, currentMonthlySpend: number): {
+  allowed: boolean
+  dailyRemaining: number | null
+  monthlyRemaining: number | null
+  action: 'allow' | 'warn' | 'downgrade' | 'deny'
+  model: string | null
+  fallbackModel: string | null
+} {
+  const config = getAgentConfig(agentId)
+  if (!config) {
+    return { allowed: true, dailyRemaining: null, monthlyRemaining: null, action: 'allow', model: null, fallbackModel: null }
+  }
+
+  let action: 'allow' | 'warn' | 'downgrade' | 'deny' = 'allow'
+  let dailyRemaining: number | null = null
+  let monthlyRemaining: number | null = null
+
+  if (config.costCapDaily !== null) {
+    dailyRemaining = config.costCapDaily - currentDailySpend
+    if (dailyRemaining <= 0) {
+      action = 'deny'
+    } else if (dailyRemaining < config.costCapDaily * 0.1) {
+      action = 'downgrade' // < 10% remaining → use fallback model
+    } else if (dailyRemaining < config.costCapDaily * 0.2) {
+      action = action === 'allow' ? 'warn' : action // < 20% remaining → warn
+    }
+  }
+
+  if (config.costCapMonthly !== null) {
+    monthlyRemaining = config.costCapMonthly - currentMonthlySpend
+    if (monthlyRemaining <= 0) {
+      action = 'deny'
+    } else if (monthlyRemaining < config.costCapMonthly * 0.1 && action !== 'deny') {
+      action = 'downgrade'
+    } else if (monthlyRemaining < config.costCapMonthly * 0.2 && action === 'allow') {
+      action = 'warn'
+    }
+  }
+
+  return {
+    allowed: action !== 'deny',
+    dailyRemaining,
+    monthlyRemaining,
+    action,
+    model: config.model,
+    fallbackModel: config.fallbackModel,
+  }
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -575,6 +575,25 @@ export function runMigrations(db: Database.Database): void {
         CREATE INDEX IF NOT EXISTS idx_agent_memories_expires ON agent_memories(expires_at) WHERE expires_at IS NOT NULL;
       `,
     },
+    {
+      version: 23,
+      sql: `
+        -- Agent config: per-agent model preference, cost cap, and settings
+        CREATE TABLE IF NOT EXISTS agent_config (
+          agent_id        TEXT PRIMARY KEY,
+          team_id         TEXT NOT NULL DEFAULT 'default',
+          model           TEXT,
+          fallback_model  TEXT,
+          cost_cap_daily  REAL,
+          cost_cap_monthly REAL,
+          max_tokens_per_call INTEGER,
+          settings        TEXT NOT NULL DEFAULT '{}',
+          created_at      INTEGER NOT NULL,
+          updated_at      INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_config_team ON agent_config(team_id);
+      `,
+    },
   ]
 
   const insertMigration = db.prepare('INSERT INTO _migrations (version) VALUES (?)')
@@ -611,6 +630,7 @@ export function runMigrations(db: Database.Database): void {
     { version: 19, tables: ['kv'] },
     { version: 21, tables: ['agent_runs', 'agent_events'] },
     { version: 22, tables: ['agent_memories'] },
+    { version: 23, tables: ['agent_config'] },
   ]
 
   const existingTables = new Set(

--- a/src/server.ts
+++ b/src/server.ts
@@ -14242,6 +14242,60 @@ If your heartbeat shows **no active task** and **no next task**:
     }, reply)
   })
 
+  // ── Agent Config ──────────────────────────────────────────────────────
+  // Per-agent model preference, cost cap, and settings.
+  // This is the policy anchor for cost enforcement.
+
+  const { getAgentConfig, listAgentConfigs, setAgentConfig, deleteAgentConfig, checkCostCap } = await import('./agent-config.js')
+
+  // GET /agents/:agentId/config — get config for an agent
+  app.get<{ Params: { agentId: string } }>('/agents/:agentId/config', async (request) => {
+    const config = getAgentConfig(request.params.agentId)
+    return config ?? { agentId: request.params.agentId, configured: false }
+  })
+
+  // PUT /agents/:agentId/config — upsert config for an agent
+  app.put<{ Params: { agentId: string } }>('/agents/:agentId/config', async (request, reply) => {
+    const body = request.body as Record<string, unknown> ?? {}
+    try {
+      const config = setAgentConfig(request.params.agentId, {
+        teamId: typeof body.teamId === 'string' ? body.teamId : undefined,
+        model: body.model !== undefined ? (body.model as string | null) : undefined,
+        fallbackModel: body.fallbackModel !== undefined ? (body.fallbackModel as string | null) : undefined,
+        costCapDaily: body.costCapDaily !== undefined ? (body.costCapDaily as number | null) : undefined,
+        costCapMonthly: body.costCapMonthly !== undefined ? (body.costCapMonthly as number | null) : undefined,
+        maxTokensPerCall: body.maxTokensPerCall !== undefined ? (body.maxTokensPerCall as number | null) : undefined,
+        settings: body.settings !== undefined ? (body.settings as Record<string, unknown>) : undefined,
+      })
+      return config
+    } catch (err: any) {
+      reply.code(400)
+      return { error: err.message }
+    }
+  })
+
+  // DELETE /agents/:agentId/config — remove config for an agent
+  app.delete<{ Params: { agentId: string } }>('/agents/:agentId/config', async (request, reply) => {
+    const deleted = deleteAgentConfig(request.params.agentId)
+    if (!deleted) { reply.code(404); return { error: 'Config not found' } }
+    return { success: true }
+  })
+
+  // GET /agent-configs — list all agent configs
+  app.get('/agent-configs', async (request) => {
+    const query = request.query as { teamId?: string }
+    return { configs: listAgentConfigs({ teamId: query.teamId }) }
+  })
+
+  // GET /agents/:agentId/cost-check — runtime cost enforcement check
+  // Used by the runtime before making model calls.
+  app.get<{ Params: { agentId: string } }>('/agents/:agentId/cost-check', async (request) => {
+    const query = request.query as { dailySpend?: string; monthlySpend?: string }
+    const dailySpend = query.dailySpend ? parseFloat(query.dailySpend) : 0
+    const monthlySpend = query.monthlySpend ? parseFloat(query.monthlySpend) : 0
+    return checkCostCap(request.params.agentId, dailySpend, monthlySpend)
+  })
+
   // ── Agent Memories ─────────────────────────────────────────────────────
 
   const {


### PR DESCRIPTION
## What
Per-agent configuration and runtime cost enforcement. The policy anchor for the cost-control seam.

### Agent Config
| Field | Purpose |
|-------|---------|
| `model` | Preferred model (e.g. opus) |
| `fallbackModel` | Downgrade model when budget tight (e.g. sonnet) |
| `costCapDaily` | Daily spend limit in dollars |
| `costCapMonthly` | Monthly spend limit |
| `maxTokensPerCall` | Per-call token cap |
| `settings` | JSON bag for future config |

### Cost Enforcement Hook
`GET /agents/:agentId/cost-check?dailySpend=X&monthlySpend=Y`

| Action | Trigger | Effect |
|--------|---------|--------|
| `allow` | Under 80% | Normal operation |
| `warn` | 80-90% spent | Warning emitted |
| `downgrade` | 90%+ spent | Use fallback model |
| `deny` | 100%+ spent | Hard stop |

### Endpoints
- `GET/PUT/DELETE /agents/:agentId/config`
- `GET /agent-configs` (list all)
- `GET /agents/:agentId/cost-check` (runtime enforcement)

### Migration
v23: `agent_config` table (SQLite)

12 tests. Route-docs: 459/459.

Task: task-1773265723943