### PR TITLE
feat(node): needs-attention call hook + clear canvas on shutdown

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -644,6 +644,18 @@ export function stopCloudIntegration(): void {
   }
   logConnectionEvent({ type: 'disconnected', timestamp: Date.now(), reason: 'shutdown' })
   console.log('☁️  Cloud integration: stopped')
+
+  // Clear canvas state on Fly so subscribers see an empty room, not ghost agents
+  if (state.hostId && state.credential && config) {
+    const clearUrl = `${config.cloudUrl}/api/hosts/${state.hostId}/canvas/clear`
+    fetch(clearUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${state.credential}`,
+      },
+    }).catch(() => { /* best-effort; already shutting down */ })
+  }
 }
 
 // ---- Data providers ----


### PR DESCRIPTION
Two fixes in one branch:

1. **Needs-attention auto-call hook** — syncCanvas fires POST /call on Fly when agent transitions to needs-attention/urgent. Fly resolves phones for members with call_on_needs_attention=true (reflectt-cloud PR #949).

2. **Clear canvas on shutdown** — stopCloudIntegration() fires POST /canvas/clear before stopping. Ghost agent state wiped from Fly immediately.

Companion cloud PRs: #949 (schema), #953 (user profile + Fly auto-call), #958 (canvas TTL + clear endpoint).