### PR TITLE
feat(node): POST /usage/ingest — accept external usage from OpenClaw sessions

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -885,6 +885,7 @@ Set via `reflectionNudge` in policy config:
 |--------|----------|-------------|
 | POST | `/usage/report` | Record model usage event. Body: `{ agent, model, provider?, input_tokens, output_tokens, estimated_cost_usd?, category?, task_id?, team_id? }`. Auto-estimates cost if not provided. |
 | POST | `/usage/report/batch` | Record batch of usage events. Body: `{ events: [...] }`. |
+| POST | `/usage/ingest` | Accept external usage records from OpenClaw sessions. Auth: `REFLECTT_HOST_HEARTBEAT_TOKEN` (Bearer / x-heartbeat-token). Single: `{ agent, model, input_tokens, output_tokens, cost_usd?, session_id?, timestamp? }`. Batch: `{ events: [...] }`. Returns `{ success, event }` or `{ success, count }`. |
 | GET | `/usage/summary` | Aggregated usage totals. Query: `since`, `until`, `agent`, `team_id`. |
 | GET | `/usage/by-agent` | Per-agent cost breakdown. Query: `since`, `until`. |
 | GET | `/usage/by-model` | Per-model cost breakdown. Query: `since`, `until`. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -14969,6 +14969,67 @@ If your heartbeat shows **no active task** and **no next task**:
     return { success: true, count: events.length }
   })
 
+  // POST /usage/ingest — accept external usage records from OpenClaw sessions
+  // Bridges agents not connected via node heartbeat (swift, kotlin, qa, etc.)
+  // into the model_usage table so the cloud dashboard captures all agent spend.
+  // Auth: REFLECTT_HOST_HEARTBEAT_TOKEN (Bearer / x-heartbeat-token / body.token).
+  // Supports single record or batch (body.events array).
+  app.post('/usage/ingest', async (request, reply) => {
+    const auth = verifyHeartbeatAuth(request as any)
+    if (!auth.ok) {
+      reply.code(401)
+      return { success: false, error: auth.error }
+    }
+
+    const body = request.body as Record<string, unknown>
+
+    // Batch path: { events: [...] }
+    if (Array.isArray(body.events)) {
+      const items = body.events as Record<string, unknown>[]
+      if (items.length === 0) {
+        reply.code(400)
+        return { success: false, error: 'events array must not be empty' }
+      }
+      const events = items.map(item => {
+        if (!item.agent || !item.model) throw Object.assign(new Error('agent and model are required in every event'), { statusCode: 400 })
+        return recordUsageTracking({
+          agent: item.agent as string,
+          model: item.model as string,
+          provider: (item.provider as string | undefined) ?? 'openclaw',
+          input_tokens: Number(item.input_tokens) || 0,
+          output_tokens: Number(item.output_tokens) || 0,
+          estimated_cost_usd: item.cost_usd != null ? Number(item.cost_usd) : undefined,
+          category: (item.category as UsageEvent['category'] | undefined) ?? 'other',
+          timestamp: Number(item.timestamp) || Date.now(),
+          api_source: (item.session_id as string | undefined) ? `openclaw:${item.session_id}` : 'openclaw',
+          metadata: item.session_id ? { session_id: item.session_id } : undefined,
+        })
+      })
+      reply.code(201)
+      return { success: true, count: events.length }
+    }
+
+    // Single record path: { agent, model, input_tokens, output_tokens, cost_usd, session_id?, timestamp? }
+    if (!body.agent || !body.model) {
+      reply.code(400)
+      return { success: false, error: 'agent and model are required' }
+    }
+    const event = recordUsageTracking({
+      agent: body.agent as string,
+      model: body.model as string,
+      provider: (body.provider as string | undefined) ?? 'openclaw',
+      input_tokens: Number(body.input_tokens) || 0,
+      output_tokens: Number(body.output_tokens) || 0,
+      estimated_cost_usd: body.cost_usd != null ? Number(body.cost_usd) : undefined,
+      category: (body.category as UsageEvent['category'] | undefined) ?? 'other',
+      timestamp: Number(body.timestamp) || Date.now(),
+      api_source: (body.session_id as string | undefined) ? `openclaw:${body.session_id}` : 'openclaw',
+      metadata: body.session_id ? { session_id: body.session_id } : undefined,
+    })
+    reply.code(201)
+    return { success: true, event }
+  })
+
   // Usage summary (total cost by period)
   app.get('/usage/summary', async (request) => {
     const q = request.query as Record<string, string>

--- a/tests/usage-tracking.test.ts
+++ b/tests/usage-tracking.test.ts
@@ -205,4 +205,68 @@ describe('Usage Tracking API', () => {
       expect(Array.isArray(body.suggestions)).toBe(true)
     })
   })
