### PR TITLE
fix(workflows): add metadata.eta in pr-review-demo synthetic task

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14860,6 +14860,7 @@ If your heartbeat shows **no active task** and **no next task**:
         createdBy: 'system',
         priority: 'P2',
         metadata: {
+          eta: '5m',
           lane: 'workflow',
           source: 'workflow-regression',
           reflection_exempt: true,


### PR DESCRIPTION
Follow-up fix for #955.

## Issue
`POST /workflows/pr-review-demo` failed at runtime with:
"Status contract: doing requires metadata.eta".

## Fix
- adds `metadata.eta: "5m"` when the endpoint auto-creates the synthetic demo task in `doing` status.

## Validation
- `npm run build` passes.
