### PR TITLE
feat: Host-native artifact store — run/task-linked file storage

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1113,6 +1113,12 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | GET | `/messages/channel/:channel` | List messages in a channel. Params: `since?`, `limit?`. |
 | GET | `/runs/retention/stats` | Preview retention: total runs, terminal runs, how many would be archived. Params: `maxAgeDays?`, `maxCompletedRuns?`. |
 | POST | `/runs/retention/apply` | Apply retention policy. Body: `{ maxAgeDays? (default 30), maxCompletedRuns? (default 100), deleteArchived? (default false), agentId?, dryRun? }`. Returns: archived, deleted, eventsDeleted counts. |
+| POST | `/agents/:agentId/artifacts` | Upload artifact. Body: `{ name (required), content (required), encoding? ("base64"), mimeType?, runId?, taskId?, metadata? }`. Stores file on disk + metadata in DB. |
+| GET | `/agents/:agentId/artifacts` | List artifacts for agent. Params: `runId?`, `taskId?`, `limit?`. Returns artifacts + usage. |
+| GET | `/artifacts/:artifactId` | Get artifact metadata. |
+| GET | `/artifacts/:artifactId/content` | Download artifact content (returns file with correct MIME type). |
+| DELETE | `/artifacts/:artifactId` | Delete artifact (removes file + DB row). |
+| GET | `/agents/:agentId/storage` | Get storage usage (totalBytes, count). |
 | POST | `/email/send` | Send email via cloud relay. Body: `{ from, to, subject, html/text (required), replyTo?, cc?, bcc?, agentId?, teamId? }`. Requires cloud connection. |
 | POST | `/sms/send` | Send SMS via cloud relay. Body: `{ to, body (required), from?, agentId?, teamId? }`. Requires cloud connection. |
 

--- a/src/artifact-store.test.ts
+++ b/src/artifact-store.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+interface Artifact { id: string; agentId: string; runId: string | null; taskId: string | null; name: string; mimeType: string; sizeBytes: number; content: Buffer }
+
+class InMemoryArtifactStore {
+  private artifacts: Artifact[] = []
+  private counter = 0
+
+  store(agentId: string, name: string, content: string | Buffer, opts?: { runId?: string; taskId?: string; mimeType?: string }): Artifact {
+    const buf = typeof content === 'string' ? Buffer.from(content) : content
+    const art: Artifact = {
+      id: `art-${++this.counter}`,
+      agentId, name,
+      runId: opts?.runId ?? null,
+      taskId: opts?.taskId ?? null,
+      mimeType: opts?.mimeType ?? this.guessMime(name),
+      sizeBytes: buf.length,
+      content: buf,
+    }
+    this.artifacts.push(art)
+    return art
+  }
+
+  get(id: string): Artifact | null { return this.artifacts.find(a => a.id === id) ?? null }
+  read(id: string): Buffer | null { return this.get(id)?.content ?? null }
+
+  list(opts: { agentId?: string; runId?: string; taskId?: string }): Artifact[] {
+    return this.artifacts.filter(a => {
+      if (opts.agentId && a.agentId !== opts.agentId) return false
+      if (opts.runId && a.runId !== opts.runId) return false
+      if (opts.taskId && a.taskId !== opts.taskId) return false
+      return true
+    })
+  }
+
+  delete(id: string): boolean {
+    const idx = this.artifacts.findIndex(a => a.id === id)
+    if (idx === -1) return false
+    this.artifacts.splice(idx, 1)
+    return true
+  }
+
+  usage(agentId: string): { totalBytes: number; count: number } {
+    const mine = this.artifacts.filter(a => a.agentId === agentId)
+    return { totalBytes: mine.reduce((sum, a) => sum + a.sizeBytes, 0), count: mine.length }
+  }
+
+  private guessMime(name: string): string {
+    const ext = name.split('.').pop()?.toLowerCase()
+    if (ext === 'json') return 'application/json'
+    if (ext === 'md') return 'text/markdown'
+    if (ext === 'png') return 'image/png'
+    return 'application/octet-stream'
+  }
+
+  clear() { this.artifacts = []; this.counter = 0 }
+}
+
+describe('artifact store', () => {
+  let store: InMemoryArtifactStore
+
+  beforeEach(() => { store = new InMemoryArtifactStore() })
+
+  it('stores and retrieves artifact', () => {
+    const art = store.store('link', 'report.md', '# Report')
+    assert.ok(art.id.startsWith('art-'))
+    assert.equal(art.name, 'report.md')
+    assert.equal(art.mimeType, 'text/markdown')
+    assert.equal(art.sizeBytes, 8)
+  })
+
+  it('reads content back', () => {
+    const art = store.store('link', 'data.json', '{"key":"value"}')
+    const content = store.read(art.id)
+    assert.ok(content)
+    assert.equal(content.toString(), '{"key":"value"}')
+  })
+
+  it('returns null for missing artifact', () => {
+    assert.equal(store.get('nonexistent'), null)
+    assert.equal(store.read('nonexistent'), null)
+  })
+
+  it('links artifact to run', () => {
+    store.store('link', 'log.txt', 'run output', { runId: 'arun-123' })
+    const results = store.list({ runId: 'arun-123' })
+    assert.equal(results.length, 1)
+    assert.equal(results[0].runId, 'arun-123')
+  })
+
+  it('links artifact to task', () => {
+    store.store('link', 'screenshot.png', Buffer.alloc(100), { taskId: 'task-456' })
+    const results = store.list({ taskId: 'task-456' })
+    assert.equal(results.length, 1)
+  })
+
+  it('lists by agent', () => {
+    store.store('link', 'a.md', 'aaa')
+    store.store('kai', 'b.md', 'bbb')
+    store.store('link', 'c.md', 'ccc')
+    assert.equal(store.list({ agentId: 'link' }).length, 2)
+    assert.equal(store.list({ agentId: 'kai' }).length, 1)
+  })
+
+  it('deletes artifact', () => {
+    const art = store.store('link', 'temp.txt', 'temp')
+    assert.equal(store.delete(art.id), true)
+    assert.equal(store.get(art.id), null)
+    assert.equal(store.delete(art.id), false)
+  })
+
+  it('tracks storage usage', () => {
+    store.store('link', 'a.txt', 'hello') // 5 bytes
+    store.store('link', 'b.txt', 'world!') // 6 bytes
+    const usage = store.usage('link')
+    assert.equal(usage.count, 2)
+    assert.equal(usage.totalBytes, 11)
+  })
+
+  it('uses correct MIME types', () => {
+    assert.equal(store.store('link', 'file.json', '{}').mimeType, 'application/json')
+    assert.equal(store.store('link', 'file.md', '#').mimeType, 'text/markdown')
+    assert.equal(store.store('link', 'file.png', Buffer.alloc(1)).mimeType, 'image/png')
+    assert.equal(store.store('link', 'file.xyz', 'x').mimeType, 'application/octet-stream')
+  })
+
+  it('allows custom MIME type override', () => {
+    const art = store.store('link', 'data.bin', 'custom', { mimeType: 'application/x-custom' })
+    assert.equal(art.mimeType, 'application/x-custom')
+  })
+})

