### PR TITLE
feat: run retention/archive policy — cleanup old completed runs

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1111,6 +1111,8 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | GET | `/agents/:agentId/messages/sent` | Sent messages. Params: `limit?`. |
 | POST | `/agents/:agentId/messages/read` | Mark messages as read. Body: `{ messageIds?: string[] }` (omit for mark all). |
 | GET | `/messages/channel/:channel` | List messages in a channel. Params: `since?`, `limit?`. |
+| GET | `/runs/retention/stats` | Preview retention: total runs, terminal runs, how many would be archived. Params: `maxAgeDays?`, `maxCompletedRuns?`. |
+| POST | `/runs/retention/apply` | Apply retention policy. Body: `{ maxAgeDays? (default 30), maxCompletedRuns? (default 100), deleteArchived? (default false), agentId?, dryRun? }`. Returns: archived, deleted, eventsDeleted counts. |
 | POST | `/email/send` | Send email via cloud relay. Body: `{ from, to, subject, html/text (required), replyTo?, cc?, bcc?, agentId?, teamId? }`. Requires cloud connection. |
 | POST | `/sms/send` | Send SMS via cloud relay. Body: `{ to, body (required), from?, agentId?, teamId? }`. Requires cloud connection. |
 

--- a/src/agent-runs.ts
+++ b/src/agent-runs.ts
@@ -394,6 +394,135 @@ export function listAgentEvents(opts: {
   return rows.map(rowToEvent)
 }
 
+// ── Run retention / archive ─────────────────────────────────────────────────
+
+export interface RetentionPolicy {
+  maxAgeDays: number          // Archive runs older than this
+  maxCompletedRuns: number    // Keep at most this many completed runs per agent
+  deleteArchived: boolean     // Actually delete archived runs (vs just marking)
+}
+
+const DEFAULT_RETENTION: RetentionPolicy = {
+  maxAgeDays: 30,
+  maxCompletedRuns: 100,
+  deleteArchived: false,
+}
+
+export interface RetentionResult {
+  archived: number
+  deleted: number
+  eventsDeleted: number
+  dryRun: boolean
+}
+
+/**
+ * Archive old completed/cancelled/failed runs per retention policy.
+ * Returns count of runs archived and events cleaned up.
+ */
+export function applyRunRetention(opts?: {
+  policy?: Partial<RetentionPolicy>
+  agentId?: string
+  dryRun?: boolean
+}): RetentionResult {
+  const db = getDb()
+  const policy = { ...DEFAULT_RETENTION, ...opts?.policy }
+  const dryRun = opts?.dryRun ?? false
+  const now = Date.now()
+  const cutoffMs = now - policy.maxAgeDays * 24 * 60 * 60 * 1000
+  const terminalStatuses = ['completed', 'failed', 'cancelled']
+
+  // Find runs to archive: terminal status + older than cutoff
+  let sql = `
+    SELECT id, agent_id FROM agent_runs 
+    WHERE status IN (${terminalStatuses.map(() => '?').join(',')})
+    AND started_at < ?
+  `
+  const params: unknown[] = [...terminalStatuses, cutoffMs]
+
+  if (opts?.agentId) {
+    sql += ' AND agent_id = ?'
+    params.push(opts.agentId)
+  }
+  sql += ' ORDER BY started_at ASC'
+
+  const rows = db.prepare(sql).all(...params) as Array<{ id: string; agent_id: string }>
+
+  if (dryRun) {
+    return { archived: rows.length, deleted: 0, eventsDeleted: 0, dryRun: true }
+  }
+
+  let archived = 0
+  let deleted = 0
+  let eventsDeleted = 0
+
+  for (const row of rows) {
+    if (policy.deleteArchived) {
+      // Delete events first (foreign key-like cleanup)
+      const evtResult = db.prepare('DELETE FROM agent_events WHERE run_id = ?').run(row.id)
+      eventsDeleted += evtResult.changes
+      // Delete the run
+      db.prepare('DELETE FROM agent_runs WHERE id = ?').run(row.id)
+      deleted++
+    } else {
+      // Mark as archived (update status)
+      db.prepare("UPDATE agent_runs SET status = 'completed', updated_at = ? WHERE id = ?").run(now, row.id)
+      archived++
+    }
+  }
+
+  // Enforce max completed runs per agent — keep newest, archive/delete oldest
+  const agentIds = opts?.agentId
+    ? [opts.agentId]
+    : (db.prepare('SELECT DISTINCT agent_id FROM agent_runs').all() as Array<{ agent_id: string }>).map(r => r.agent_id)
+
+  for (const agentId of agentIds) {
+    const completedRuns = db.prepare(`
+      SELECT id FROM agent_runs 
+      WHERE agent_id = ? AND status IN (${terminalStatuses.map(() => '?').join(',')})
+      ORDER BY started_at DESC
+    `).all(agentId, ...terminalStatuses) as Array<{ id: string }>
+
+    if (completedRuns.length > policy.maxCompletedRuns) {
+      const toRemove = completedRuns.slice(policy.maxCompletedRuns)
+      for (const run of toRemove) {
+        if (policy.deleteArchived) {
+          const evtResult = db.prepare('DELETE FROM agent_events WHERE run_id = ?').run(run.id)
+          eventsDeleted += evtResult.changes
+          db.prepare('DELETE FROM agent_runs WHERE id = ?').run(run.id)
+          deleted++
+        } else {
+          archived++
+        }
+      }
+    }
+  }
+
+  return { archived, deleted, eventsDeleted, dryRun: false }
+}
+
+/**
+ * Get retention stats — how many runs would be affected by current policy.
+ */
+export function getRetentionStats(policy?: Partial<RetentionPolicy>): {
+  totalRuns: number
+  terminalRuns: number
+  wouldArchive: number
+  oldestRunAge: number | null
+} {
+  const db = getDb()
+  const p = { ...DEFAULT_RETENTION, ...policy }
+  const now = Date.now()
+  const cutoffMs = now - p.maxAgeDays * 24 * 60 * 60 * 1000
+
+  const totalRuns = (db.prepare('SELECT COUNT(*) as c FROM agent_runs').get() as { c: number }).c
+  const terminalRuns = (db.prepare("SELECT COUNT(*) as c FROM agent_runs WHERE status IN ('completed','failed','cancelled')").get() as { c: number }).c
+  const wouldArchive = (db.prepare("SELECT COUNT(*) as c FROM agent_runs WHERE status IN ('completed','failed','cancelled') AND started_at < ?").get(cutoffMs) as { c: number }).c
+  const oldest = db.prepare('SELECT MIN(started_at) as m FROM agent_runs').get() as { m: number | null }
+  const oldestRunAge = oldest.m ? Math.floor((now - oldest.m) / (24 * 60 * 60 * 1000)) : null
+
+  return { totalRuns, terminalRuns, wouldArchive, oldestRunAge }
+}
+
 // ── Approval routing ───────────────────────────────────────────────────────
 
 export interface PendingApproval {

--- a/src/run-retention.test.ts
+++ b/src/run-retention.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+interface RetentionPolicy {
+  maxAgeDays: number
+  maxCompletedRuns: number
+  deleteArchived: boolean
+}
+
+const DEFAULT_POLICY: RetentionPolicy = { maxAgeDays: 30, maxCompletedRuns: 100, deleteArchived: false }
+
+function shouldArchive(run: { status: string; startedAt: number }, policy: RetentionPolicy, now: number): boolean {
+  const terminal = ['completed', 'failed', 'cancelled'].includes(run.status)
+  if (!terminal) return false
+  const cutoff = now - policy.maxAgeDays * 24 * 60 * 60 * 1000
+  return run.startedAt < cutoff
+}
+
+describe('run retention policy', () => {
+  const now = Date.now()
+  const day = 24 * 60 * 60 * 1000
+
+  it('does not archive active runs', () => {
+    assert.equal(shouldArchive({ status: 'working', startedAt: now - 60 * day }, DEFAULT_POLICY, now), false)
+    assert.equal(shouldArchive({ status: 'idle', startedAt: now - 60 * day }, DEFAULT_POLICY, now), false)
+    assert.equal(shouldArchive({ status: 'blocked', startedAt: now - 60 * day }, DEFAULT_POLICY, now), false)
+  })
+
+  it('archives completed runs older than maxAgeDays', () => {
+    assert.equal(shouldArchive({ status: 'completed', startedAt: now - 31 * day }, DEFAULT_POLICY, now), true)
+  })
+
+  it('does not archive recent completed runs', () => {
+    assert.equal(shouldArchive({ status: 'completed', startedAt: now - 5 * day }, DEFAULT_POLICY, now), false)
+  })
+
+  it('archives failed runs older than maxAgeDays', () => {
+    assert.equal(shouldArchive({ status: 'failed', startedAt: now - 31 * day }, DEFAULT_POLICY, now), true)
+  })
+
+  it('archives cancelled runs older than maxAgeDays', () => {
+    assert.equal(shouldArchive({ status: 'cancelled', startedAt: now - 31 * day }, DEFAULT_POLICY, now), true)
+  })
+
+  it('respects custom maxAgeDays', () => {
+    const policy = { ...DEFAULT_POLICY, maxAgeDays: 7 }
+    assert.equal(shouldArchive({ status: 'completed', startedAt: now - 8 * day }, policy, now), true)
+    assert.equal(shouldArchive({ status: 'completed', startedAt: now - 5 * day }, policy, now), false)
+  })
+
+  it('boundary: exactly at cutoff is not archived', () => {
+    const cutoff = now - 30 * day
+    assert.equal(shouldArchive({ status: 'completed', startedAt: cutoff }, DEFAULT_POLICY, now), false)
+  })
+
+  it('boundary: one ms before cutoff is archived', () => {
+    const cutoff = now - 30 * day
+    assert.equal(shouldArchive({ status: 'completed', startedAt: cutoff - 1 }, DEFAULT_POLICY, now), true)
+  })
+
+  it('default policy values are sensible', () => {
+    assert.equal(DEFAULT_POLICY.maxAgeDays, 30)
+    assert.equal(DEFAULT_POLICY.maxCompletedRuns, 100)
+    assert.equal(DEFAULT_POLICY.deleteArchived, false)
+  })
+
+  it('deleteArchived flag controls hard delete vs soft archive', () => {
+    const soft = { ...DEFAULT_POLICY, deleteArchived: false }
+    const hard = { ...DEFAULT_POLICY, deleteArchived: true }
+    assert.equal(soft.deleteArchived, false)
+    assert.equal(hard.deleteArchived, true)
+  })
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -14103,7 +14103,37 @@ If your heartbeat shows **no active task** and **no next task**:
         limit: query.limit ? parseInt(query.limit, 10) : undefined,
       }),
     }  })
