### PR TITLE
feat(node): review auto-close bridge — [review] approved: comment → validating→done

### DIFF
--- a/src/review-autoclose.ts
+++ b/src/review-autoclose.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Review auto-close bridge.
+ *
+ * Parses structured `[review] approved:` / `[review] rejected:` comments
+ * posted by the assigned reviewer and auto-fires the review decision,
+ * transitioning the task from validating→done or validating→todo.
+ *
+ * Safety invariants:
+ *   - Only fires when task.status === 'validating'
+ *   - Author must match task.reviewer (exact match, case-insensitive)
+ *   - Parsed via strict regex — no fuzzy matching
+ *   - Idempotent: ignores if task already past validating
+ *   - Emits trust event on self-review attempt (reviewer === assignee)
+ *   - Dry-run safe: `dryRun=true` returns parsed result without mutating
+ *
+ * Comment format (reviewer posts in task-comments):
+ *   [review] approved: <comment text>
+ *   [review] rejected: <comment text>
+ *
+ * task-1773490646984-eujrozhai
+ */
+
+/** Result of parsing a comment for a review signal. */
+export interface ReviewSignal {
+  detected: boolean
+  decision?: 'approve' | 'reject'
+  comment?: string
+}
+
+/**
+ * Parse a task comment body for a structured review signal.
+ *
+ * Accepts:
+ *   [review] approved: <comment>
+ *   [review] rejected: <comment>
+ *   [review] approved (no trailing text also accepted)
+ *
+ * Case-insensitive. Leading/trailing whitespace ignored.
+ */
+export function parseReviewSignal(content: string): ReviewSignal {
+  const normalized = content.trim()
+  // Match: [review] approved: ... or [review] rejected: ...
+  const match = normalized.match(/^\[review\]\s+(approved|rejected)[:\s]*(.*)/i)
+  if (!match) return { detected: false }
+  const decision = match[1].toLowerCase() === 'approved' ? 'approve' : 'reject'
+  const comment = (match[2] ?? '').trim() || (decision === 'approve' ? 'Approved via structured review comment' : 'Rejected via structured review comment')
+  return { detected: true, decision, comment }
+}
+
+export interface AutoCloseContext {
+  taskId: string
+  taskStatus: string
+  taskReviewer: string | null | undefined
+  taskAssignee: string | null | undefined
+  commentAuthor: string
+  commentContent: string
+  dryRun?: boolean
+}
+
+export interface AutoCloseResult {
+  fired: boolean
+  decision?: 'approve' | 'reject'
+  reason?: string
+  dryRun?: boolean
+}
+
+/**
+ * Evaluate whether a comment should trigger auto-close, and return the decision.
+ * Does NOT mutate — caller is responsible for invoking the review endpoint.
+ *
+ * Returns fired=true + decision when all safety checks pass.
+ * Returns fired=false with reason when skipped.
+ */
+export function evaluateAutoClose(ctx: AutoCloseContext): AutoCloseResult {
+  const { taskStatus, taskReviewer, taskAssignee, commentAuthor, commentContent, dryRun } = ctx
+
+  // Only act on validating tasks
+  if (taskStatus !== 'validating') {
+    return { fired: false, reason: `task is ${taskStatus}, not validating` }
+  }
+
+  // Must have an assigned reviewer
+  if (!taskReviewer) {
+    return { fired: false, reason: 'task has no assigned reviewer' }
+  }
+
+  // Author must be the assigned reviewer
+  if (commentAuthor.trim().toLowerCase() !== taskReviewer.trim().toLowerCase()) {
+    return { fired: false, reason: `author "${commentAuthor}" is not the assigned reviewer "${taskReviewer}"` }
+  }
+
+  // Parse the comment
+  const signal = parseReviewSignal(commentContent)
+  if (!signal.detected) {
+    return { fired: false, reason: 'no structured [review] signal found in comment' }
+  }
+
+  return {
+    fired: true,
+    decision: signal.decision,
+    dryRun,
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6052,6 +6052,59 @@ export async function createServer(): Promise<FastifyInstance> {
         }).catch(() => { /* knowledge indexing is best-effort */ })
       }
 
