### PR TITLE
feat(node): emit canvas_push on task transitions — utterance on doing, work_released on validating

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9004,6 +9004,52 @@ export async function createServer(): Promise<FastifyInstance> {
         })
       }
 
+      // ── Canvas push: self-emit utterance on task state transitions ──
+      {
+        const canvasAgent = (task.assignee || 'unknown').toLowerCase()
+        const canvasNow = Date.now()
+        const AGENT_COLORS: Record<string, string> = {
+          kai: '#6366f1', link: '#22d3ee', sage: '#a78bfa', pixel: '#ec4899',
+          echo: '#f472b6', rhythm: '#a3e635', spark: '#fb923c', scout: '#fbbf24',
+          harmony: '#34d399', swift: '#38bdf8', kotlin: '#f97316',
+        }
+        const agentColor = AGENT_COLORS[canvasAgent] ?? '#94a3b8'
+        const taskSnippet = (task.title ?? '').slice(0, 60)
+
+        if (parsed.status === 'doing' && existing.status !== 'doing') {
+          // Agent picks up work → utterance on canvas
+          eventBus.emit({
+            id: `canvas-doing-${canvasNow}-${task.id.slice(-6)}`,
+            type: 'canvas_push',
+            timestamp: canvasNow,
+            data: {
+              type: 'utterance',
+              agentId: canvasAgent,
+              agentColor,
+              text: `picking up: ${taskSnippet}`,
+              t: canvasNow,
+            },
+          })
+        } else if (parsed.status === 'validating' && existing.status !== 'validating') {
+          // Agent submits for review → work_released on canvas
+          const prUrl = (mergedMeta as any)?.review_handoff?.pr_url || (mergedMeta as any)?.pr_url || undefined
+          eventBus.emit({
+            id: `canvas-validating-${canvasNow}-${task.id.slice(-6)}`,
+            type: 'canvas_push',
+            timestamp: canvasNow,
+            data: {
+              type: 'work_released',
+              agentId: canvasAgent,
+              agentColor,
+              summary: `ready for review: ${taskSnippet}`,
+              prUrl,
+              t: canvasNow,
+            },
+          })
+        }
+      }
+      // ── End canvas push ──
+
       // ── Activation funnel: track first_task_started / first_task_completed ──
       {
         const funnelUserId = (task.metadata as any)?.userId || task.assignee || ''

--- a/tests/canvas-approval-card.test.ts
+++ b/tests/canvas-approval-card.test.ts
@@ -335,3 +335,53 @@ describe('Hosts query card', () => {
     expect(body.card.type).toBe('hosts')
   })
 })
+
+describe('Canvas push on task transitions', () => {
+  it('emits canvas_push utterance when task moves todo→doing', async () => {
+    const res = await app.inject({ method: 'POST', url: '/tasks', payload: { title: `Transition test ${Date.now()}`, assignee: 'kai', reviewer: 'coo', priority: 'P2', status: 'todo', done_criteria: ['done'] } })
+    const taskId: string = JSON.parse(res.body).task?.id ?? JSON.parse(res.body).id
+    createdIds.push(taskId)
+
+    const captured: unknown[] = []
+    const listenerId = `test-doing-${Date.now()}`
+    eventBus.on(listenerId, (event) => { if (event.type === 'canvas_push') captured.push(event) })
+    try {
+      await app.inject({ method: 'PATCH', url: `/tasks/${taskId}`, payload: { status: 'doing' } })
+    } finally {
+      eventBus.off(listenerId)
+    }
+
+    const utterance = (captured as any[]).find(e => (e.data as any)?.type === 'utterance')
+    expect(utterance).toBeDefined()
+    expect((utterance as any).data.text).toContain('picking up')
+  })
+
+  it('emits canvas_push work_released when task moves doing→validating', async () => {
+    const taskId = await createDoingTask()
+
+    const captured: unknown[] = []
+    const listenerId = `test-validating-push-${Date.now()}`
+    eventBus.on(listenerId, (event) => { if (event.type === 'canvas_push') captured.push(event) })
+    try {
+      const shortId = taskId.split('-').slice(-1)[0]
+      await app.inject({
+        method: 'PATCH', url: `/tasks/${taskId}`,
+        payload: {
+          status: 'validating',
+          metadata: {
+            pr_integrity_override: true,
+            pr_integrity_override_reason: 'test',
+            review_handoff: { task_id: taskId, artifact_path: `process/TASK-${shortId}.md`, known_caveats: 'none', pr_url: 'https://github.com/reflectt/reflectt-node/pull/999', commit_sha: 'abc1234' },
+            qa_bundle: { lane: 'engineering', summary: 'test', review_packet: { task_id: taskId, pr_url: 'https://github.com/reflectt/reflectt-node/pull/999', commit: 'abc1234', changed_files: ['src/server.ts'], artifact_path: `process/TASK-${shortId}.md`, what_changed: 'test', how_tested: 'vitest', caveats: 'none' } },
+          },
+        },
+      })
+    } finally {
+      eventBus.off(listenerId)
+    }
+
+    const wr = (captured as any[]).find(e => (e.data as any)?.type === 'work_released')
+    expect(wr).toBeDefined()
+    expect((wr as any).data.summary).toContain('ready for review')
+  })
+})


### PR DESCRIPTION
## What
Wires the task state machine to the canvas_push stream so agents self-emit without any manual API calls.

## Transitions wired
- **todo→doing**: emits `canvas_push` type `utterance` — "picking up: {task title}". Canvas shows agent speaking when they pick up work.
- **doing→validating**: emits `canvas_push` type `work_released` — "ready for review: {task title}" + prUrl if available. Canvas shows work_released card when agent ships.

## What this does NOT change
- done→ still fires canvas_artifact (already wired in #999)
- approval_requested still fires on validating (already wired in #1001)
- No new routes, no docs change needed (no routes added)

## Tests
2 new tests in canvas-approval-card.test.ts — 8 tests total, all pass.