+
+  describe('POST /usage/ingest', () => {
+    it('ingests a single external usage record (no auth configured)', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/usage/ingest',
+        payload: {
+          agent: 'swift',
+          model: 'claude-sonnet-4-6',
+          input_tokens: 500,
+          output_tokens: 200,
+          cost_usd: 0.0045,
+          session_id: 'sess-abc123',
+          timestamp: Date.now(),
+        },
+      })
+      expect(res.statusCode).toBe(201)
+      const body = JSON.parse(res.body)
+      expect(body.success).toBe(true)
+      expect(body.event).toBeDefined()
+      expect(body.event.agent).toBe('swift')
+      expect(body.event.api_source).toBe('openclaw:sess-abc123')
+    })
+
+    it('ingests a batch of external usage records', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/usage/ingest',
+        payload: {
+          events: [
+            { agent: 'kotlin', model: 'gpt-5.4', input_tokens: 1000, output_tokens: 400, cost_usd: 0.006 },
+            { agent: 'qa', model: 'claude-sonnet-4-6', input_tokens: 300, output_tokens: 100 },
+          ],
+        },
+      })
+      expect(res.statusCode).toBe(201)
+      const body = JSON.parse(res.body)
+      expect(body.success).toBe(true)
+      expect(body.count).toBe(2)
+    })
+
+    it('returns 400 when agent or model is missing', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/usage/ingest',
+        payload: { model: 'gpt-5.4', input_tokens: 100, output_tokens: 50 },
+      })
+      expect(res.statusCode).toBe(400)
+      expect(JSON.parse(res.body).success).toBe(false)
+    })
+
+    it('ingest records appear in /usage/by-agent', async () => {
+      await app.inject({
+        method: 'POST',
+        url: '/usage/ingest',
+        payload: { agent: 'shield', model: 'gpt-5.3', input_tokens: 200, output_tokens: 80, cost_usd: 0.001 },
+      })
+      const res = await app.inject({ method: 'GET', url: '/usage/by-agent' })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.body)
+      const agents = (body.usage ?? body).map((a: { agent: string }) => a.agent)
+      expect(agents).toContain('shield')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes GitHub #681 (full fix).

Adds `POST /usage/ingest` to bridge agents not connected via node heartbeat (swift, kotlin, qa, shield, etc.) into the `model_usage` table so the cloud dashboard shows all 25 agents, not just 9.

## Changes

- **`src/server.ts`** — new `POST /usage/ingest` endpoint with host credential auth
- **`public/docs.md`** — route contract updated (544 routes)
- **`tests/usage-tracking.test.ts`** — 4 new tests (23 total, all passing)

## Endpoint

```
POST /usage/ingest
Auth: REFLECTT_HOST_HEARTBEAT_TOKEN (Bearer / x-heartbeat-token header)

Single:  { agent, model, input_tokens, output_tokens, cost_usd?, session_id?, timestamp? }
Batch:   { events: [...] }
```

Records write to `model_usage` and appear in `GET /usage/by-agent`. Sets `api_source = 'openclaw:<session_id>'` for traceability.

## Test Results

- usage-tracking.test.ts: 23/23 ✅
- Full suite: 2151/2154 (3 pre-existing failures in canvas-approval-card.test.ts, unrelated)
- Route/docs contract: 544/544 ✅
- tsc: clean ✅

## Task

task-1773514579523-0h8ppg8ia