+      // ── Review auto-close bridge ──────────────────────────────────────────
+      // If the assigned reviewer posts a structured [review] approved/rejected comment,
+      // auto-fire the review decision without requiring a separate API call.
+      // Safety: validating-only, reviewer-identity-gated, idempotent, audited.
+      {
+        const taskForReview = taskManager.getTask(resolved.resolvedId)
+        if (taskForReview) {
+          const { evaluateAutoClose } = await import('./review-autoclose.js')
+          const autoClose = evaluateAutoClose({
+            taskId: resolved.resolvedId,
+            taskStatus: taskForReview.status,
+            taskReviewer: taskForReview.reviewer,
+            taskAssignee: taskForReview.assignee,
+            commentAuthor: data.author,
+            commentContent: data.content,
+          })
+          if (autoClose.fired && autoClose.decision) {
+            // Self-review detection (non-blocking — just emits trust event)
+            if (
+              taskForReview.reviewer &&
+              taskForReview.assignee &&
+              taskForReview.reviewer.trim().toLowerCase() === taskForReview.assignee.trim().toLowerCase()
+            ) {
+              import('./trust-events.js').then(({ emitTrustEvent }) => {
+                emitTrustEvent({
+                  agentId: data.author,
+                  eventType: 'self_review_violation',
+                  context: { taskId: resolved.resolvedId, taskTitle: taskForReview.title, reviewer: taskForReview.reviewer, assignee: taskForReview.assignee, decision: autoClose.decision, source: 'review-autoclose' },
+                })
+              }).catch(() => {})
+            }
+            // Fire the review decision by injecting into the existing /tasks/:id/review route.
+            // Using inject() keeps all guards (duplicate closure, QA bundle gate, etc.) intact.
+            const reviewComment = `[auto-close] ${autoClose.decision === 'approve' ? 'Approved' : 'Rejected'} via structured [review] comment (comment ID: ${comment.id})`
+            setImmediate(() => {
+              app.inject({
+                method: 'POST',
+                url: `/tasks/${resolved.resolvedId}/review`,
+                payload: { reviewer: data.author, decision: autoClose.decision, comment: reviewComment },
+              }).then(res => {
+                if (res.statusCode >= 400) {
+                  console.warn(`[review-autoclose] Review injection failed for ${resolved.resolvedId}: ${res.statusCode} ${res.body.slice(0, 120)}`)
+                } else {
+                  console.log(`[review-autoclose] ${autoClose.decision} fired for ${resolved.resolvedId} by ${data.author}`)
+                }
+              }).catch((err: unknown) => {
+                console.warn(`[review-autoclose] inject error for ${resolved.resolvedId}:`, err)
+              })
+            })
+          }
+        }
+      }
+
       // Task-comments are now primary execution comms:
       // fan out inbox-visible notifications to assignee/reviewer + explicit @mentions.
       // Notification routing respects per-agent preferences (quiet hours, mute, filters).

