### PR TITLE
feat(node): insight lifecycle sync — task done auto-closes linked insight

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -13,6 +13,7 @@ import { createTaskStateAdapterFromEnv, type TaskStateAdapter } from './taskStat
 import { getDb, importJsonlIfNeeded, safeJsonStringify, safeJsonParse } from './db.js'
 import { isTestHarnessTask, TEST_TASK_EXCLUDE_SQL } from './test-task-filter.js'
 import { assertDuplicateClosureHasCanonicalRefs } from './duplicateClosureGuard.js'
+import { closeInsightById } from './insight-mutation.js'
 import { getAgentAliases } from './assignment.js'
 import { getAgentLane } from './lane-config.js'
 import type Database from 'better-sqlite3'
@@ -1752,7 +1753,33 @@ class TaskManager {
         } catch { /* never fail a task close */ }
       })()
     }
-    
+
+    // ── Insight lifecycle sync ────────────────────────────────────────────
+    // When a task with metadata.insight_id is closed (status→done), auto-close
+    // the linked insight so candidate backlog reflects true unresolved work.
+    // Safety: best-effort (never blocks task completion), audit-logged by closeInsightById.
+    if (updates.status === 'done' && task.status !== 'done') {
+      const meta = task.metadata as Record<string, unknown> | null | undefined
+      const insightId = typeof meta?.insight_id === 'string' ? meta.insight_id.trim() : null
+      if (insightId) {
+        void (async () => {
+          try {
+            const actor = updates.assignee ?? task.assignee ?? 'system'
+            const result = closeInsightById(insightId, {
+              actor,
+              reason: `Task ${id} closed (${task.title?.slice(0, 60) ?? 'no title'}) — auto lifecycle sync`,
+              notes: `Linked task ${id} transitioned to done. Insight auto-closed by lifecycle sync.`,
+            })
+            if (!result.success) {
+              console.warn(`[insight-lifecycle-sync] Failed to close insight ${insightId} for task ${id}: ${result.error}`)
+            }
+          } catch (err) {
+            console.warn(`[insight-lifecycle-sync] Unexpected error closing insight ${insightId}:`, err)
+          }
+        })()
+      }
+    }
+
     return updated
   }
 

