### PR TITLE
fix: trust indicator color → red-400 per spec review

### DIFF
--- a/public/design-tokens-platform.md
+++ b/public/design-tokens-platform.md
@@ -24,7 +24,7 @@ extension Color {
     static let stateHandoff = Color(hex: "#10B981")
 
     // Trust
-    static let trustActive = Color(hex: "#EF4444")
+    static let trustActive = Color(hex: "#F87171")  // Red 400 — visible without alarming
 }
 
 // Dimensions.swift
@@ -65,7 +65,7 @@ enum Timing {
 <color name="state_urgent">#FFEF4444</color>
 <color name="state_handoff">#FF10B981</color>
 
-<color name="trust_active">#FFEF4444</color>
+<color name="trust_active">#FFF87171</color> <!-- Red 400 -->
 
 <!-- dimens.xml -->
 <dimen name="tap_target_min">44dp</dimen>
@@ -87,6 +87,12 @@ object Timing {
     const val ORB_GLOW = 1800L
 }
 ```
+
+## Important Notes
+
+**Canvas state colors are tint references, not solid fills.** The spec uses these as radial gradient tints. Platform implementations should apply them as gradient bases, not flat backgrounds. For v0 surfaces using solid fills, these values are acceptable approximations.
+
+**Trust indicator uses red-400 (#F87171)** — deliberately lighter than error red. Present and visible without being alarming. Both-sensors escalates to red-500 (#EF4444).
 
 ## Token Categories
 

--- a/public/design-tokens.css
+++ b/public/design-tokens.css
@@ -40,9 +40,9 @@
   --color-state-handoff: #10B981;        /* Emerald 500 — transferring control */
 
   /* ── Trust Indicator ──────────────────────────────────────────────── */
-  --color-trust-mic: #EF4444;            /* Red — microphone active */
-  --color-trust-camera: #EF4444;         /* Red — camera active */
-  --color-trust-mic-camera: #DC2626;     /* Red 600 — both active */
+  --color-trust-mic: #F87171;            /* Red 400 — visible without alarming */            /* Red — microphone active */
+  --color-trust-camera: #F87171;         /* Red — camera active */
+  --color-trust-mic-camera: #EF4444;  /* Red 500 — both sensors escalated */     /* Red 600 — both active */
   --trust-indicator-size: 10px;
   --trust-indicator-position-top: env(safe-area-inset-top, 8px);
   --trust-indicator-position-left: 12px;


### PR DESCRIPTION
Per @pixel review of PR #892:
- Trust: `#EF4444` → `#F87171` (red-400, visible without alarming)
- Both-sensors: `#DC2626` → `#EF4444` (escalated)
- Added gradient tint note for canvas state colors
- Updated Swift + Kotlin mapping