### PR TITLE
feat(presence): widen AgentPresenceSchema state enum — all 9 states valid for emit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8959,7 +8959,9 @@ export async function createServer(): Promise<FastifyInstance> {
     spark: '#f59e0b', swift: '#06b6d4', kotlin: '#7c3aed', bookkeeper: '#10b981',
   }
 
-  type PresenceState = 'idle' | 'working' | 'needs-attention'
+  type PresenceState = 'idle' | 'working' | 'thinking' | 'rendering' | 'needs-attention' | 'urgent' | 'handoff' | 'decision' | 'waiting'
+
+  const VALID_PRESENCE_STATES: PresenceState[] = ['idle', 'working', 'thinking', 'rendering', 'needs-attention', 'urgent', 'handoff', 'decision', 'waiting']
 
   const AgentPresenceSchema = z.object({
     state: z.enum(['idle', 'working', 'thinking', 'rendering', 'needs-attention', 'urgent', 'handoff', 'decision', 'waiting']),
@@ -8988,7 +8990,7 @@ export async function createServer(): Promise<FastifyInstance> {
       reply.code(422)
       return {
         error: `Invalid presence: ${result.error.issues.map(i => i.message).join(', ')}`,
-        validStates: ['idle', 'working', 'needs-attention'],
+        validStates: VALID_PRESENCE_STATES,
       }
     }
 
@@ -8997,8 +8999,15 @@ export async function createServer(): Promise<FastifyInstance> {
     const identityColor = AGENT_IDENTITY_COLORS[agentId] || '#9ca3af'
 
     // Map presence state to canvas state for backward compatibility
+    // New states pass through directly to canvas (1:1 where names match)
     const canvasState: CanvasState = presenceState === 'needs-attention' ? 'decision'
       : presenceState === 'working' ? 'thinking'
+      : presenceState === 'thinking' ? 'thinking'
+      : presenceState === 'rendering' ? 'rendering'
+      : presenceState === 'urgent' ? 'urgent'
+      : presenceState === 'handoff' ? 'handoff'
+      : presenceState === 'decision' ? 'decision'
+      : presenceState === 'waiting' ? 'ambient'  // waiting = soft ambient (no ring)
       : 'ambient'
 
     // Store in canvasStateMap (backward compat with existing GET /canvas/state)

--- a/tests/agent-presence-states.test.ts
+++ b/tests/agent-presence-states.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for AgentPresenceSchema state enum widening.
+ * Verifies all 9 valid states are accepted and invalid states are rejected.
+ *
+ * task-1773442756827-va3jfqwqe
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createServer } from '../src/server.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeEach(async () => {
+  app = await createServer({ logger: false })
+  await app.ready()
+})
+
+afterEach(async () => {
+  await app.close()
+})
+
+const BASE_PAYLOAD = {
+  activeTask: { title: 'Test task', id: 'task-test-123' },
+  recency: '1m ago',
+  sensors: null,
+}
+
+const VALID_STATES = [
+  'idle',
+  'working',
+  'thinking',
+  'rendering',
+  'needs-attention',
+  'urgent',
+  'handoff',
+  'decision',
+  'waiting',
+] as const
+
+describe('AgentPresenceSchema — state enum', () => {
+  for (const state of VALID_STATES) {
+    it(`accepts state="${state}"`, async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/agents/link/canvas',
+        payload: { ...BASE_PAYLOAD, state },
+      })
+      expect(res.statusCode, `state="${state}" should be 200`).toBe(200)
+      const body = JSON.parse(res.body)
+      expect(body.success ?? body.name).toBeTruthy()
+    })
+  }
+
+  it('rejects an invalid state with 422', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agents/link/canvas',
+      payload: { ...BASE_PAYLOAD, state: 'flying' },
+    })
+    expect(res.statusCode).toBe(422)
+    const body = JSON.parse(res.body)
+    // Error may be wrapped by global handler — check it contains the enum rejection message
+    const errorText = JSON.stringify(body)
+    expect(errorText).toContain('Invalid')
+    expect(errorText).toContain('flying')
+  })
+
+  it('rejects missing state with 422', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agents/link/canvas',
+      payload: { ...BASE_PAYLOAD },
+    })
+    expect(res.statusCode).toBe(422)
+  })
+
+  it('accepts thinking with currentPr and progress', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agents/link/canvas',
+      payload: { ...BASE_PAYLOAD, state: 'thinking', currentPr: 944, progress: 0.65 },
+    })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('accepts urgent with attention block', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agents/link/canvas',
+      payload: {
+        ...BASE_PAYLOAD,
+        state: 'urgent',
+        attention: { type: 'block', taskId: 'task-abc', label: 'Blocked on deploy' },
+      },
+    })
+    expect(res.statusCode).toBe(200)
+  })
+
+  it('accepts decision with attention review', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agents/link/canvas',
+      payload: {
+        ...BASE_PAYLOAD,
+        state: 'decision',
+        attention: { type: 'review', taskId: 'task-abc' },
+      },
+    })
+    expect(res.statusCode).toBe(200)
+  })
+})


### PR DESCRIPTION
Closes task-1773442756827-va3jfqwqe.\n\n## Problem\n\n`POST /agents/:agentId/canvas` only accepted `idle|working|needs-attention`. Agents couldn't emit `thinking`, `rendering`, `urgent`, `handoff`, `decision`, or `waiting` — the states existed client-side but were rejected server-side.\n\n## Changes\n\n- `PresenceState` type updated: now `'idle' | 'working' | 'thinking' | 'rendering' | 'needs-attention' | 'urgent' | 'handoff' | 'decision' | 'waiting'`\n- `VALID_PRESENCE_STATES` const added for DRY error responses\n- 422 error response now shows all 9 valid states\n- Canvas state mapping extended (thinking→thinking, rendering→rendering, urgent→urgent, handoff→handoff, decision→decision, waiting→ambient)\n\n## Before/after\n```\nBefore: POST /agents/link/canvas { state: 'thinking' } → 422\nAfter:  POST /agents/link/canvas { state: 'thinking' } → 200 ✓\n         POST /agents/link/canvas { state: 'flying' }   → 422 ✗\n```\n\n14 new tests covering all 9 states. 1920 total pass. tsc clean.