### PR TITLE
infra: launchctl plist for evi-presence-sync.sh

### DIFF
--- a/scripts/launchd/ai.reflectt.evi-presence-sync.plist
+++ b/scripts/launchd/ai.reflectt.evi-presence-sync.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.reflectt.evi-presence-sync</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/ryan/.openclaw/workspace/scripts/evi-presence-sync.sh</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/reflectt-evi-presence-sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/reflectt-evi-presence-sync-error.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Adds `scripts/launchd/ai.reflectt.evi-presence-sync.plist` so `evi-presence-sync.sh` auto-starts on Mac Daddy reboot.

## Follows PR #927

PR #927 shipped the script. This ships the launchd service definition.

## Install

```bash
cp scripts/launchd/ai.reflectt.evi-presence-sync.plist ~/Library/LaunchAgents/
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/ai.reflectt.evi-presence-sync.plist
```

## Already installed + verified on Mac Daddy

- Service running: pid 85339 (`launchctl list | grep evi-presence`)
- Posting every 60s to EVI
- EVI `/presence` shows builder/scout/ops after launchd-managed start

Closes task-1773408261964-r18zd7w8h