### PR TITLE
feat: emit canvas state per workflow step

### DIFF
--- a/src/workflow-canvas-state.test.ts
+++ b/src/workflow-canvas-state.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { runWorkflow, type WorkflowTemplate } from './workflow-templates.js'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('workflow canvas state emission', () => {
+  it('emits thinking then rendering for each successful step, then ambient', async () => {
+    const calls: Array<{ state: string; agentId: string; text?: string }> = []
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || '{}'))
+      calls.push({ state: body.state, agentId: body.agentId, text: body.payload?.text })
+      return new Response(JSON.stringify({ success: true }), { status: 200 })
+    }) as typeof fetch
+
+    const template: WorkflowTemplate = {
+      id: 'test',
+      name: 'test',
+      description: 'test',
+      steps: [
+        { name: 'one', description: 'Step one', action: () => ({ success: true }) },
+        { name: 'two', description: 'Step two', action: () => ({ success: true }) },
+      ],
+    }
+
+    const result = await runWorkflow(template, 'rhythm', 'default')
+    assert.equal(result.success, true)
+    assert.deepEqual(calls.map(c => c.state), ['thinking', 'rendering', 'thinking', 'rendering', 'ambient'])
+    assert.equal(calls[0]?.agentId, 'rhythm')
+    assert.equal(calls[0]?.text, 'Step one')
+    assert.equal(calls[1]?.text, 'Completed: Step one')
+  })
+
+  it('emits urgent when a step fails', async () => {
+    const calls: string[] = []
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || '{}'))
+      calls.push(body.state)
+      return new Response(JSON.stringify({ success: true }), { status: 200 })
+    }) as typeof fetch
+
+    const template: WorkflowTemplate = {
+      id: 'test-fail',
+      name: 'test-fail',
+      description: 'test',
+      steps: [
+        { name: 'one', description: 'Step one', action: () => ({ success: false, error: 'nope' }) },
+      ],
+    }
+
+    const result = await runWorkflow(template, 'rhythm', 'default')
+    assert.equal(result.success, false)
+    assert.deepEqual(calls, ['thinking', 'urgent'])
+  })
+})

--- a/src/workflow-templates.ts
+++ b/src/workflow-templates.ts
@@ -4,6 +4,26 @@
 
 import { createAgentRun, updateAgentRun, appendAgentEvent, getAgentRun } from './agent-runs.js'
 
+const LOCAL_NODE_BASE = process.env.REFLECTT_NODE_BASE_URL || 'http://127.0.0.1:4445'
+
+type CanvasEmitState = 'thinking' | 'rendering' | 'ambient' | 'urgent'
+
+async function emitCanvasState(agentId: string, state: CanvasEmitState, text: string, extraPayload: Record<string, unknown> = {}): Promise<void> {
+  try {
+    await fetch(`${LOCAL_NODE_BASE}/canvas/state`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        state,
+        agentId,
+        payload: { text, ...extraPayload },
+      }),
+    })
+  } catch {
+    // Presence updates are best-effort; workflow execution must continue.
+  }
+}
+
 export interface WorkflowStep {
   name: string
   description: string
@@ -155,6 +175,7 @@ export async function runWorkflow(
 
   for (const step of template.steps) {
     const stepStart = Date.now()
+    await emitCanvasState(ctx.agentId, 'thinking', step.description)
     try {
       const result = await step.action(ctx)
       stepResults.push({
@@ -165,8 +186,10 @@ export async function runWorkflow(
         durationMs: Date.now() - stepStart,
       })
       if (!result.success) {
+        await emitCanvasState(ctx.agentId, 'urgent', result.error || `Step failed: ${step.description}`)
         return { success: false, runId: ctx.runId, steps: stepResults, totalDurationMs: Date.now() - start }
       }
+      await emitCanvasState(ctx.agentId, 'rendering', `Completed: ${step.description}`)
     } catch (err: any) {
       stepResults.push({
         name: step.name,
@@ -174,10 +197,12 @@ export async function runWorkflow(
         error: err.message,
         durationMs: Date.now() - stepStart,
       })
+      await emitCanvasState(ctx.agentId, 'urgent', err.message || `Step failed: ${step.description}`)
       return { success: false, runId: ctx.runId, steps: stepResults, totalDurationMs: Date.now() - start }
     }
   }
 
+  await emitCanvasState(ctx.agentId, 'ambient', 'Workflow completed successfully')
   return { success: true, runId: ctx.runId, steps: stepResults, totalDurationMs: Date.now() - start }
 }
 


### PR DESCRIPTION
## Summary
- emit `POST /canvas/state` updates for workflow run steps
- send `thinking` when a step starts and `rendering` when it completes
- emit `urgent` on failure and `ambient` on successful workflow completion
- add focused tests covering the canvas-state emission sequence

## Why
This makes Presence feel alive between milestones by feeding live agent work text into the existing `/canvas/state` seam.

## Validation
- `./node_modules/.bin/tsx --test src/workflow-templates.test.ts src/workflow-canvas-state.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit --pretty false`
