### PR TITLE
feat: runtime cost-policy enforcement middleware (closes Host seam cluster)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reflectt-node",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## What
The last open Host control seam per COO/cos operating plan. Real enforcement, not just reporting.

### New endpoints:
- `POST /agents/:agentId/enforce-cost` — runtime check before model calls
- `GET /agents/:agentId/spend` — current daily + monthly spend
- `POST /usage/record` — record usage events
- `POST /usage/purge` — retention cleanup

### Enforcement tiers:
| Tier | Trigger | Action |
|------|---------|--------|
| allow | <80% cap | Proceed with preferred model |
| warn | 80-90% | Log warning, proceed |
| downgrade | 90-100% | Switch to fallback model |
| deny | 100%+ | Block call (403) |

### Tests
9 tests, all passing. Unique agent per test for isolation.

### Closes
`task-1773265241526-eq2v4kge5` — cost-policy enforcement hook