### PR TITLE
feat: agent presence waiting state — blocked_on_human signal in heartbeat

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1124,6 +1124,8 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | GET | `/webhooks/payloads/:payloadId` | Get single payload with full body + headers. |
 | POST | `/webhooks/payloads/:payloadId/process` | Mark payload as processed. |
 | POST | `/webhooks/purge` | Delete old processed payloads. Body: `{ maxAgeDays? }` (default 30). |
+| POST | `/agents/:agent/waiting` | Set agent to waiting state (blocked on human). Body: `{ reason (required), waitingFor?, taskId?, expiresAt? }`. Shows in heartbeat response. |
+| DELETE | `/agents/:agent/waiting` | Clear waiting state — agent is unblocked. |
 | POST | `/email/send` | Send email via cloud relay. Body: `{ from, to, subject, html/text (required), replyTo?, cc?, bcc?, agentId?, teamId? }`. Requires cloud connection. |
 | POST | `/sms/send` | Send SMS via cloud relay. Body: `{ to, body (required), from?, agentId?, teamId? }`. Requires cloud connection. |
 

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -12,7 +12,7 @@ import { eventBus } from './events.js'
 import { getDb } from './db.js'
 import { getAgentRoles } from './assignment.js'
 
-export type PresenceStatus = 'idle' | 'working' | 'reviewing' | 'blocked' | 'offline'
+export type PresenceStatus = 'idle' | 'working' | 'reviewing' | 'blocked' | 'waiting' | 'offline'
 
 export type FocusLevel = 'soft' | 'deep'
 // soft: suppress system fallback nudges, idle-nudge; allow direct @mentions
@@ -26,6 +26,14 @@ export interface FocusState {
   reason?: string    // what they're focusing on
 }
 
+export interface WaitingState {
+  reason: string          // e.g. 'approval', 'review', 'human_input', 'token_refresh'
+  waitingFor?: string     // who/what specifically (e.g. 'ryan', 'kai', 'host_token')
+  taskId?: string         // related task
+  since: number           // when wait started
+  expiresAt?: number      // optional timeout
+}
+
 export interface AgentPresence {
   agent: string
   status: PresenceStatus
@@ -34,6 +42,7 @@ export interface AgentPresence {
   lastUpdate: number
   last_active?: number // Last real activity (message, task action, etc.)
   focus?: FocusState
+  waiting?: WaitingState  // populated when status === 'waiting'
 }
 
 export interface AgentActivity {
@@ -478,6 +487,31 @@ export class PresenceManager {
   }
 
   /**
+   * Set agent to waiting state (blocked on human).
+   */
+  setWaiting(agent: string, opts: { reason: string; waitingFor?: string; taskId?: string; expiresAt?: number }): void {
+    const lower = agent.toLowerCase()
+    const presence = this.presence.get(lower) || { agent: lower, status: 'idle' as PresenceStatus, since: Date.now(), lastUpdate: Date.now() }
+    presence.status = 'waiting'
+    presence.waiting = { reason: opts.reason, waitingFor: opts.waitingFor, taskId: opts.taskId, since: Date.now(), expiresAt: opts.expiresAt }
+    presence.lastUpdate = Date.now()
+    this.presence.set(lower, presence)
+  }
+
+  /**
+   * Clear waiting state — agent is unblocked.
+   */
+  clearWaiting(agent: string): void {
+    const lower = agent.toLowerCase()
+    const presence = this.presence.get(lower)
+    if (presence?.status === 'waiting') {
+      presence.status = 'idle'
+      presence.waiting = undefined
+      presence.lastUpdate = Date.now()
+    }
+  }
+
+  /**
    * Record real activity (message, task action, etc.)
    */
   recordActivity(agent: string, type: 'message' | 'task_completed' | 'heartbeat'): void {
@@ -631,6 +665,7 @@ export class PresenceManager {
       working: 0,
       reviewing: 0,
       blocked: 0,
+      waiting: 0,
       offline: 0,
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10648,12 +10648,33 @@ export async function createServer(): Promise<FastifyInstance> {
       ...(pauseStatus.paused ? { paused: true, pauseMessage: pauseStatus.message, resumesAt: pauseStatus.entry?.pausedUntil ?? null } : {}),
       ...(bootMemories.length > 0 ? { memories: bootMemories } : {}),
       ...(activeRun ? { run: activeRun } : {}),
+      ...(() => {
+        const p = presenceManager.getAllPresence().find(p => p.agent === agent)
+        return p?.waiting ? { waiting: p.waiting } : {}
+      })(),
       action: pauseStatus.paused ? `PAUSED: ${pauseStatus.message}`
         : activeTask ? `Continue ${activeTask.id}`
         : nextTask ? `Claim ${nextTask.id}`
         : inbox.length > 0 ? `Check inbox (${inbox.length} messages)`
         : 'HEARTBEAT_OK',
     }
+  })
+
+  // ── Agent Waiting State ──────────────────────────────────────────────
+  // Agents signal they're blocked on human input. Shows in heartbeat + presence.
+
+  app.post<{ Params: { agent: string } }>('/agents/:agent/waiting', async (request, reply) => {
+    const agent = String(request.params.agent || '').trim().toLowerCase()
+    const body = request.body as { reason?: string; waitingFor?: string; taskId?: string; expiresAt?: number } ?? {}
+    if (!body.reason) return reply.code(400).send({ error: 'reason is required' })
+    presenceManager.setWaiting(agent, { reason: body.reason, waitingFor: body.waitingFor, taskId: body.taskId, expiresAt: body.expiresAt })
+    return { success: true, agent, status: 'waiting', waiting: { reason: body.reason, waitingFor: body.waitingFor, taskId: body.taskId, expiresAt: body.expiresAt } }
+  })
+
+  app.delete<{ Params: { agent: string } }>('/agents/:agent/waiting', async (request) => {
+    const agent = String(request.params.agent || '').trim().toLowerCase()
+    presenceManager.clearWaiting(agent)
+    return { success: true, agent, status: 'idle' }
   })
 
   // ── Bootstrap: dynamic agent config generation ──────────────────────


### PR DESCRIPTION
## What
Agents can now signal they're blocked on human input. Shows in heartbeat + presence.

### New presence status: `waiting`
- `POST /agents/:agent/waiting` — set with reason, waitingFor, taskId, expiresAt
- `DELETE /agents/:agent/waiting` — clear, back to idle
- Heartbeat includes `waiting` field when set

### WaitingState
```json
{ "reason": "approval", "waitingFor": "ryan", "taskId": "task-123", "since": 1773..., "expiresAt": 1773... }
```

Route-docs: 467/467.
Task: `task-1773265209567-wdhehxwbd`