### PR TITLE
ci: post-merge /health smoke test + enforce admin branch protection

### DIFF
--- a/.github/workflows/post-merge-health.yml
+++ b/.github/workflows/post-merge-health.yml
@@ -1,0 +1,52 @@
+name: post-merge-health
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  health-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Start server and health check
+        run: |
+          # Start server in background
+          node dist/index.js &
+          SERVER_PID=$!
+
+          # Wait for server to be ready (max 60s)
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:4445/health > /dev/null 2>&1; then
+              echo "✅ Server healthy after ${i}s"
+              HEALTH=$(curl -s http://127.0.0.1:4445/health)
+              echo "$HEALTH" | python3 -m json.tool
+              kill $SERVER_PID 2>/dev/null || true
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "❌ Server failed to respond to /health within 60s"
+          kill $SERVER_PID 2>/dev/null || true
+          exit 1
+        env:
+          NODE_ENV: production
+          PORT: "4445"
+          HOST: "127.0.0.1"
+          REFLECTT_HOME: /tmp/reflectt-test


### PR DESCRIPTION
## What

1. **post-merge-health.yml**: After every push to main, builds dist, starts server, curls `/health`. Fails if no response in 60s.

2. **Branch protection hardened** (already applied via API):
   - `enforce_admins: true` — no more direct pushes to main bypassing CI
   - `strict: true` — branches must be up-to-date before merge

## Why

Node crashed 2026-03-11 ~17:56 because direct commits to main introduced broken code that bypassed CI. This ensures every change to main passes build + tests, and every merge is verified with a live health check.

## Task
`task-1773279787952`