### PR TITLE
feat(canvas): expose lastMessage in GET /canvas/state per agent

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8907,13 +8907,28 @@ export async function createServer(): Promise<FastifyInstance> {
   // GET /canvas/state — current state for all agents (or one)
   app.get('/canvas/state', async (request) => {
     const query = request.query as { agentId?: string }
+
+    // Helper: get most recent chat message for an agent
+    function getLastMessage(agentId: string): { content: string; timestamp: number } | null {
+      try {
+        const _db = getDb()
+        const row = _db.prepare(
+          `SELECT content, timestamp FROM chat_messages WHERE "from" = ? AND "to" IS NULL ORDER BY timestamp DESC LIMIT 1`
+        ).get(agentId) as { content: string; timestamp: number } | undefined
+        return row ?? null
+      } catch {
+        return null
+      }
+    }
+
     if (query.agentId) {
       const entry = canvasStateMap.get(query.agentId)
-      return entry ?? { state: 'floor', sensors: null, payload: {}, updatedAt: null }
+      const base = entry ?? { state: 'floor', sensors: null, payload: {}, updatedAt: null }
+      return { ...base, lastMessage: getLastMessage(query.agentId) }
     }
     const all: Record<string, unknown> = {}
     for (const [id, entry] of canvasStateMap) {
-      all[id] = entry
+      all[id] = { ...entry, lastMessage: getLastMessage(id) }
     }
     return { agents: all, count: canvasStateMap.size }
   })


### PR DESCRIPTION
Adds `lastMessage` field to the per-agent canvas state response.

## What
`GET /canvas/state` now returns `lastMessage: { content, timestamp } | null` per agent.

Queries `chat_messages` table for the most recent outbound message from each agent (`to IS NULL`).  
Falls back gracefully to `null` when no messages exist or the table is unavailable.

## Why
The presence card detail panel (reflectt-cloud PR #917) notes "last message" as a field but the data was not surfaced from the node. This closes that gap.

## Used by
`reflectt-cloud` `use-host-state.ts` → `AgentPresence.lastMessage` → detail panel "last message" row.

## Safety
- Read-only query
- try/catch — any DB error silently returns null (no regression on existing callers)
- tsc clean (pre-existing stagehand type error unrelated)

@kai — task-1773365964507-t6knp5iox (cloud side in separate PR)