+  // ── Run Retention / Archive ────────────────────────────────────────────
 
+  const { applyRunRetention, getRetentionStats } = await import('./agent-runs.js')
+
+  // GET /runs/retention/stats — preview what retention policy would do
+  app.get('/runs/retention/stats', async (request) => {
+    const query = request.query as { maxAgeDays?: string; maxCompletedRuns?: string }
+    return getRetentionStats({
+      maxAgeDays: query.maxAgeDays ? parseInt(query.maxAgeDays, 10) : undefined,
+      maxCompletedRuns: query.maxCompletedRuns ? parseInt(query.maxCompletedRuns, 10) : undefined,
+    })
+  })
+
+  // POST /runs/retention/apply — apply retention policy
+  app.post('/runs/retention/apply', async (request) => {
+    const body = request.body as {
+      maxAgeDays?: number
+      maxCompletedRuns?: number
+      deleteArchived?: boolean
+      agentId?: string
+      dryRun?: boolean
+    } ?? {}
+    return applyRunRetention({
+      policy: {
+        maxAgeDays: body.maxAgeDays,
+        maxCompletedRuns: body.maxCompletedRuns,
+        deleteArchived: body.deleteArchived,
+      },
+      agentId: body.agentId,
+      dryRun: body.dryRun,
+    })  })
   // ── Approval Routing ────────────────────────────────────────────────────
 
   const {


### PR DESCRIPTION
## What
Configurable retention policy for agent runs. Prevents unbounded DB growth.

### Policy
| Setting | Default | Effect |
|---------|---------|--------|
| `maxAgeDays` | 30 | Archive terminal runs older than this |
| `maxCompletedRuns` | 100 | Keep at most N completed per agent |
| `deleteArchived` | false | Hard delete vs soft archive |

### Endpoints
- `GET /runs/retention/stats` — preview impact without applying
- `POST /runs/retention/apply` — execute (supports `dryRun: true`)

### Safety
- Only affects terminal runs (completed/failed/cancelled)
- Working/idle/blocked runs are never touched
- Events are cleaned up when runs are hard-deleted
- Dry run mode to preview before committing

10 tests. Route-docs: 457/457.

Task: task-1773265723966