### PR TITLE
fix: escaped backticks in db.ts migration v23/v24 — fixes 30 test failures

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -592,11 +592,11 @@ export function runMigrations(db: Database.Database): void {
           updated_at      INTEGER NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_agent_config_team ON agent_config(team_id);
-      \`,
+      `,
     },
     {
       version: 24,
-      sql: \`
+      sql: `
         -- Agent messages: Host-native agent-to-agent messaging
         CREATE TABLE IF NOT EXISTS agent_messages (
           id          TEXT PRIMARY KEY,


### PR DESCRIPTION
## Bug

Migration v23's closing backtick and v24's opening backtick were escaped (\\`) from a bad merge. This caused the template literal to never close, leaking SQL into JavaScript object syntax → SQLite syntax error on every test that runs migrations.

## Fix

Remove the backslashes: \\` → `

## Impact

- **Before:** 18 test files failing, 37 tests failing
- **After:** 2 test files failing, 7 tests failing
- **Root cause:** Bad merge artifact from PR chain that added migrations v22-v25

Remaining 7 failures are pre-existing test expectation mismatches in `usage-tracking.test.ts` and `api.test.ts` (unrelated to migrations).