### PR TITLE
feat: enforce routing payload vocabulary on agent events

### DIFF
--- a/src/agent-runs.ts
+++ b/src/agent-runs.ts
@@ -298,7 +298,11 @@ export function listAgentRuns(
 
 // ── Events (append-only) ──────────────────────────────────────────────────
 
-// Event types that require structured payload fields per COO routing semantics
+// Routing payload is a narrow API contract for actionable boundary writes.
+// Internal/event-specific payloads can still carry richer fields.
+export const VALID_ACTION_REQUIRED = ['review', 'unblock', 'approve', 'fyi'] as const
+export const VALID_ROUTING_URGENCY = ['blocking', 'normal', 'low'] as const
+
 const ACTIONABLE_EVENT_TYPES = new Set([
   'review_requested',
   'approval_requested',
@@ -306,7 +310,8 @@ const ACTIONABLE_EVENT_TYPES = new Set([
   'handoff',
 ])
 
-const VALID_URGENCY = new Set(['low', 'normal', 'high', 'critical'])
+const VALID_ACTION_REQUIRED_SET = new Set<string>(VALID_ACTION_REQUIRED)
+const VALID_ROUTING_URGENCY_SET = new Set<string>(VALID_ROUTING_URGENCY)
 
 export interface RoutingValidation {
   valid: boolean
@@ -314,38 +319,33 @@ export interface RoutingValidation {
   warnings: string[]
 }
 
-/**
- * Validate routing semantics for actionable events.
- * Enforces: action_required, urgency, owner required.
- * Optional: expires_at.
- */
 export function validateRoutingSemantics(eventType: string, payload: Record<string, unknown>): RoutingValidation {
   const errors: string[] = []
   const warnings: string[] = []
 
-  if (!ACTIONABLE_EVENT_TYPES.has(eventType)) {
+  const hasRoutingFields = payload.action_required !== undefined
+    || payload.urgency !== undefined
+    || payload.owner !== undefined
+    || payload.expires_at !== undefined
+
+  if (!ACTIONABLE_EVENT_TYPES.has(eventType) && !hasRoutingFields) {
     return { valid: true, errors: [], warnings: [] }
   }
 
-  if (!payload.action_required || typeof payload.action_required !== 'string') {
-    errors.push('Actionable events require action_required (string describing what needs to happen)')
+  if (typeof payload.action_required !== 'string' || payload.action_required.trim().length === 0) {
+    errors.push(`action_required is required and must be one of: ${VALID_ACTION_REQUIRED.join('|')}`)
+  } else if (!VALID_ACTION_REQUIRED_SET.has(payload.action_required.trim())) {
+    errors.push(`action_required must be one of: ${VALID_ACTION_REQUIRED.join('|')}`)
   }
-  if (!payload.urgency || typeof payload.urgency !== 'string') {
-    errors.push('Actionable events require urgency (low|normal|high|critical)')
-  } else if (!VALID_URGENCY.has(payload.urgency as string)) {
-    errors.push(`urgency must be one of: ${[...VALID_URGENCY].join(', ')}`)
-  }
-  if (!payload.owner || typeof payload.owner !== 'string') {
-    errors.push('Actionable events require owner (who needs to act)')
+
+  if (typeof payload.urgency !== 'string' || payload.urgency.trim().length === 0) {
+    errors.push(`urgency is required and must be one of: ${VALID_ROUTING_URGENCY.join('|')}`)
+  } else if (!VALID_ROUTING_URGENCY_SET.has(payload.urgency.trim())) {
+    errors.push(`urgency must be one of: ${VALID_ROUTING_URGENCY.join('|')}`)
   }
 
   if (payload.expires_at !== undefined && typeof payload.expires_at !== 'number') {
     warnings.push('expires_at should be a numeric timestamp (epoch ms)')
-  }
-
-  // Decision events should include rationale
-  if (eventType === 'approval_requested' && !payload.title) {
-    warnings.push('approval_requested events should include title for the approval queue')
   }
 
   return { valid: errors.length === 0, errors, warnings }

--- a/src/e2e-loop-proof.test.ts
+++ b/src/e2e-loop-proof.test.ts
@@ -53,10 +53,15 @@ describe('E2E Host Loop — trigger → run → decision → approval → comple
       eventType: 'review_requested',
       runId,
       payload: {
-        action_required: 'Approve E2E loop test',
+        action_required: 'approve',
         urgency: 'normal',
         owner: 'ryan',
         prUrl: 'https://github.com/reflectt/reflectt-node/pull/e2e-test',
+        rationale: {
+          choice: 'request approval for E2E loop proof',
+          considered: ['host loop reached review point', 'approval path needs proof'],
+          constraint: 'must pass through real approval endpoint',
+        },
       },
     })
     assert.equal(status, 201)
@@ -74,6 +79,11 @@ describe('E2E Host Loop — trigger → run → decision → approval → comple
       decision: 'approve',
       reviewer: 'ryan',
       comment: 'LGTM — E2E proof approved',
+      rationale: {
+        choice: 'approve E2E loop proof',
+        considered: ['review request present', 'loop should prove approval path'],
+        constraint: 'keep to host-only proof path',
+      },
     })
     assert.equal(status, 200)
     console.log('  ✓ Approved by ryan')

--- a/src/routing-enforcement.test.ts
+++ b/src/routing-enforcement.test.ts
@@ -1,96 +1,72 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-
-const ACTIONABLE = new Set(['review_requested', 'approval_requested', 'escalation', 'handoff'])
-const VALID_URGENCY = new Set(['low', 'normal', 'high', 'critical'])
-
-function validate(eventType: string, payload: Record<string, unknown>): { valid: boolean; errors: string[] } {
-  if (!ACTIONABLE.has(eventType)) return { valid: true, errors: [] }
-  const errors: string[] = []
-  if (!payload.action_required || typeof payload.action_required !== 'string') errors.push('action_required required')
-  if (!payload.urgency || typeof payload.urgency !== 'string') errors.push('urgency required')
-  else if (!VALID_URGENCY.has(payload.urgency as string)) errors.push('invalid urgency')
-  if (!payload.owner || typeof payload.owner !== 'string') errors.push('owner required')
-  return { valid: errors.length === 0, errors }
-}
+import { validateRoutingSemantics, VALID_ACTION_REQUIRED, VALID_ROUTING_URGENCY } from './agent-runs.js'
 
 describe('routing semantics enforcement', () => {
-  it('non-actionable events always pass', () => {
-    assert.equal(validate('task_completed', {}).valid, true)
-    assert.equal(validate('memory_written', {}).valid, true)
-    assert.equal(validate('run_started', {}).valid, true)
+  it('non-routing payload on non-actionable events passes', () => {
+    assert.equal(validateRoutingSemantics('task_completed', {}).valid, true)
+    assert.equal(validateRoutingSemantics('memory_written', {}).valid, true)
   })
 
-  it('review_requested with all fields passes', () => {
-    const r = validate('review_requested', { action_required: 'Review PR', urgency: 'normal', owner: 'kai' })
+  it('review_requested with locked routing vocabulary passes', () => {
+    const r = validateRoutingSemantics('review_requested', { action_required: 'review', urgency: 'normal', owner: 'kai' })
     assert.equal(r.valid, true)
   })
 
-  it('approval_requested with all fields passes', () => {
-    const r = validate('approval_requested', { action_required: 'Deploy?', urgency: 'high', owner: 'ryan' })
-    assert.equal(r.valid, true)
-  })
-
-  it('escalation with all fields passes', () => {
-    const r = validate('escalation', { action_required: 'Server down', urgency: 'critical', owner: 'link' })
-    assert.equal(r.valid, true)
-  })
-
-  it('handoff with all fields passes', () => {
-    const r = validate('handoff', { action_required: 'Continue build', urgency: 'normal', owner: 'pixel' })
-    assert.equal(r.valid, true)
+  it('routing payload on any event requires both fields', () => {
+    const r = validateRoutingSemantics('tool_invoked', { action_required: 'fyi' })
+    assert.equal(r.valid, false)
+    assert.ok(r.errors.some(e => e.includes('urgency')))
   })
 
   it('rejects missing action_required', () => {
-    const r = validate('review_requested', { urgency: 'normal', owner: 'kai' })
+    const r = validateRoutingSemantics('review_requested', { urgency: 'normal', owner: 'kai' })
     assert.equal(r.valid, false)
     assert.ok(r.errors.some(e => e.includes('action_required')))
   })
 
   it('rejects missing urgency', () => {
-    const r = validate('review_requested', { action_required: 'Review', owner: 'kai' })
+    const r = validateRoutingSemantics('review_requested', { action_required: 'review', owner: 'kai' })
     assert.equal(r.valid, false)
     assert.ok(r.errors.some(e => e.includes('urgency')))
   })
 
-  it('rejects missing owner', () => {
-    const r = validate('review_requested', { action_required: 'Review', urgency: 'normal' })
+  it('rejects invalid action_required value', () => {
+    const r = validateRoutingSemantics('review_requested', { action_required: 'Review PR', urgency: 'normal', owner: 'kai' })
     assert.equal(r.valid, false)
-    assert.ok(r.errors.some(e => e.includes('owner')))
+    assert.ok(r.errors.some(e => e.includes('action_required')))
   })
 
   it('rejects invalid urgency value', () => {
-    const r = validate('review_requested', { action_required: 'Review', urgency: 'medium', owner: 'kai' })
+    const r = validateRoutingSemantics('review_requested', { action_required: 'review', urgency: 'high', owner: 'kai' })
     assert.equal(r.valid, false)
     assert.ok(r.errors.some(e => e.includes('urgency')))
   })
 
-  it('accepts all valid urgency levels', () => {
-    for (const u of ['low', 'normal', 'high', 'critical']) {
-      const r = validate('review_requested', { action_required: 'Test', urgency: u, owner: 'kai' })
-      assert.equal(r.valid, true, `${u} should be valid`)
+  it('accepts all locked action_required values', () => {
+    for (const value of VALID_ACTION_REQUIRED) {
+      const r = validateRoutingSemantics('review_requested', { action_required: value, urgency: 'normal' })
+      assert.equal(r.valid, true, `${value} should be valid`)
     }
   })
 
-  it('rejects empty payload for actionable event', () => {
-    const r = validate('approval_requested', {})
-    assert.equal(r.valid, false)
-    assert.equal(r.errors.length, 3) // missing all 3 required fields
+  it('accepts all locked urgency values', () => {
+    for (const value of VALID_ROUTING_URGENCY) {
+      const r = validateRoutingSemantics('review_requested', { action_required: 'review', urgency: value })
+      assert.equal(r.valid, true, `${value} should be valid`)
+    }
   })
 
-  it('collects all errors at once', () => {
-    const r = validate('escalation', {})
-    assert.equal(r.errors.length, 3)
+  it('collects both missing-field errors at once', () => {
+    const r = validateRoutingSemantics('handoff', {})
+    assert.equal(r.valid, false)
+    assert.equal(r.errors.length, 2)
   })
 
-  it('rejects non-string action_required', () => {
-    const r = validate('review_requested', { action_required: 123, urgency: 'normal', owner: 'kai' })
-    assert.equal(r.valid, false)
-  })
-
-  it('rejects non-string owner', () => {
-    const r = validate('review_requested', { action_required: 'Review', urgency: 'normal', owner: 42 })
-    assert.equal(r.valid, false)
+  it('warns on non-numeric expires_at', () => {
+    const r = validateRoutingSemantics('handoff', { action_required: 'approve', urgency: 'low', expires_at: 'soon' as unknown as number })
+    assert.equal(r.valid, true)
+    assert.ok(r.warnings.some(w => w.includes('expires_at')))
   })
 })

--- a/src/server.ts
+++ b/src/server.ts
@@ -13853,15 +13853,18 @@ If your heartbeat shows **no active task** and **no next task**:
       })
       return reply.code(201).send(event)
     } catch (err: any) {
-      if (err.message.includes('Routing semantics violation')) {
-        return reply.code(422).send({ error: err.message, hint: 'Actionable events require: action_required (string), urgency (low|normal|high|critical), owner (string). Optional: expires_at (number).' })
-      }
-      return reply.code(500).send({ error: err.message })
       const message = String(err?.message || err)
+      if (message.includes('Routing semantics violation')) {
+        return reply.code(422).send({
+          error: message,
+          hint: 'Routing payload requires action_required (review|unblock|approve|fyi) and urgency (blocking|normal|low). Optional: owner, expires_at.',
+        })
+      }
       if (message.includes('rationale')) {
         return reply.code(400).send({ error: message })
       }
-      return reply.code(500).send({ error: message })    }
+      return reply.code(500).send({ error: message })
+    }
   })
 
   // List agent events

--- a/src/workflow-templates.ts
+++ b/src/workflow-templates.ts
@@ -79,7 +79,7 @@ export const prReviewWorkflow: WorkflowTemplate = {
           runId: ctx.runId,
           eventType: 'review_requested',
           payload: {
-            action_required: 'Review and approve the submitted work',
+            action_required: 'review',
             urgency: ctx.params.urgency as string ?? 'normal',
             owner: ctx.params.reviewer as string ?? 'kai',
             pr_url: ctx.params.prUrl as string,
@@ -115,7 +115,7 @@ export const prReviewWorkflow: WorkflowTemplate = {
           runId: ctx.runId,
           eventType: 'handoff',
           payload: {
-            action_required: 'Deploy or merge the approved work',
+            action_required: 'approve',
             urgency: 'normal',
             owner: ctx.params.nextOwner as string ?? ctx.agentId,
             summary: ctx.params.summary as string ?? 'Work reviewed and approved',


### PR DESCRIPTION
## Summary
- enforce locked routing payload vocabulary at the `agent_events` API boundary
- require `action_required` in `review|unblock|approve|fyi`
- require `urgency` in `blocking|normal|low`
- keep enforcement narrow to routing semantics; no schema sprawl
- update workflow/e2e fixtures to use the locked routing contract

## Why
This lands `task-1773262304190-mrodk0u52` by making actionable event writes fail loudly at the boundary instead of relying on docs or free-form strings.

## Validation
- `./node_modules/.bin/tsx --test src/routing-enforcement.test.ts src/agent-runs.test.ts src/e2e-loop-proof.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false`
