### PR TITLE
feat(node): canvas alive — emit canvas_push on done/blocked transitions

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9046,6 +9046,37 @@ export async function createServer(): Promise<FastifyInstance> {
               t: canvasNow,
             },
           })
+        } else if (parsed.status === 'done' && existing.status !== 'done') {
+          // Agent closes task — burst from their orb
+          eventBus.emit({
+            id: `canvas-done-${canvasNow}-${task.id.slice(-6)}`,
+            type: 'canvas_push',
+            timestamp: canvasNow,
+            data: {
+              type: 'work_released',
+              agentId: canvasAgent,
+              agentColor,
+              text: 'shipped',
+              taskTitle: taskSnippet,
+              intensity: 0.8,
+              t: canvasNow,
+            },
+          })
+        } else if (parsed.status === 'blocked' && existing.status !== 'blocked') {
+          // Agent is blocked — utterance from their orb
+          eventBus.emit({
+            id: `canvas-blocked-${canvasNow}-${task.id.slice(-6)}`,
+            type: 'canvas_push',
+            timestamp: canvasNow,
+            data: {
+              type: 'utterance',
+              agentId: canvasAgent,
+              agentColor,
+              text: `blocked on: ${taskSnippet}`,
+              ttl: 4000,
+              t: canvasNow,
+            },
+          })
         }
       }
       // ── End canvas push ──

--- a/tests/canvas-approval-card.test.ts
+++ b/tests/canvas-approval-card.test.ts
@@ -384,4 +384,84 @@ describe('Canvas push on task transitions', () => {
     expect(wr).toBeDefined()
     expect((wr as any).data.summary).toContain('ready for review')
   })
+
+  it('emits canvas_push work_released when task moves validating→done', async () => {
+    // Insert directly at validating with reviewer_approved=true to pass task-close gate
+    const db = getDb()
+    const taskId = `task-test-done-push-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+    const now = Date.now()
+    db.prepare(`INSERT INTO tasks (id, title, description, status, assignee, reviewer, priority, created_by, created_at, updated_at, done_criteria, metadata)
+      VALUES (@id, @title, @description, @status, @assignee, @reviewer, @priority, @created_by, @created_at, @updated_at, @done_criteria, @metadata)`).run({
+      id: taskId,
+      title: `TEST: done canvas_push ${taskId}`,
+      description: '',
+      status: 'validating',
+      assignee: 'kai',
+      reviewer: 'coo',
+      priority: 'P2',
+      created_by: 'test',
+      created_at: now,
+      updated_at: now,
+      done_criteria: JSON.stringify(['done']),
+      metadata: JSON.stringify({ is_test: true, reviewer_approved: true }),
+    })
+    createdIds.push(taskId)
+
+    const captured: unknown[] = []
+    const listenerId = `test-done-push-${Date.now()}`
+    eventBus.on(listenerId, (event) => { if (event.type === 'canvas_push') captured.push(event) })
+    try {
+      await app.inject({
+        method: 'PATCH', url: `/tasks/${taskId}`,
+        payload: { status: 'done', actor: 'coo', metadata: { artifacts: ['https://github.com/reflectt/reflectt-node/pull/999'], reviewer_approved: true, is_test: true } },
+      })
+    } finally {
+      eventBus.off(listenerId)
+    }
+
+    const wr = (captured as any[]).find(e => (e.data as any)?.type === 'work_released')
+    expect(wr).toBeDefined()
+    expect((wr as any).data.agentId).toBe('kai')
+    expect((wr as any).data.intensity).toBe(0.8)
+  })
+
+  it('emits canvas_push utterance when task moves doing→blocked', async () => {
+    // Insert directly at doing status with reviewer+eta so validateLifecycleGates passes
+    const db = getDb()
+    const taskId = `task-test-blocked-push-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+    const now = Date.now()
+    db.prepare(`INSERT INTO tasks (id, title, description, status, assignee, reviewer, priority, created_by, created_at, updated_at, done_criteria, metadata)
+      VALUES (@id, @title, @description, @status, @assignee, @reviewer, @priority, @created_by, @created_at, @updated_at, @done_criteria, @metadata)`).run({
+      id: taskId,
+      title: `TEST: blocked canvas_push ${taskId}`,
+      description: '',
+      status: 'doing',
+      assignee: 'link',
+      reviewer: 'kai',
+      priority: 'P2',
+      created_by: 'test',
+      created_at: now,
+      updated_at: now,
+      done_criteria: JSON.stringify(['done']),
+      metadata: JSON.stringify({ is_test: true, eta: '2026-04-01' }),
+    })
+    createdIds.push(taskId)
+
+    const captured: unknown[] = []
+    const listenerId = `test-blocked-push-${Date.now()}`
+    eventBus.on(listenerId, (event) => { if (event.type === 'canvas_push') captured.push(event) })
+    try {
+      await app.inject({
+        method: 'PATCH', url: `/tasks/${taskId}`,
+        payload: { status: 'blocked', metadata: { transition: { type: 'pause', reason: 'waiting on dependency' } } },
+      })
+    } finally {
+      eventBus.off(listenerId)
+    }
+
+    const utterance = (captured as any[]).find(e => (e.data as any)?.type === 'utterance')
+    expect(utterance).toBeDefined()
+    expect((utterance as any).data.agentId).toBe('link')
+    expect((utterance as any).data.text).toContain('blocked on')
+  })
 })


### PR DESCRIPTION
## What

Extends the canvas_push self-emit block to cover all 4 key task transitions:

| Transition | Canvas event |
|---|---|
| todo→doing | utterance 'picking up: ...' (existing, PR #1002) |
| doing→validating | work_released 'ready for review: ...' (existing, PR #1002) |
| **validating→done** | **work_released (intensity 0.8) — shipped** |
| **doing→blocked** | **utterance 'blocked on: ...'** |

## Why

The canvas floor was showing agent orbs but staying silent — orbs just sat there without any visible activity. Now every task state transition lights up the canvas automatically, without agents needing to manually call `POST /canvas/push`.

## Tests

- 2 new tests: `emits canvas_push work_released when task moves validating→done` and `emits canvas_push utterance when task moves doing→blocked`
- Full suite: 2147+ passing, contract 543/543, tsc clean
- 3 pre-existing failures in canvas-approval-card.test.ts (unrelated to this PR — present on main before this change)

## Related

Part of task `task-1773515152929-32dfyx9tt` — canvas alive: task state machine → canvas_push