--- a/tests/insight-lifecycle-sync.test.ts
+++ b/tests/insight-lifecycle-sync.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests: insight lifecycle sync on task done
+ * task-1773491932598-izynfta9z
+ *
+ * When a task with metadata.insight_id transitions to done, the linked
+ * insight must auto-close so the candidate backlog reflects true unresolved work.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { createServer } from '../src/server.js'
+import { getDb } from '../src/db.js'
+import { _clearInsightMutationAuditLog, getRecentInsightMutationAudits } from '../src/insight-mutation.js'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+  app = await createServer()
+  await app.ready()
+})
+
+beforeEach(() => {
+  if (!process.env.REFLECTT_TEST_MODE) throw new Error('Refusing unscoped DELETE outside test mode')
+  const db = getDb()
+  db.prepare('DELETE FROM insights').run()
+  db.prepare("DELETE FROM tasks WHERE metadata LIKE '%insight_id%' OR metadata LIKE '%is_test%'").run()
+  _clearInsightMutationAuditLog()
+})
+
+function insertInsight(id: string, status = 'candidate') {
+  const db = getDb()
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO insights (
+      id, cluster_key, workflow_stage, failure_family, impacted_unit,
+      title, status, score, priority, reflection_ids, independent_count,
+      evidence_refs, authors, promotion_readiness, recurring_candidate,
+      task_id, metadata, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0.5, 'P2', '[]', 1, '[]', '[]', 0.5, 0, NULL, NULL, ?, ?)
+  `).run(id, 'workflow::review::closeout', 'workflow', 'review', 'closeout',
+    'Test insight', status, now, now)
+}
+
+async function createTask(extra: Record<string, unknown> = {}) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/tasks',
+    payload: {
+      title: 'test insight sync task',
+      assignee: 'link',
+      reviewer: 'sage',
+      done_criteria: ['criterion one'],
+      metadata: { is_test: true, ...extra },
+    },
+  })
+  return JSON.parse(res.body).task
+}
+
+/**
+ * Move a task to done via non-code lane (qa_bundle.non_code=true).
+ * Avoids process file + PR integrity requirements in test environment.
+ */
+async function moveTaskToDone(taskId: string) {
+  // todo → doing (wip_override: test env has real doing tasks that hit cap)
+  await app.inject({
+    method: 'PATCH',
+    url: `/tasks/${taskId}`,
+    payload: { status: 'doing', actor: 'link', metadata: { wip_override: 'test-harness bypass' } },
+  })
+
+  // doing → validating via non-code lane (no PR/process file required)
+  // Use URL artifact_path to pass the retrievability check; doc_only skips commit_sha
+  await app.inject({
+    method: 'PATCH',
+    url: `/tasks/${taskId}`,
+    payload: {
+      status: 'validating',
+      actor: 'link',
+      metadata: {
+        review_handoff: {
+          task_id: taskId,
+          artifact_path: 'https://github.com/reflectt/reflectt-node/pull/987',
+          known_caveats: 'test-harness',
+          doc_only: true,
+          reviewer: 'sage',
+        },
+        qa_bundle: {
+          non_code: true,
+          lane: 'ops',
+          summary: 'insight lifecycle sync test',
+          artifact_links: ['https://github.com/reflectt/reflectt-node/pull/987'],
+          changed_files: ['src/tasks.ts'],
+          screenshot_proof: ['https://github.com/reflectt/reflectt-node/pull/987'],
+          reviewer: 'sage',
+        },
+      },
+    },
+  })
+
+  // validating → done via review approval
+  await app.inject({
+    method: 'POST',
+    url: `/tasks/${taskId}/review`,
+    payload: { reviewer: 'sage', decision: 'approve', comment: 'test approval' },
+  })
+}
+
+describe('insight lifecycle sync — task done auto-closes linked insight', () => {
+  it('closes a candidate insight when its task is done', async () => {
+    const insightId = `ins-test-${Date.now()}`
+    insertInsight(insightId, 'candidate')
+
+    const task = await createTask({ insight_id: insightId })
+    await moveTaskToDone(task.id)
+
+    // Give setImmediate + async a tick to settle
+    await new Promise(r => setTimeout(r, 100))
+
+    const db = getDb()
+    const row = db.prepare('SELECT status FROM insights WHERE id = ?').get(insightId) as any
+    expect(row?.status).toBe('closed')
+  })
+
+  it('records an audit entry for the auto-close', async () => {
+    const insightId = `ins-test-audit-${Date.now()}`
+    insertInsight(insightId, 'candidate')
+
+    const task = await createTask({ insight_id: insightId })
+    await moveTaskToDone(task.id)
+    await new Promise(r => setTimeout(r, 100))
+
+    const audits = getRecentInsightMutationAudits(10)
+    const entry = audits.find(a => a.insightId === insightId)
+    expect(entry).toBeDefined()
+    expect(entry?.reason).toContain('auto lifecycle sync')
+  })
+
+  it('does NOT close insight when task transitions to non-done status', async () => {
+    const insightId = `ins-test-nondone-${Date.now()}`
+    insertInsight(insightId, 'candidate')
+
+    const task = await createTask({ insight_id: insightId })
+    await app.inject({
+      method: 'PATCH',
+      url: `/tasks/${task.id}`,
+      payload: { status: 'doing', actor: 'link', metadata: { wip_override: 'test' } },
+    })
+    await new Promise(r => setTimeout(r, 100))
+
+    const db = getDb()
+    const row = db.prepare('SELECT status FROM insights WHERE id = ?').get(insightId) as any
+    expect(row?.status).toBe('candidate') // unchanged
+  })
+
+  it('does NOT close insight when task has no insight_id in metadata', async () => {
+    const insightId = `ins-test-noid-${Date.now()}`
+    insertInsight(insightId, 'candidate')
+
+    const task = await createTask() // no insight_id
+    await moveTaskToDone(task.id)
+    await new Promise(r => setTimeout(r, 100))
+
+    const db = getDb()
+    const row = db.prepare('SELECT status FROM insights WHERE id = ?').get(insightId) as any
+    expect(row?.status).toBe('candidate') // unchanged — no link
+  })
+
+  it('handles missing insight_id gracefully (no throw)', async () => {
+    const task = await createTask({ insight_id: 'ins-does-not-exist-xxxx' })
+    await expect(moveTaskToDone(task.id)).resolves.not.toThrow()
+  })
+})


### PR DESCRIPTION
Closes task-1773491932598-izynfta9z

## The problem

Insight candidate stays open after its mitigation ships because the linked task closing (status→done) doesn't trigger insight lifecycle sync. Manual `POST /insights/:id/close` required.

## The fix

In `updateTask()`, when a task with `metadata.insight_id` transitions to `done`, auto-call `closeInsightById()`.

```ts
// tasks.ts — hook after done transition
if (updates.status === 'done' && task.status !== 'done') {
  const insightId = task.metadata?.insight_id
  if (insightId) closeInsightById(insightId, { actor, reason: '...' })
}
```

## Safety

- **Best-effort**: never blocks task completion (fire-and-forget async)
- **Failures logged**: `console.warn` on any error, never thrown
- **Audit trail**: `closeInsightById` writes to `insight-mutation-audit.jsonl` automatically
- **No new routes**: hooks into existing code path only

## Tests (5/5)

- closes candidate insight when its task is done ✅
- records audit entry for the auto-close ✅
- does NOT close when task moves to non-done status ✅
- does NOT close when task has no insight_id ✅
- handles missing/invalid insight_id gracefully ✅

**tsc clean ✅  534 routes ✅**