--- a/tests/review-autoclose.test.ts
+++ b/tests/review-autoclose.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for review-autoclose bridge.
+ * task-1773490646984-eujrozhai
+ */
+import { describe, it, expect } from 'vitest'
+import { parseReviewSignal, evaluateAutoClose } from '../src/review-autoclose.js'
+
+describe('parseReviewSignal', () => {
+  it('detects approved', () => {
+    const r = parseReviewSignal('[review] approved: looks good')
+    expect(r.detected).toBe(true)
+    expect(r.decision).toBe('approve')
+    expect(r.comment).toBe('looks good')
+  })
+
+  it('detects rejected', () => {
+    const r = parseReviewSignal('[review] rejected: needs rework')
+    expect(r.detected).toBe(true)
+    expect(r.decision).toBe('reject')
+    expect(r.comment).toBe('needs rework')
+  })
+
+  it('is case-insensitive', () => {
+    expect(parseReviewSignal('[REVIEW] Approved: ok').decision).toBe('approve')
+    expect(parseReviewSignal('[Review] Rejected: no').decision).toBe('reject')
+  })
+
+  it('accepts approved with no trailing comment', () => {
+    const r = parseReviewSignal('[review] approved')
+    expect(r.detected).toBe(true)
+    expect(r.decision).toBe('approve')
+    expect(r.comment).toBeTruthy()
+  })
+
+  it('ignores non-structured comments', () => {
+    expect(parseReviewSignal('approved')).toMatchObject({ detected: false })
+    expect(parseReviewSignal('LGTM ✅')).toMatchObject({ detected: false })
+    expect(parseReviewSignal('task approved')).toMatchObject({ detected: false })
+    expect(parseReviewSignal('[review]')).toMatchObject({ detected: false })
+  })
+
+  it('ignores partial matches in longer text', () => {
+    // Must start with [review]
+    expect(parseReviewSignal('some text [review] approved: ok')).toMatchObject({ detected: false })
+  })
+})
+
+describe('evaluateAutoClose', () => {
+  const base = {
+    taskId: 'task-123',
+    taskStatus: 'validating' as const,
+    taskReviewer: 'pixel',
+    taskAssignee: 'link',
+    commentAuthor: 'pixel',
+    commentContent: '[review] approved: all criteria met',
+  }
+
+  it('fires approve when all checks pass', () => {
+    const r = evaluateAutoClose(base)
+    expect(r.fired).toBe(true)
+    expect(r.decision).toBe('approve')
+  })
+
+  it('fires reject correctly', () => {
+    const r = evaluateAutoClose({ ...base, commentContent: '[review] rejected: needs fixes' })
+    expect(r.fired).toBe(true)
+    expect(r.decision).toBe('reject')
+  })
+
+  it('does not fire when task is not validating', () => {
+    expect(evaluateAutoClose({ ...base, taskStatus: 'doing' }).fired).toBe(false)
+    expect(evaluateAutoClose({ ...base, taskStatus: 'done' }).fired).toBe(false)
+    expect(evaluateAutoClose({ ...base, taskStatus: 'todo' }).fired).toBe(false)
+  })
+
+  it('does not fire when author is not the reviewer', () => {
+    const r = evaluateAutoClose({ ...base, commentAuthor: 'kai' })
+    expect(r.fired).toBe(false)
+    expect(r.reason).toContain('not the assigned reviewer')
+  })
+
+  it('does not fire when reviewer is null', () => {
+    const r = evaluateAutoClose({ ...base, taskReviewer: null })
+    expect(r.fired).toBe(false)
+    expect(r.reason).toContain('no assigned reviewer')
+  })
+
+  it('does not fire on unstructured comment', () => {
+    const r = evaluateAutoClose({ ...base, commentContent: 'Looks great! LGTM' })
+    expect(r.fired).toBe(false)
+    expect(r.reason).toContain('no structured [review] signal')
+  })
+
+  it('reviewer match is case-insensitive', () => {
+    const r = evaluateAutoClose({ ...base, commentAuthor: 'PIXEL' })
+    expect(r.fired).toBe(true)
+  })
+
+  it('returns dryRun flag when set', () => {
+    const r = evaluateAutoClose({ ...base, dryRun: true })
+    expect(r.fired).toBe(true)
+    expect(r.dryRun).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes task-1773490646984-eujrozhai

## The problem

Reviewer posts approval in chat/task-comments. Task stays stuck in `validating` until someone separately calls `POST /tasks/:id/review`. That's the recurring friction.

## The fix

When the assigned reviewer posts a structured comment in task-comments, auto-fire the review decision:
```
[review] approved: all criteria met
[review] rejected: needs rework before merge
```

## Safety invariants

- **validating-only gate**: no-op on any other status
- **Reviewer identity check**: author must match `task.reviewer` (case-insensitive)
- **Self-review detection**: emits `self_review_violation` trust event if reviewer === assignee
- **Reuses existing route**: `app.inject()` into `POST /tasks/:id/review` — all guards (duplicate closure check, QA bundle gate, etc.) stay active
- **Idempotent**: non-blocking via `setImmediate`, failures logged not thrown
- **Strict regex only**: `/^\[review\]\s+(approved|rejected)[:\s]*(.*)/i` — no fuzzy matching

## New file

`src/review-autoclose.ts` — pure logic module, no server deps, fully testable

## Tests

14/14 in `tests/review-autoclose.test.ts`:
- parseReviewSignal: approved/rejected/case-insensitive/no-comment/unstructured/partial
- evaluateAutoClose: fires/reject/non-validating/wrong-author/no-reviewer/unstructured/case-insensitive/dryRun

**tsc clean ✅  534 routes ✅  14 new tests ✅**