### PR TITLE
feat(node): agent-exec guardrail — domain allowlist + action scope limiter (task-1773464158936-siapmabts)

### DIFF
--- a/src/agent-exec-guardrail.test.ts
+++ b/src/agent-exec-guardrail.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { checkActionAllowed, requiresApprovalGate } from './agent-exec-guardrail.js'
+
+describe('checkActionAllowed', () => {
+  it('allows github_issue_create with github.com domain', () => {
+    const result = checkActionAllowed('github_issue_create', 'https://github.com/owner/repo')
+    assert.equal(result.allowed, true)
+    assert.equal(result.reason, undefined)
+  })
+
+  it('allows github_issue_create with no target', () => {
+    const result = checkActionAllowed('github_issue_create')
+    assert.equal(result.allowed, true)
+  })
+
+  it('denies unknown action with reason', () => {
+    // @ts-expect-error testing unknown kind
+    const result = checkActionAllowed('unknown_action')
+    assert.equal(result.allowed, false)
+    assert.ok(result.reason?.includes('unknown_action'))
+    assert.ok(result.reason?.includes('approved action list'))
+  })
+
+  it('denies out-of-scope domain with reason', () => {
+    const result = checkActionAllowed('github_issue_create', 'https://evil.com/owner/repo')
+    assert.equal(result.allowed, false)
+    assert.ok(result.reason?.includes('evil.com'))
+    assert.ok(result.reason?.includes('approved domain list'))
+  })
+
+  it('allows subdomain of github.com', () => {
+    const result = checkActionAllowed('github_issue_create', 'https://api.github.com/repos/owner/repo/issues')
+    assert.equal(result.allowed, true)
+  })
+
+  it('does not match partial domain (githubx.com)', () => {
+    const result = checkActionAllowed('github_issue_create', 'https://githubx.com/owner/repo')
+    assert.equal(result.allowed, false)
+    assert.ok(result.reason?.includes('githubx.com'))
+  })
+
+  it('ignores non-URL target strings (no hostname to check)', () => {
+    // If target is not a URL, URL parsing returns null and no domain check is done
+    const result = checkActionAllowed('github_issue_create', 'owner/repo')
+    assert.equal(result.allowed, true)
+  })
+})
+
+describe('requiresApprovalGate', () => {
+  it('returns true for github_issue_create', () => {
+    assert.equal(requiresApprovalGate('github_issue_create'), true)
+  })
+
+  it('returns true for all v1 actions (always requires human approval)', () => {
+    // All v1 actions are irreversible — gate is always on
+    const kinds = ['github_issue_create'] as const
+    for (const kind of kinds) {
+      assert.equal(requiresApprovalGate(kind), true)
+    }
+  })
+})

--- a/src/agent-exec-guardrail.ts
+++ b/src/agent-exec-guardrail.ts
@@ -1,0 +1,25 @@
+import type { RunKind } from "./agent-interface.js";
+
+export const ALLOWED_ACTIONS: RunKind[] = ["github_issue_create"];
+export const ALLOWED_DOMAINS: string[] = ["github.com"];
+
+export function checkActionAllowed(
+  kind: RunKind,
+  target?: string
+): { allowed: boolean; reason?: string } {
+  if (!ALLOWED_ACTIONS.includes(kind)) {
+    return { allowed: false, reason: `Action "${kind}" is not in the approved action list` };
+  }
+  if (target) {
+    const url = (() => { try { return new URL(target); } catch { return null; } })();
+    if (url && !ALLOWED_DOMAINS.some(d => url.hostname === d || url.hostname.endsWith("." + d))) {
+      return { allowed: false, reason: `Domain "${url.hostname}" is not in the approved domain list` };
+    }
+  }
+  return { allowed: true };
+}
+
+export function requiresApprovalGate(_kind: RunKind): boolean {
+  // All v1 actions are irreversible — always require human approval
+  return true;
+}

--- a/src/agent-interface.ts
+++ b/src/agent-interface.ts
@@ -9,6 +9,8 @@
  * Task: task-1773257734617-6fvzfl52z
  */
 
+import { checkActionAllowed } from "./agent-exec-guardrail.js";
+
 export type RunKind = 'github_issue_create'
 export type RunStatus = 'queued' | 'running' | 'awaiting_approval' | 'completed' | 'failed' | 'rejected'
 
@@ -60,6 +62,21 @@ export function createRun(kind: RunKind, input: Record<string, unknown>): AgentI
     log: [],
   }
   runs.set(run.id, run)
+
+  // Guardrail check: deny non-approved actions or out-of-scope domains immediately
+  const target = typeof input.repo === 'string' ? input.repo : undefined
+  const guard = checkActionAllowed(kind, target)
+  if (!guard.allowed) {
+    run.status = 'failed'
+    run.result = { outcome: 'failed', errorMessage: guard.reason, recoveryHint: 'Only approved actions and domains are permitted.' }
+    run.log.push({
+      type: 'step_failed',
+      timestamp: Date.now(),
+      payload: { step: 'guardrail', reason: guard.reason },
+    })
+    run.updatedAt = Date.now()
+  }
+
   return run
 }
 


### PR DESCRIPTION
Domain allowlist + action scope guardrail for agent-interface runs. Wired into run creation path — non-approved actions/domains fail immediately with explicit denial reason logged. All actions require human approval gate.

Task: task-1773464158936-siapmabts