### PR TITLE
ops: lane template files — self-propelling task successor generation

### DIFF
--- a/defaults/lane-templates/ops.json
+++ b/defaults/lane-templates/ops.json
@@ -1,0 +1,32 @@
+{
+  "lane": "ops",
+  "description": "Template for ops-lane tasks. On completion, auto-generates the next ops health check or process-improvement task.",
+  "done_criteria_template": [
+    "Artifact committed at {{artifact_path}}",
+    "No regressions in existing tests",
+    "Status posted to task comments with shipped/blocker/next"
+  ],
+  "successor_rule": {
+    "strategy": "insight_or_default",
+    "insight_pool": "ops",
+    "default_task": {
+      "title": "ops: board health sweep — verify ready floors and stale task cleanup",
+      "priority": "P3",
+      "assignee": "rhythm",
+      "tags": ["ops", "board-health", "auto-generated"],
+      "done_criteria": [
+        "All lanes at or above ready floor",
+        "No tasks stale in doing > 24h without comment",
+        "Placeholder tasks purged or rescoped"
+      ]
+    },
+    "idempotency_key_template": "successor:ops:{{parent_task_id}}",
+    "max_successors_per_parent": 1
+  },
+  "transition_hook": "onTaskDone",
+  "transition_guard": {
+    "require_artifact": true,
+    "require_reviewer_approval": false,
+    "skip_if_successor_exists": true
+  }
+}

--- a/defaults/lane-templates/workflow.json
+++ b/defaults/lane-templates/workflow.json
@@ -1,0 +1,32 @@
+{
+  "lane": "workflow",
+  "description": "Template for workflow/process tasks. On completion, auto-generates a validation or follow-up task.",
+  "done_criteria_template": [
+    "Process artifact committed at {{artifact_path}}",
+    "Owner notified",
+    "No open blockers"
+  ],
+  "successor_rule": {
+    "strategy": "insight_or_default",
+    "insight_pool": "workflow",
+    "default_task": {
+      "title": "ops: verify workflow adoption — confirm previous process change is in active use",
+      "priority": "P3",
+      "assignee": "rhythm",
+      "tags": ["ops", "workflow", "adoption-check", "auto-generated"],
+      "done_criteria": [
+        "Confirm the shipped process change is used in at least one real task cycle",
+        "Document any friction or deviation observed",
+        "Flag if abandoned or superseded"
+      ]
+    },
+    "idempotency_key_template": "successor:workflow:{{parent_task_id}}",
+    "max_successors_per_parent": 1
+  },
+  "transition_hook": "onTaskDone",
+  "transition_guard": {
+    "require_artifact": true,
+    "require_reviewer_approval": false,
+    "skip_if_successor_exists": true
+  }
+}


### PR DESCRIPTION
## Summary
Lane template JSON files for ops and workflow lanes that define the successor task generation contract.

Part of task-1773262304237 (self-propelling task templates). This PR delivers the template data layer; the implementation hook will be wired by @sage.

## Changed files
- `defaults/lane-templates/ops.json` — ops lane template with successor rule + idempotency contract
- `defaults/lane-templates/workflow.json` — workflow lane template

## Template schema
Each file defines:
- `done_criteria_template` — reusable criteria shape
- `successor_rule.default_task` — fallback successor if insights pool is empty
- `successor_rule.idempotency_key_template` — prevents duplicate successors
- `transition_hook: onTaskDone` — hook point for @sage to wire in src/tasks.ts
- `transition_guard` — safety controls (require_artifact, skip_if_successor_exists)

## Implementation spec
`process/LANE-TEMPLATE-SUCCESSOR-SPEC.md` (in workspace) contains full spec for @sage:
- `src/lane-template-successor.ts` (new) — core logic
- Wire into `src/tasks.ts` at done transition
- Tests A1–A4 (idempotency, guard, missing-template safety)

## Reviewer
@coo