### PR TITLE
fix(node): suppress ArtifactMirror source-not-found noise in prod install

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8894,9 +8894,14 @@ export async function createServer(): Promise<FastifyInstance> {
           if (mirrorResult?.mirrored) {
             console.log(`[ArtifactMirror] Mirrored ${mirrorResult.filesCopied} file(s) for ${task.id} → ${mirrorResult.destination}`)
           } else if (mirrorResult && !mirrorResult.mirrored) {
-            // Important: failures here are what make artifacts feel "randomly missing" across workspaces.
-            // Keep it non-fatal, but log loudly so we can diagnose deployment/path issues.
-            console.warn(`[ArtifactMirror] FAILED for ${task.id}: ${mirrorResult.error || 'unknown error'} (source=${mirrorResult.source})`)
+            // "Source artifact not found" is expected in prod installs where process/*.md
+            // files live only in the dev workspace, not the npm package directory.
+            // Downgrade to debug-level (no console output) for source-not-found; keep
+            // warn only for genuine I/O failures (permissions, disk full, etc.).
+            const isSourceNotFound = mirrorResult.error?.includes('not found') || mirrorResult.error?.includes('Not a process/')
+            if (!isSourceNotFound) {
+              console.warn(`[ArtifactMirror] FAILED for ${task.id}: ${mirrorResult.error || 'unknown error'} (source=${mirrorResult.source})`)
+            }
           }
         } catch (err) {
           console.warn(`[ArtifactMirror] ERROR for ${task.id}: ${(err as Error).message}`)


### PR DESCRIPTION
Closes task-1773482676162-t2idqvblt

## Problem
Production logs flooded with:
```
[ArtifactMirror] FAILED for task-xxx: Source artifact not found (checked all ~/.openclaw/workspace* roots) (source=/opt/homebrew/lib/node_modules/reflectt-node/process/TASK-xxx.md)
```

In a prod npm install, `process/TASK-*.md` files live only in the dev workspace — they're never packaged. The mirror correctly searches all `~/.openclaw/workspace*` roots but when none contain the file it logs FAILED on every task transition.

## Fix
Distinguish expected (source simply not present) from unexpected (I/O error):
- `error includes 'not found'` or `'Not a process/'` → **silent** (no log)  
- Any other error → **still warns** as before

Mirror behavior is unchanged — it already skips gracefully. This only quiets the noise.

tsc clean ✅  531 routes ✅