### PR TITLE
feat(agents): GET /agents/:agent/timeline — unified activity feed

### DIFF
--- a/process/TASK-m0nh8zpok.md
+++ b/process/TASK-m0nh8zpok.md
@@ -1,0 +1,2 @@
+# TASK-m0nh8zpok process artifact
+PR: https://github.com/reflectt/reflectt-node/pull/950

--- a/public/docs.md
+++ b/public/docs.md
@@ -495,6 +495,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 |--------|------|-------------|
 | GET | `/agents/activity` | All agents activity summary |
 | GET | `/agents/:agent/activity` | Single agent activity |
+| GET | `/agents/:agent/timeline` | Unified activity feed: runs + task state changes + trust events. Each event: `{ type, timestamp, summary, taskId?, runId?, meta? }`. Query: `limit` (default 50, max 200), `since` (epoch ms). Returns reverse-chronological order. |
 | GET | `/analytics/foragents` | forAgents.dev analytics |
 | GET | `/metrics` | Operational metrics snapshot (tasks/chat/presence/activity rates + uptime) |
 | GET | `/metrics/daily` | Daily funnel metrics by channel. Query: `timezone` (IANA tz, default `America/Vancouver`) |

--- a/src/server.ts
+++ b/src/server.ts
@@ -11938,6 +11938,93 @@ If your heartbeat shows **no active task** and **no next task**:
     return { activity }
   })
 
