### PR TITLE
feat(approvals): POST /run-approvals/:eventId/decide for iOS action buttons

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1095,6 +1095,7 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | GET | `/agents/:agentId/events` | List events. Query: `?runId=&type=&since=&limit=` |
 | GET | `/approvals/pending` | List pending approvals (review_requested events needing action). Query: `?agentId=&limit=` |
 | POST | `/approvals/:eventId/decide` | Submit approval decision. Body: `{ decision: "approve"|"reject", reviewer (required), comment? }`. Auto-unblocks run on approve. |
+| POST | `/run-approvals/:eventId/decide` | iOS lock screen action button endpoint. Body: `{ decision: "approve"|"reject", actor (required), reason? }`. Same effect as `/approvals/:eventId/decide` — emits canvas_input SSE on success. |
 | GET | `/agents/:agentId/runs/:runId/stream` | SSE stream for a specific run. Sends snapshot (run + recent events), then real-time events as they occur. Heartbeat every 15s. |
 | GET | `/runs/:runId/stream` | SSE stream for a run by ID (no agentId required). Cloud Presence surface subscribes here for live run activity. Sends snapshot then real-time events. Heartbeat every 15s. |
 | GET | `/agents/:agentId/stream` | SSE stream for all events for an agent. Sends snapshot (active run + recent events), then real-time events. Heartbeat every 15s. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -14595,6 +14595,55 @@ If your heartbeat shows **no active task** and **no next task**:
     }
   })
 
+  // POST /run-approvals/:eventId/decide — iOS lock screen action buttons
+  // Accepts approve/reject decisions from mobile clients directly.
+  // Mirrors /approval-queue/:id/decide but uses the run-approvals URL shape
+  // so iOS can construct the path from the eventId in the push payload.
+  app.post<{ Params: { eventId: string } }>('/run-approvals/:eventId/decide', async (request, reply) => {
+    const { eventId } = request.params
+    const body = request.body as {
+      decision?: string
+      actor?: string
+      reason?: string
+      rationale?: { choice?: string; considered?: string[]; constraint?: string }
+    }
+    if (!body?.decision || !['approve', 'reject'].includes(body.decision)) {
+      return reply.code(400).send({ error: 'decision must be "approve" or "reject"' })
+    }
+    if (!body?.actor) {
+      return reply.code(400).send({ error: 'actor is required' })
+    }
+    try {
+      const rationale = body.rationale ?? {
+        choice: body.decision === 'approve' ? 'Approved' : 'Rejected',
+        considered: ['approve', 'reject'],
+        constraint: `Mobile decision by ${body.actor}`,
+      }
+      const result = submitApprovalDecision({
+        eventId,
+        decision: body.decision as 'approve' | 'reject',
+        reviewer: body.actor,
+        comment: body.reason,
+        rationale: rationale as any,
+      })
+      // Emit canvas_input so Presence Layer reflects the decision
+      eventBus.emit({
+        id: `ra-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        type: 'canvas_input' as const,
+        timestamp: Date.now(),
+        data: {
+          action: 'decision',
+          approvalId: eventId,
+          decision: body.decision,
+          actor: body.actor,
+        },
+      })
+      return result
+    } catch (err: any) {
+      return reply.code(err.message.includes('not found') ? 404 : 400).send({ error: err.message })
+    }
+  })
+
   // ── Canvas Input ──────────────────────────────────────────────────────
   // Human → agent control seam for the Presence Layer.
   // Payload is intentionally small per COO spec: action + target + actor.


### PR DESCRIPTION
## Summary

Adds `POST /run-approvals/:eventId/decide` — a dedicated endpoint for iOS lock screen notification action buttons.

## Why

iOS notification action buttons need a predictable URL constructed from the `eventId` in the APNs push payload. This endpoint uses the same naming shape as the push payload so @swift can build the URL directly without extra lookups.

## What

- **Endpoint:** `POST /run-approvals/:eventId/decide`
- **Body:** `{ decision: 'approve'|'reject', actor (required), reason? }`
- **Effect:** Delegates to `submitApprovalDecision` (same as `/approval-queue/:id/decide`)
- **SSE:** Emits `canvas_input` so Presence Layer updates immediately
- **Rationale:** Auto-supplied if omitted (mobile clients won't know to send it)
- **Docs:** Route/docs contract passes (503/503), tsc clean

## Tests

1896 passing, 1 skipped — no regressions

Closes task-1773406652652-odl61n7bu