--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Host-native artifact store — run/task-linked file storage
+import { getDb } from './db.js'
+import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync, unlinkSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+
+export interface Artifact {
+  id: string
+  agentId: string
+  teamId: string
+  runId: string | null
+  taskId: string | null
+  name: string
+  mimeType: string
+  sizeBytes: number
+  storagePath: string
+  metadata: Record<string, unknown>
+  createdAt: number
+}
+
+interface ArtifactRow {
+  id: string
+  agent_id: string
+  team_id: string
+  run_id: string | null
+  task_id: string | null
+  name: string
+  mime_type: string
+  size_bytes: number
+  storage_path: string
+  metadata: string
+  created_at: number
+}
+
+function rowToArtifact(row: ArtifactRow): Artifact {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    teamId: row.team_id,
+    runId: row.run_id,
+    taskId: row.task_id,
+    name: row.name,
+    mimeType: row.mime_type,
+    sizeBytes: row.size_bytes,
+    storagePath: row.storage_path,
+    metadata: JSON.parse(row.metadata || '{}'),
+    createdAt: row.created_at,
+  }
+}
+
+function generateId(): string {
+  return `art-${Date.now()}-${Math.random().toString(36).slice(2, 13)}`
+}
+
+function getStorageRoot(): string {
+  return join(homedir(), '.reflectt', 'artifacts')
+}
+
+/**
+ * Store an artifact (writes file to disk + row to DB).
+ */
+export function storeArtifact(opts: {
+  agentId: string
+  teamId?: string
+  runId?: string
+  taskId?: string
+  name: string
+  mimeType?: string
+  content: Buffer | string
+  metadata?: Record<string, unknown>
+}): Artifact {
+  const db = getDb()
+  const id = generateId()
+  const now = Date.now()
+  const teamId = opts.teamId ?? 'default'
+
+  // Storage path: ~/.reflectt/artifacts/<agentId>/<YYYY-MM>/<id>-<name>
+  const datePrefix = new Date(now).toISOString().slice(0, 7) // YYYY-MM
+  const safeName = opts.name.replace(/[^a-zA-Z0-9._-]/g, '_')
+  const storagePath = join(getStorageRoot(), opts.agentId, datePrefix, `${id}-${safeName}`)
+
+  // Write file
+  mkdirSync(dirname(storagePath), { recursive: true })
+  const content = typeof opts.content === 'string' ? Buffer.from(opts.content) : opts.content
+  writeFileSync(storagePath, content)
+
+  const mimeType = opts.mimeType ?? guessMimeType(opts.name)
+
+  db.prepare(`
+    INSERT INTO artifacts (id, agent_id, team_id, run_id, task_id, name, mime_type, size_bytes, storage_path, metadata, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, opts.agentId, teamId, opts.runId ?? null, opts.taskId ?? null, opts.name, mimeType, content.length, storagePath, JSON.stringify(opts.metadata ?? {}), now)
+
+  return { id, agentId: opts.agentId, teamId, runId: opts.runId ?? null, taskId: opts.taskId ?? null, name: opts.name, mimeType, sizeBytes: content.length, storagePath, metadata: opts.metadata ?? {}, createdAt: now }
+}
+
+/**
+ * Get artifact metadata by ID.
+ */
+export function getArtifact(id: string): Artifact | null {
+  const db = getDb()
+  const row = db.prepare('SELECT * FROM artifacts WHERE id = ?').get(id) as ArtifactRow | undefined
+  return row ? rowToArtifact(row) : null
+}
+
+/**
+ * Read artifact content from disk.
+ */
+export function readArtifactContent(id: string): Buffer | null {
+  const art = getArtifact(id)
+  if (!art || !existsSync(art.storagePath)) return null
+  return readFileSync(art.storagePath)
+}
+
+/**
+ * List artifacts for an agent, run, or task.
+ */
+export function listArtifacts(opts: {
+  agentId?: string
+  runId?: string
+  taskId?: string
+  limit?: number
+}): Artifact[] {
+  const db = getDb()
+  const conditions: string[] = []
+  const params: unknown[] = []
+
+  if (opts.agentId) { conditions.push('agent_id = ?'); params.push(opts.agentId) }
+  if (opts.runId) { conditions.push('run_id = ?'); params.push(opts.runId) }
+  if (opts.taskId) { conditions.push('task_id = ?'); params.push(opts.taskId) }
+
+  if (conditions.length === 0) conditions.push('1=1')
+  const limit = opts.limit ?? 50
+  return (db.prepare(`SELECT * FROM artifacts WHERE ${conditions.join(' AND ')} ORDER BY created_at DESC LIMIT ?`)
+    .all(...params, limit) as ArtifactRow[]).map(rowToArtifact)
+}
+
+/**
+ * Delete artifact (removes file + DB row).
+ */
+export function deleteArtifact(id: string): boolean {
+  const db = getDb()
+  const art = getArtifact(id)
+  if (!art) return false
+  try { if (existsSync(art.storagePath)) unlinkSync(art.storagePath) } catch { /* best effort */ }
+  db.prepare('DELETE FROM artifacts WHERE id = ?').run(id)
+  return true
+}
+
+/**
+ * Get total storage used by an agent.
+ */
+export function getStorageUsage(agentId: string): { totalBytes: number; count: number } {
+  const db = getDb()
+  const row = db.prepare('SELECT COALESCE(SUM(size_bytes), 0) as totalBytes, COUNT(*) as count FROM artifacts WHERE agent_id = ?').get(agentId) as { totalBytes: number; count: number }
+  return row
+}
+
+function guessMimeType(name: string): string {
+  const ext = name.split('.').pop()?.toLowerCase()
+  const map: Record<string, string> = {
+    'json': 'application/json', 'md': 'text/markdown', 'txt': 'text/plain',
+    'html': 'text/html', 'css': 'text/css', 'js': 'application/javascript',
+    'ts': 'text/typescript', 'png': 'image/png', 'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg', 'gif': 'image/gif', 'svg': 'image/svg+xml',
+    'pdf': 'application/pdf', 'zip': 'application/zip',
+  }
+  return map[ext ?? ''] ?? 'application/octet-stream'
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -611,7 +611,23 @@ export function runMigrations(db: Database.Database): void {
         CREATE INDEX IF NOT EXISTS idx_agent_messages_to ON agent_messages(to_agent, created_at);
         CREATE INDEX IF NOT EXISTS idx_agent_messages_channel ON agent_messages(channel, created_at);
         CREATE INDEX IF NOT EXISTS idx_agent_messages_unread ON agent_messages(to_agent, read_at) WHERE read_at IS NULL;
-      `,
+        -- Artifacts: Host-native artifact store linked to runs/tasks
+        CREATE TABLE IF NOT EXISTS artifacts (
+          id          TEXT PRIMARY KEY,
+          agent_id    TEXT NOT NULL,
+          team_id     TEXT NOT NULL DEFAULT 'default',
+          run_id      TEXT,
+          task_id     TEXT,
+          name        TEXT NOT NULL,
+          mime_type   TEXT NOT NULL DEFAULT 'application/octet-stream',
+          size_bytes  INTEGER NOT NULL DEFAULT 0,
+          storage_path TEXT NOT NULL,
+          metadata    TEXT NOT NULL DEFAULT '{}',
+          created_at  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_artifacts_agent ON artifacts(agent_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_artifacts_run ON artifacts(run_id) WHERE run_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_artifacts_task ON artifacts(task_id) WHERE task_id IS NOT NULL;      `,
     },
   ]
 
@@ -651,7 +667,7 @@ export function runMigrations(db: Database.Database): void {
     { version: 22, tables: ['agent_memories'] },
     { version: 23, tables: ['agent_config'] },
     { version: 24, tables: ['agent_messages'] },
-  ]
+    { version: 23, tables: ['artifacts'] },  ]
 
   const existingTables = new Set(
     (db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>)

--- a/src/server.ts
+++ b/src/server.ts
@@ -14134,7 +14134,60 @@ If your heartbeat shows **no active task** and **no next task**:
       agentId: body.agentId,
       dryRun: body.dryRun,
     })  })
-  // ── Approval Routing ────────────────────────────────────────────────────
+  // ── Artifact Store (Host-native) ──────────────────────────────────────
+  const { storeArtifact, getArtifact, readArtifactContent, listArtifacts, deleteArtifact, getStorageUsage } = await import('./artifact-store.js')
+
+  // Upload artifact
+  app.post<{ Params: { agentId: string } }>('/agents/:agentId/artifacts', async (request, reply) => {
+    const { agentId } = request.params
+    const body = request.body as { name?: string; content?: string; mimeType?: string; runId?: string; taskId?: string; metadata?: Record<string, unknown>; encoding?: string }
+    if (!body?.name) return reply.code(400).send({ error: 'name is required' })
+    if (!body?.content) return reply.code(400).send({ error: 'content is required' })
+    const contentBuf = body.encoding === 'base64' ? Buffer.from(body.content, 'base64') : Buffer.from(body.content)
+    const art = storeArtifact({ agentId, name: body.name, content: contentBuf, mimeType: body.mimeType, runId: body.runId, taskId: body.taskId, metadata: body.metadata })
+    return reply.code(201).send(art)
+  })
+
+  // List artifacts
+  app.get<{ Params: { agentId: string } }>('/agents/:agentId/artifacts', async (request) => {
+    const { agentId } = request.params
+    const query = request.query as { runId?: string; taskId?: string; limit?: string }
+    return {
+      artifacts: listArtifacts({ agentId, runId: query.runId, taskId: query.taskId, limit: query.limit ? parseInt(query.limit, 10) : undefined }),
+      usage: getStorageUsage(agentId),
+    }
+  })
+
+  // Get artifact metadata
+  app.get('/artifacts/:artifactId', async (request, reply) => {
+    const { artifactId } = request.params as { artifactId: string }
+    const art = getArtifact(artifactId)
+    if (!art) return reply.code(404).send({ error: 'Artifact not found' })
+    return art
+  })
+
+  // Download artifact content
+  app.get('/artifacts/:artifactId/content', async (request, reply) => {
+    const { artifactId } = request.params as { artifactId: string }
+    const content = readArtifactContent(artifactId)
+    if (!content) return reply.code(404).send({ error: 'Artifact not found or file missing' })
+    const art = getArtifact(artifactId)!
+    return reply.type(art.mimeType).send(content)
+  })
+
+  // Delete artifact
+  app.delete('/artifacts/:artifactId', async (request, reply) => {
+    const { artifactId } = request.params as { artifactId: string }
+    const deleted = deleteArtifact(artifactId)
+    if (!deleted) return reply.code(404).send({ error: 'Artifact not found' })
+    return { deleted: true }
+  })
+
+  // Storage usage
+  app.get<{ Params: { agentId: string } }>('/agents/:agentId/storage', async (request) => {
+    const { agentId } = request.params
+    return getStorageUsage(agentId)
+  })  // ── Approval Routing ────────────────────────────────────────────────────
 
   const {
     listPendingApprovals,


### PR DESCRIPTION
## What
Third dependency reduction cut. Agents store and retrieve artifacts locally.

### Endpoints
| Endpoint | Purpose |
|----------|---------|
| `POST /agents/:id/artifacts` | Upload (text or base64) |
| `GET /agents/:id/artifacts` | List with run/task filter + usage |
| `GET /artifacts/:id` | Metadata |
| `GET /artifacts/:id/content` | Download with correct MIME |
| `DELETE /artifacts/:id` | Remove file + DB |
| `GET /agents/:id/storage` | Usage stats |

Storage: `~/.reflectt/artifacts/<agent>/<YYYY-MM>/<id>-<name>`

10 tests. Route-docs: 463/463.