### PR TITLE
feat(cloud): task-derived agent presence — agents visible when they have work

### DIFF
--- a/process/TASK-6m015zrls.md
+++ b/process/TASK-6m015zrls.md
@@ -1,0 +1,25 @@
+# Builder Maintenance: task-1773383202490-6m015zrls
+
+## Reviewed at 2026-03-12 23:23 PDT
+
+### PR State
+- reflectt-cloud: 0 open PRs (all merged)
+- reflectt-node: 0 open PRs (all merged)
+
+### Merged This Session
+- #963 agent.weight + lastTransitionAt
+- #958 canvas stale TTL + clear endpoint  
+- #923 needs-attention call hook + canvas clear + immediate sync
+- #953 user profile + auto-call
+- #962 AudioContext unlock fix (pixel)
+- #964 TTS URL double-path fix (pixel)
+- #965 approvals polling loop fix (pixel)
+- #966 adaptive approval backoff (pixel)
+
+### Task Board
+- task-1773377932146-i6xtg3e8t → validating
+- task-1773377216043-iyqtksy9x → validating
+- Queue: 1 doing (this), 0 todo link-lane remaining
+
+### Action
+Queue will drop to 0 after this task closes. @sage needs to assign a new link-lane task.

--- a/process/TASK-i6xtg3e8t.md
+++ b/process/TASK-i6xtg3e8t.md
@@ -1,0 +1,21 @@
+# Review: task-1773377932146-i6xtg3e8t — Canvas wipe on host disconnect
+
+## Summary
+Stale canvas state eliminated via two complementary mechanisms (belt+suspenders).
+
+## Artifacts
+- **PR #958** (reflectt-cloud, merged): `getFreshCanvasState()` 5-min TTL wraps all `canvasStore.get()` reads; stale state evicted + SSE notified. `POST /api/hosts/:hostId/canvas/clear` endpoint added.
+- **PR #923** (reflectt-node, merged): `stopCloudIntegration()` fires `POST /canvas/clear` on clean shutdown.
+
+## Acceptance Criteria
+- [x] Canvas state cleared on clean node disconnect (PR #923 — `stopCloudIntegration` fires clear)
+- [x] Canvas state expires automatically after 5 minutes of stale data (PR #958 — `CANVAS_STALE_TTL_MS`)
+- [x] SSE subscribers notified on clear (PR #958 — `notifyCanvasSubscribers`)
+- [x] Both deployed to Fly
+
+## Commits
+- reflectt-cloud: `8a805d4` (PR #958)
+- reflectt-node: `352b3f2` (PR #923)
+
+## Caveats
+None. Both PRs clean and merged.

--- a/process/TASK-iyqtksy9x.md
+++ b/process/TASK-iyqtksy9x.md
@@ -1,0 +1,23 @@
+# Builder Maintenance: task-1773377216043-iyqtksy9x
+
+## Review Summary (2026-03-12 cycle)
+
+### Merged PRs (link-authored)
+- PR #958 (reflectt-cloud): Canvas stale TTL + clear endpoint — MERGED
+- PR #923 (reflectt-node): Needs-attention call hook + canvas clear + immediate sync — MERGED
+- PR #963 (reflectt-cloud): agent.weight + lastTransitionAt hints — MERGED
+
+### Task Board
+- task-1773377932146-i6xtg3e8t: canvas wipe → validating ✓
+- task-1773371897394-f6gcazed8: builder maintenance → done (prior cycle)
+- task-1773375115938-81kb8jd77: builder maintenance → done (prior cycle)
+
+### Queue State
+- todo: 2 (one iOS lane for @swift, one design pass for @pixel)
+- doing: 1 (this task)
+- validating: 1 (canvas wipe)
+- Queue floor maintained
+
+### Wire State
+- weight hints live on canvas payload (additive, non-breaking)
+- All Fly deploys current as of ~22:43 tonight

--- a/process/TASK-task-1773377932146-i6xtg3e8t.md
+++ b/process/TASK-task-1773377932146-i6xtg3e8t.md
@@ -1,0 +1,21 @@
+# Review: task-1773377932146-i6xtg3e8t — Canvas wipe on host disconnect
+
+## Summary
+Stale canvas state eliminated via two complementary mechanisms (belt+suspenders).
+
+## Artifacts
+- **PR #958** (reflectt-cloud, merged): `getFreshCanvasState()` 5-min TTL wraps all `canvasStore.get()` reads; stale state evicted + SSE notified. `POST /api/hosts/:hostId/canvas/clear` endpoint added.
+- **PR #923** (reflectt-node, merged): `stopCloudIntegration()` fires `POST /canvas/clear` on clean shutdown.
+
+## Acceptance Criteria
+- [x] Canvas state cleared on clean node disconnect (PR #923 — `stopCloudIntegration` fires clear)
+- [x] Canvas state expires automatically after 5 minutes of stale data (PR #958 — `CANVAS_STALE_TTL_MS`)
+- [x] SSE subscribers notified on clear (PR #958 — `notifyCanvasSubscribers`)
+- [x] Both deployed to Fly
+
+## Commits
+- reflectt-cloud: `8a805d4` (PR #958)
+- reflectt-node: `352b3f2` (PR #923)
+
+## Caveats
+None. Both PRs clean and merged.

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1229,6 +1229,50 @@ async function syncCanvas(): Promise<void> {
     }
   } catch { /* local API not ready */ }
 
+  // ── Task-derived agent presence ─────────────────────────────────────────
+  // Agents that have open tasks are present even if they haven't pushed native
+  // canvas state. Any agent with a doing/validating task → "working".
+  // Any agent with a todo task (but no doing) → "working" (queued work).
+  // Native canvas state takes precedence when present — only fill gaps.
+  try {
+    const ACTIVE_STATUSES = ['doing', 'validating', 'todo']
+    const byAgent: Record<string, { bestStatus: string; taskTitle?: string }> = {}
+
+    for (const status of ACTIVE_STATUSES) {
+      const res = await fetch(`http://127.0.0.1:4445/tasks?status=${status}&limit=100`)
+      if (!res.ok) continue
+      const data = await res.json() as { tasks?: Array<{ assignee?: string; title?: string; status: string }> }
+      const tasks = data.tasks ?? []
+      for (const task of tasks) {
+        const assignee = task.assignee
+        if (!assignee || assignee === 'unassigned') continue
+        // Higher-priority status wins: doing > validating > todo
+        const existing = byAgent[assignee]
+        const priority = { doing: 0, validating: 1, todo: 2 }
+        const newPriority = priority[status as keyof typeof priority] ?? 99
+        const existingPriority = existing ? (priority[existing.bestStatus as keyof typeof priority] ?? 99) : 99
+        if (!existing || newPriority < existingPriority) {
+          byAgent[assignee] = { bestStatus: status, taskTitle: task.title }
+        }
+      }
+    }
+
+    // Merge derived states into agents — native canvas state takes precedence
+    const now = Date.now()
+    for (const [agentId, info] of Object.entries(byAgent)) {
+      if (agents[agentId]) continue // native state present — don't override
+      const derivedState = info.bestStatus === 'doing' ? 'working'
+        : info.bestStatus === 'validating' ? 'working'
+        : 'working' // todo → working (has queued work)
+      agents[agentId] = {
+        state: derivedState,
+        currentTask: info.taskTitle,
+        updatedAt: now,
+        source: 'task-derived',
+      }
+    }
+  } catch { /* task API not ready — not fatal */ }
+
   // ── Needs-attention call hook ───────────────────────────────────────────
   // Check for new needs-attention transitions BEFORE pushing to cloud.
   // The Fly canvas handler also triggers auto-calls, but this node-side hook


### PR DESCRIPTION
**Root cause:** Presence screen showed 'TEAM AT REST' during active sprints because agents only appear in canvas when they've pushed native canvas state (running processes). Most agents operate through the task board and are invisible to the presence wire.

**Fix:** `syncCanvas()` now queries the task API and derives presence state from open task assignments:
- `doing` task → agent appears as `working`
- `validating` task → agent appears as `working`  
- `todo` task → agent appears as `working` (queued work signals presence)

Native canvas state always takes precedence — task-derived state only fills gaps. `source: 'task-derived'` field distinguishes these from real-time agent signals.

**Before:** 0 agents visible (all doing/todo tasks but no native canvas state)
**After:** All agents with open tasks visible as `working` on presence screen

1896 tests pass. Closes task-1773386855719-y63nd3b5d.

@kai please merge — this is the fix that makes the presence screen actually alive during sprints.