+  // ── Agent Timeline ───────────────────────────────────────────────────
+  // Unified activity feed: runs + task state changes + trust events.
+  // Returns events in reverse-chronological order.
+  app.get<{ Params: { agent: string } }>('/agents/:agent/timeline', async (request) => {
+    const agent = String(request.params.agent || '').trim().toLowerCase()
+    if (!agent) return { error: 'agent is required' }
+
+    const rawQuery = request.query as Record<string, string>
+    const limit = Math.min(parseInt(rawQuery.limit || '50', 10), 200)
+    const since = rawQuery.since ? parseInt(rawQuery.since, 10) : undefined
+
+    const events: Array<{
+      type: 'run_complete' | 'task_state_change' | 'trust_event'
+      timestamp: number
+      summary: string
+      taskId?: string
+      runId?: string
+      meta?: Record<string, unknown>
+    }> = []
+
+    // ── Source 1: Agent runs (completed/failed) ────────────────────
+    try {
+      const { listAgentRuns } = await import('./agent-runs.js')
+      const agentRuns = listAgentRuns(agent, 'default', { limit, includeArchived: true })
+      for (const run of agentRuns) {
+        const endTs = run.completedAt ?? null
+        const ts = endTs ?? run.startedAt
+        if (since && ts < since) continue
+        if (run.status === 'idle' || run.status === 'working') continue // only completed runs
+        events.push({
+          type: 'run_complete',
+          timestamp: ts,
+          summary: `Run ${run.status}: ${run.objective.slice(0, 100)}`,
+          runId: run.id,
+          meta: {
+            status: run.status,
+            durationMs: endTs ? endTs - run.startedAt : null,
+          },
+        })
+      }
+    } catch { /* agent-runs not available */ }
+
+    // ── Source 2: Task state changes (from comments on agent tasks) ──
+    {
+      const agentAliases = getAgentAliases(agent)
+      const agentTasks = taskManager.listTasks({ assigneeIn: agentAliases })
+      for (const task of agentTasks) {
+        const comments = taskManager.getTaskComments(task.id)
+        for (const c of comments) {
+          if (since && c.timestamp < since) continue
+          // Status-change comments have category 'status_change' or contain [transition]
+          const isStateChange = c.category === 'status_change'
+            || /\[transition\]|\bdoing\b.*\bvalidating\b|\bvalidating\b.*\bdone\b|\btodo\b.*\bdoing\b|\bblocked\b/i.test(c.content)
+          if (!isStateChange) continue
+          events.push({
+            type: 'task_state_change',
+            timestamp: c.timestamp,
+            summary: `Task ${task.id}: ${c.content.slice(0, 120)}`,
+            taskId: task.id,
+            meta: { taskTitle: task.title, author: c.author },
+          })
+        }
+      }
+    }
+
+    // ── Source 3: Trust events ─────────────────────────────────────
+    try {
+      const { listTrustEvents } = await import('./trust-events.js')
+      const trustEvts = listTrustEvents({ agentId: agent, since, limit })
+      for (const te of trustEvts) {
+        events.push({
+          type: 'trust_event',
+          timestamp: te.occurredAt,
+          summary: `[${te.severity}] ${te.eventType}: ${te.summary}`,
+          taskId: te.taskId ?? undefined,
+          meta: { eventType: te.eventType, severity: te.severity },
+        })
+      }
+    } catch { /* trust-events not available */ }
+
+    // Sort reverse-chrono and cap at limit
+    events.sort((a, b) => b.timestamp - a.timestamp)
+    const sliced = events.slice(0, limit)
+
+    return { agent, timeline: sliced, count: sliced.length }
+  })
+
   // ============ TEAM MANIFEST ENDPOINT ============
 
   function parseMarkdownSections(markdown: string): Array<{ heading: string; level: number; content: string }> {

--- a/tests/agent-timeline.test.ts
+++ b/tests/agent-timeline.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createServer } from '../src/server.js'
+
+describe('GET /agents/:agent/timeline', () => {
+  let app: Awaited<ReturnType<typeof createServer>>
+
+  beforeEach(async () => {
+    app = await createServer({ logger: false })
+    await app.ready()
+  })
+
+  it('returns 200 with timeline array + count', async () => {
+    const res = await app.inject({ method: 'GET', url: '/agents/link/timeline' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body).toHaveProperty('agent', 'link')
+    expect(body).toHaveProperty('timeline')
+    expect(body).toHaveProperty('count')
+    expect(Array.isArray(body.timeline)).toBe(true)
+    expect(typeof body.count).toBe('number')
+  })
+
+  it('each event has type, timestamp, summary', async () => {
+    const res = await app.inject({ method: 'GET', url: '/agents/link/timeline' })
+    const body = JSON.parse(res.body)
+    for (const event of body.timeline) {
+      expect(['run_complete', 'task_state_change', 'trust_event']).toContain(event.type)
+      expect(typeof event.timestamp).toBe('number')
+      expect(typeof event.summary).toBe('string')
+    }
+  })
+
+  it('supports ?limit= param', async () => {
+    const res = await app.inject({ method: 'GET', url: '/agents/link/timeline?limit=5' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.timeline.length).toBeLessThanOrEqual(5)
+  })
+
+  it('supports ?since= param (filters by timestamp)', async () => {
+    const futureTs = Date.now() + 1_000_000_000
+    const res = await app.inject({ method: 'GET', url: `/agents/link/timeline?since=${futureTs}` })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    // No events after a far-future timestamp
+    expect(body.timeline.length).toBe(0)
+  })
+
+  it('returns events in reverse-chronological order', async () => {
+    // Create a task + comment to seed at least one event
+    const task = await app.inject({
+      method: 'POST', url: '/tasks',
+      payload: { title: 'timeline order test', assignee: 'link', actor: 'kai' },
+    })
+    const taskBody = JSON.parse(task.body)
+    if (taskBody.task) {
+      await app.inject({
+        method: 'POST', url: `/tasks/${taskBody.task.id}/comments`,
+        payload: { content: '[transition] doing → validating', author: 'kai', category: 'status_change' },
+      })
+    }
+
+    const res = await app.inject({ method: 'GET', url: '/agents/link/timeline' })
+    const body = JSON.parse(res.body)
+    const timestamps = body.timeline.map((e: any) => e.timestamp)
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i - 1])
+    }
+  })
+
+  it('caps at limit=200 even if more requested', async () => {
+    const res = await app.inject({ method: 'GET', url: '/agents/link/timeline?limit=999' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.timeline.length).toBeLessThanOrEqual(200)
+  })
+})


### PR DESCRIPTION
Closes task-1773445200939-m0nh8zpok.\n\nUnified activity timeline for any agent. Merges:\n- **run_complete** — finished agent_runs (completed/failed/cancelled)\n- **task_state_change** — transition comments on agent-assigned tasks\n- **trust_event** — trust events for this agent\n\nAll sorted reverse-chrono, capped at `?limit` (max 200), filterable by `?since` (epoch ms).\n\n**Done criteria:**\n- [x] Returns array in reverse-chronological order\n- [x] Each event has type, timestamp, summary\n- [x] ?limit and ?since supported\n- [x] 6 tests covering all criteria\n\n1932 tests pass.