### PR TITLE
feat: CI build gate + startup freshness check

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,11 +135,61 @@ function buildServerEnv(config: Config): NodeJS.ProcessEnv {
   return env
 }
 
+/**
+ * Check if dist/ is stale compared to src/ (i.e. source files were modified after last build).
+ * Returns a warning message if stale, or null if fresh.
+ */
+function checkBuildFreshness(): string | null {
+  const __filename = fileURLToPath(import.meta.url)
+  const projectRoot = join(dirname(__filename), '..')
+  const distDir = join(projectRoot, 'dist')
+  const srcDir = join(projectRoot, 'src')
+
+  if (!existsSync(distDir)) {
+    return `❌ Build output missing: ${distDir} does not exist. Run 'npm run build' before starting.`
+  }
+
+  const distIndex = join(distDir, 'server.js')
+  if (!existsSync(distIndex)) {
+    return `❌ Build output incomplete: dist/server.js not found. Run 'npm run build' before starting.`
+  }
+
+  try {
+    const distMtime = statSync(distIndex).mtimeMs
+    // Check a few key source files — if any are newer than dist, build is stale
+    const checkFiles = ['server.ts', 'cli.ts', 'config.ts', 'chat.ts']
+    for (const file of checkFiles) {
+      const srcFile = join(srcDir, file)
+      if (existsSync(srcFile)) {
+        const srcMtime = statSync(srcFile).mtimeMs
+        if (srcMtime > distMtime) {
+          return `⚠️  Build may be stale: src/${file} is newer than dist/server.js. Run 'npm run build' to rebuild.`
+        }
+      }
+    }
+  } catch {
+    // If stat fails, don't block startup
+  }
+
+  return null
+}
+
 function startServerDetached(config: Config): number {
   const { projectRoot, serverPath, useNode } = getRuntimePaths()
 
   if (!existsSync(serverPath)) {
     throw new Error(`Server file not found: ${serverPath}`)
+  }
+
+  // Check build freshness for compiled mode
+  if (useNode) {
+    const warning = checkBuildFreshness()
+    if (warning) {
+      console.warn(warning)
+      if (warning.startsWith('❌')) {
+        throw new Error('Cannot start: build output is missing or incomplete. Run "npm run build" first.')
+      }
+    }
   }
 
   const cmd = useNode ? 'node' : 'npx'

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,13 @@ function checkBuildFreshness(): void {
 
     if (newestSrc > distMtime + 1000) { // 1s tolerance
       const ageSec = Math.round((newestSrc - distMtime) / 1000)
-      console.warn(`⚠️  Build may be stale: src/ is ${ageSec}s newer than dist/. Run \`npm run build\` to recompile.`)
+      console.warn('')
+      console.warn('╔══════════════════════════════════════════════════════════════╗')
+      console.warn(`║  ⚠️  BUILD STALE: src/ is ${ageSec}s newer than dist/`)
+      console.warn('║  Run: npm run build')
+      console.warn('║  The running server may not reflect your latest code changes.')
+      console.warn('╚══════════════════════════════════════════════════════════════╝')
+      console.warn('')
     }
   } catch {
     // Non-fatal — skip check if anything goes wrong


### PR DESCRIPTION
## CI Build Gate for Main Branch

**Problem:** Node crashed 2026-03-11 18:30 because bad merges broke TypeScript compilation but branch CI passed.

**Fix (3 parts):**

### 1. Branch protection (already applied)
- `test` workflow is now a required status check before merge to main
- `strict: true` — branch must be up to date with main before merge
- This means `npm run build` + `npm test` + route-docs contract must all pass

### 2. Enhanced build freshness check (cli.ts)
- `checkBuildFreshness()` runs before server starts in compiled mode
- **Hard error** if dist/ or dist/server.js is missing
- **Warning** if src/ files are newer than dist/

### 3. Prominent stale-build warning (index.ts)
- Server startup shows a visible box warning if build is stale
- Makes it immediately obvious when running old compiled code

### Done criteria:
- ✅ npm run build is a required check before merge to main
- ✅ post-merge health check runs after every merge (already existed)
- ✅ node startup gives clear human error if build is stale/broken

Task: task-1773279787952-qb8iy4xd9