### PR TITLE
fix(dev): post-merge hook skips restart on non-main branches

### DIFF
--- a/scripts/post-merge-rebuild.sh
+++ b/scripts/post-merge-rebuild.sh
@@ -20,6 +20,22 @@ SERVICE_LOG="/tmp/reflectt-node.log"
 # Ensure PATH includes node/npm
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
+# ── Branch guard: only restart production server from main ──────────
+# Feature branches must never trigger a production restart.
+CURRENT_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] post-merge: skipping restart — branch is '$CURRENT_BRANCH' (not main)" | tee -a "$LOG_FILE"
+  exit 0
+fi
+
+# ── Branch guard: only restart production server from main ──────────
+# Feature branches must never trigger a production restart.
+CURRENT_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] post-merge: skipping restart — branch is '$CURRENT_BRANCH' (not main)" | tee -a "$LOG_FILE"
+  exit 0
+fi
+
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
 }


### PR DESCRIPTION
## Problem

Switching to a feature branch and merging/pulling would trigger the post-merge hook, which rebuilt reflectt-node from that branch's dist/ and restarted the production server. This killed the running production server and caused port conflicts.

**Root cause today:** `link/task-e3ztn8pq4-starter-compose` branch triggered the hook after a `git pull origin main` merge, starting a process that conflicted with the launchd-managed global install.

## Fix

Added a branch guard at the top of the hook:

```bash
CURRENT_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)"
if [[ "$CURRENT_BRANCH" != "main" ]]; then
  echo "post-merge: skipping restart — branch is '$CURRENT_BRANCH' (not main)"
  exit 0
fi
```

Production server should always run from the global npm install (`/opt/homebrew/bin/reflectt`). The hook should only restart via launchctl when merging into `main`.

Closes task-1773417928911-twkyqt8sa