### PR TITLE
fix(node): use "from" column in auto-wake dedup query — no such column: sender

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -553,7 +553,7 @@ async function main() {
         const BROADCAST_DEDUP_WINDOW_MS = 60_000
         const db = getDb()
         const recentBroadcast = db.prepare(
-          "SELECT 1 FROM chat_messages WHERE sender = 'system' AND content LIKE '%Server restarted%' AND timestamp > ? LIMIT 1",
+          "SELECT 1 FROM chat_messages WHERE \"from\" = 'system' AND content LIKE '%Server restarted%' AND timestamp > ? LIMIT 1",
         ).get(Date.now() - BROADCAST_DEDUP_WINDOW_MS)
         if (recentBroadcast) {
           console.log('🔔 Auto-wake: skipped (duplicate within 60s)')


### PR DESCRIPTION
Closes task-1773482659921-uc1jojb5c

## Root cause
`chat_messages` schema uses `"from"` (quoted reserved word) as the sender column, not `sender`. The auto-wake dedup guard was querying `sender = 'system'` which fails with:

```
⚠️  Auto-wake failed: no such column: sender
```

This fires on every server restart.

## Fix
One-line change in `src/index.ts`:
```sql
-- before
WHERE sender = 'system'

-- after  
WHERE "from" = 'system'
```

tsc clean ✅  531 routes ✅