### PR TITLE
fix(node): ArtifactMirror skips gracefully when process/TASK files missing in prod

### DIFF
--- a/src/artifact-mirror.ts
+++ b/src/artifact-mirror.ts
@@ -125,12 +125,15 @@ export async function mirrorArtifacts(artifactPath: string): Promise<MirrorResul
   try {
     const lookup = await findArtifactSource(artifactPath)
     if (!lookup) {
+      // Normal in prod installs (e.g. /opt/homebrew/lib/node_modules/reflectt-node/):
+      // process/TASK-*.md files live in dev workspaces, not the global install.
+      // Return mirrored=false with no error — caller should skip silently.
       return {
         mirrored: false,
         source: sourcePath,
         destination: destPath,
         filesCopied: 0,
-        error: 'Source artifact not found (checked all ~/.openclaw/workspace* roots)',
+        // no error field — "not found" is expected in prod, not an error condition
       }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8894,13 +8894,10 @@ export async function createServer(): Promise<FastifyInstance> {
           if (mirrorResult?.mirrored) {
             console.log(`[ArtifactMirror] Mirrored ${mirrorResult.filesCopied} file(s) for ${task.id} → ${mirrorResult.destination}`)
           } else if (mirrorResult && !mirrorResult.mirrored) {
-            // "Source artifact not found" is expected in prod installs where process/*.md
-            // files live only in the dev workspace, not the npm package directory.
-            // Downgrade to debug-level (no console output) for source-not-found; keep
-            // warn only for genuine I/O failures (permissions, disk full, etc.).
-            const isSourceNotFound = mirrorResult.error?.includes('not found') || mirrorResult.error?.includes('Not a process/')
-            if (!isSourceNotFound) {
-              console.warn(`[ArtifactMirror] FAILED for ${task.id}: ${mirrorResult.error || 'unknown error'} (source=${mirrorResult.source})`)
+            // Skip silently when no error — source simply not found (expected in prod installs).
+            // Only warn on genuine I/O failures (permissions, disk full, etc.).
+            if (mirrorResult.error) {
+              console.warn(`[ArtifactMirror] FAILED for ${task.id}: ${mirrorResult.error} (source=${mirrorResult.source})`)
             }
           }
         } catch (err) {

--- a/tests/artifact-mirror.test.ts
+++ b/tests/artifact-mirror.test.ts
@@ -57,11 +57,13 @@ describe('Artifact Mirror', () => {
     expect(result.error).toContain('Not a process/')
   })
 
-  it('returns error for non-existent source', async () => {
+  it('skips gracefully for non-existent source (no error — expected in prod)', async () => {
     const mod = await import('../src/artifact-mirror.js')
     const result = await mod.mirrorArtifacts('process/does-not-exist')
     expect(result.mirrored).toBe(false)
-    expect(result.error).toContain('not found')
+    // No error field when source simply not found — this is expected in prod installs
+    // where process/TASK-*.md files live only in dev workspaces.
+    expect(result.error).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Fixes repeated prod log warnings.

Root cause: process/TASK-*.md files only exist in dev workspaces, not the prod install. 'Not found' is expected — not an error.

- artifact-mirror.ts: return `{ mirrored: false }` with NO error field when source not found
- server.ts: only warn when mirrorResult.error is truthy
- tests: updated expectation

531/531 contract ✅ · 10/10 artifact-mirror tests ✅ · task-1773482676162-t2idqvblt