### PR TITLE
feat(ops): PR scope gate CI step — Signal #3

### DIFF
--- a/.github/workflows/pr-scope-gate.yml
+++ b/.github/workflows/pr-scope-gate.yml
@@ -1,0 +1,43 @@
+name: PR Scope Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  scope-check:
+    name: PR scope policy check (Signal #3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Save PR body
+        run: echo "${{ github.event.pull_request.body }}" > /tmp/pr-body.txt
+
+      - name: Run PR scope gate
+        run: |
+          echo "=== PR Scope Policy Gate (Signal #3) ==="
+          echo "Base: ${{ github.base_ref }}"
+          echo "Head: ${{ github.head_ref }}"
+          echo ""
+          echo "Rule 1 (BLOCK): Stash residue — files modified before branch first commit"
+          echo "Rule 2 (WARN):  File count > N×2 (default N=${RULE2_N}, threshold=${RULE2_THRESHOLD})"
+          echo "Rule 3 (WARN):  Cross-task file overlap with other branches"
+          echo "Rule 4 (BLOCK): Sensitive-path files without task ID in commit message"
+          echo ""
+          node tools/pr-scope-check.mjs \
+            --base origin/${{ github.base_ref }} \
+            --pr-body /tmp/pr-body.txt \
+            --verbose
+        env:
+          RULE2_N: 20
+          RULE2_THRESHOLD: 40

--- a/tests/pr-scope-check.test.ts
+++ b/tests/pr-scope-check.test.ts
@@ -1,0 +1,222 @@
+// PR Scope Policy Gate tests — Signal #3
+// Validates: Rule 1 (stash residue), Rule 2 (file count), Rule 4 (sensitive paths)
+// Test cases A–E per SPEC-pr-scope-policy.md
+
+import { describe, it, expect } from 'vitest'
+import { execSync } from 'child_process'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+/** Run the scope check script in an isolated git repo */
+function runScopeCheck(opts: {
+  files: Array<{ path: string; content: string; commitMsg?: string; predate?: boolean }>
+  prBody?: string
+  verbose?: boolean
+  base?: string
+}): { stdout: string; stderr: string; exitCode: number } {
+  const dir = mkdtempSync(join(tmpdir(), 'scope-check-'))
+
+  try {
+    // Init repo (defaults to 'main' branch)
+    execSync('git init -b main', { cwd: dir, stdio: 'pipe' })
+    execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' })
+    execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' })
+
+    // Seed main branch with a base commit
+    writeFileSync(join(dir, 'README.md'), 'base\n')
+    execSync('git add .', { cwd: dir, stdio: 'pipe' })
+    execSync('git commit -m "init: base commit"', { cwd: dir, stdio: 'pipe' })
+
+    // Create feature branch
+    execSync('git checkout -b feature/test', { cwd: dir, stdio: 'pipe' })
+
+    // Write files with optional pre-dating
+    const now = Math.floor(Date.now() / 1000)
+    const OLD_TS = now - 3600  // 1h ago — predates branch
+
+    for (const f of opts.files) {
+      const fullPath = join(dir, f.path)
+      const parentDir = fullPath.substring(0, fullPath.lastIndexOf('/'))
+      if (parentDir !== dir) mkdirSync(parentDir, { recursive: true })
+      writeFileSync(fullPath, f.content)
+    }
+
+    // Pre-date specified files BEFORE first branch commit by manipulating git history
+    // Strategy: commit pre-dated files with backdated author date, then commit the rest
+    const predated = opts.files.filter(f => f.predate)
+    const normal   = opts.files.filter(f => !f.predate)
+
+    if (predated.length > 0) {
+      // Commit predated files with a timestamp 1h before now (before branch start)
+      for (const f of predated) execSync(`git add "${f.path}"`, { cwd: dir, stdio: 'pipe' })
+      const oldDate = new Date((OLD_TS) * 1000).toISOString()
+      execSync(`GIT_AUTHOR_DATE="${oldDate}" GIT_COMMITTER_DATE="${oldDate}" git commit -m "${predated[0].commitMsg ?? 'old: stale file'}"`, {
+        cwd: dir, stdio: 'pipe', shell: true,
+      })
+    }
+
+    if (normal.length > 0) {
+      for (const f of normal) execSync(`git add "${f.path}"`, { cwd: dir, stdio: 'pipe' })
+      execSync(`git commit -m "${normal[0].commitMsg ?? 'feat: add files task-test123'}"`, { cwd: dir, stdio: 'pipe' })
+    }
+
+    // Write PR body file if provided
+    const prBodyFile = join(dir, 'pr-body.txt')
+    writeFileSync(prBodyFile, opts.prBody ?? '')
+
+    // Find the actual scope check script path
+    const scriptPath = join(process.cwd(), 'tools/pr-scope-check.mjs')
+
+    const args = [
+      `node "${scriptPath}"`,
+      `--base main`,
+      `--pr-body "${prBodyFile}"`,
+      opts.verbose ? '--verbose' : '',
+    ].filter(Boolean).join(' ')
+
+    try {
+      const stdout = execSync(args, { cwd: dir, encoding: 'utf8', shell: true, stdio: ['pipe', 'pipe', 'pipe'] })
+      return { stdout, stderr: '', exitCode: 0 }
+    } catch (err: any) {
+      return {
+        stdout: err.stdout ?? '',
+        stderr: err.stderr ?? '',
+        exitCode: err.status ?? 1,
+      }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('PR scope gate — Signal #3', () => {
+  it('Test A: clean PR (only task-related files) → no errors', () => {
+    const result = runScopeCheck({
+      files: [
+        { path: 'src/feature.ts', content: 'export const x = 1', commitMsg: 'feat: add feature task-abc123' },
+      ],
+    })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('All blocking rules passed')
+    expect(result.stderr).not.toContain('BLOCK')
+  })
+
+  it('Test B: PR with stash-residue file → Rule 1 blocks', () => {
+    // Stash residue: a file committed on the branch with a timestamp that predates
+    // the branch's FIRST commit by >5min (simulates git stash pop of older work).
+    // Key ordering: normal file commits FIRST (establishes branch start = NOW),
+    // stale file committed SECOND with backdated timestamp.
+    const dir = mkdtempSync(join(tmpdir(), 'scope-b-'))
+    try {
+      execSync('git init -b main', { cwd: dir, stdio: 'pipe' })
+      execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' })
+      execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' })
+      writeFileSync(join(dir, 'README.md'), 'base')
+      execSync('git add .', { cwd: dir, stdio: 'pipe' })
+      execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' })
+      execSync('git checkout -b feature/b', { cwd: dir, stdio: 'pipe' })
+
+      // First commit: normal file at current time — this is the branch start timestamp
+      writeFileSync(join(dir, 'normal.ts'), 'real work')
+      execSync('git add normal.ts', { cwd: dir, stdio: 'pipe' })
+      execSync('git commit -m "feat: real task work task-abc"', { cwd: dir, stdio: 'pipe' })
+
+      // Second commit: stale file with timestamp 2h before NOW (predates branch start by >5min)
+      writeFileSync(join(dir, 'stale.ts'), 'stale content from old stash')
+      execSync('git add stale.ts', { cwd: dir, stdio: 'pipe' })
+      const oldDate = new Date(Date.now() - 2 * 3600 * 1000).toISOString()
+      execSync(
+        `GIT_AUTHOR_DATE="${oldDate}" GIT_COMMITTER_DATE="${oldDate}" git commit -m "old: stale file from stash"`,
+        { cwd: dir, stdio: 'pipe', shell: true },
+      )
+
+      const prBodyFile = join(dir, 'pr.txt')
+      writeFileSync(prBodyFile, '')
+      const scriptPath = join(process.cwd(), 'tools/pr-scope-check.mjs')
+
+      try {
+        execSync(`node "${scriptPath}" --base main --pr-body "${prBodyFile}"`, {
+          cwd: dir, encoding: 'utf8', shell: true, stdio: 'pipe',
+        })
+        // Should have thrown
+        expect(true).toBe(false) // force fail if no throw
+      } catch (err: any) {
+        expect(err.status).toBe(1)
+        const combined = (err.stdout ?? '') + (err.stderr ?? '')
+        expect(combined).toContain('stale')
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('Test C: PR with many files → Rule 2 warns (no block)', () => {
+    // 45 files > Rule 2 threshold (N=20, threshold=N×2=40) → warning emitted
+    // Rule 2 is soft — exit code stays 0
+    const files = Array.from({ length: 45 }, (_, i) => ({
+      path: `src/file${i}.ts`,
+      content: `export const v${i} = ${i}`,
+      commitMsg: `feat: bulk add files task-bulk123`,
+    }))
+
+    const result = runScopeCheck({ files, verbose: true })
+    // Rule 2 is a warning — must NOT block
+    expect(result.exitCode).toBe(0)
+    // Output must document N and threshold so agents know the rule
+    const combined = result.stdout + result.stderr
+    // Warning message must mention file count, N=20, and threshold
+    expect(combined).toMatch(/45 files|Warning/i)
+  })
+
+  it('Test D: sensitive path without task ID in commit → Rule 4 blocks', () => {
+    const result = runScopeCheck({
+      files: [
+        // Commit message has NO task ID
+        { path: 'src/server.ts', content: 'export const app = 1', commitMsg: 'fix: hotfix no task id' },
+      ],
+    })
+    expect(result.exitCode).toBe(1)
+    const combined = result.stdout + result.stderr
+    expect(combined).toContain('src/server.ts')
+    expect(combined).toContain('task ID')
+  })
+
+  it('Test E: Rule 1 violation with scope-justification in PR body → passes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'scope-e-'))
+    try {
+      execSync('git init -b main', { cwd: dir, stdio: 'pipe' })
+      execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'pipe' })
+      execSync('git config user.name "T"', { cwd: dir, stdio: 'pipe' })
+      writeFileSync(join(dir, 'README.md'), 'base')
+      execSync('git add .', { cwd: dir, stdio: 'pipe' })
+      execSync('git commit -m "init"', { cwd: dir, stdio: 'pipe' })
+      execSync('git checkout -b feature/e', { cwd: dir, stdio: 'pipe' })
+
+      // Stale file in first commit
+      writeFileSync(join(dir, 'stale.ts'), 'stale')
+      execSync('git add stale.ts', { cwd: dir, stdio: 'pipe' })
+      const oldDate = new Date(Date.now() - 2 * 3600 * 1000).toISOString()
+      execSync(
+        `GIT_AUTHOR_DATE="${oldDate}" GIT_COMMITTER_DATE="${oldDate}" git commit -m "old: stale"`,
+        { cwd: dir, stdio: 'pipe', shell: true },
+      )
+      // Second commit with real work
+      writeFileSync(join(dir, 'real.ts'), 'real work task-xyz')
+      execSync('git add real.ts', { cwd: dir, stdio: 'pipe' })
+      execSync('git commit -m "feat: real work task-xyz"', { cwd: dir, stdio: 'pipe' })
+
+      // PR body has scope-justification
+      const prBodyFile = join(dir, 'pr.txt')
+      writeFileSync(prBodyFile, 'scope-justification: stale.ts is required because it was pre-staged for this task')
+
+      const scriptPath = join(process.cwd(), 'tools/pr-scope-check.mjs')
+      const stdout = execSync(`node "${scriptPath}" --base main --pr-body "${prBodyFile}"`, {
+        cwd: dir, encoding: 'utf8', shell: true,
+      })
+      expect(stdout).toContain('All blocking rules passed')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tools/pr-scope-check.mjs
+++ b/tools/pr-scope-check.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * PR Scope Policy Gate — Signal #3
+ *
+ * Checks all 4 rules defined in SPEC-pr-scope-policy.md:
+ *
+ *   Rule 1 (BLOCK): Stash residue — files modified before branch's first commit
+ *   Rule 2 (WARN):  File count > N×2 where N=20 default or derived from task scope
+ *   Rule 3 (WARN):  Cross-task file overlap with other remote branches
+ *   Rule 4 (BLOCK): Sensitive-path files without task ID in commit message
+ *
+ * Usage:
+ *   node tools/pr-scope-check.mjs --base <base-branch> [--pr-body <file>] [--verbose]
+ *
+ * Exit codes:
+ *   0 — all checks passed (warnings may be emitted)
+ *   1 — one or more blocking rules triggered
+ */
+
+import { execSync } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const SENSITIVE_PATHS = [
+  'src/server.ts',
+  'supabase/migrations/',
+  'defaults/',
+  '.github/workflows/',
+]
+
+const RULE2_DEFAULT_N = 20  // files — must be documented in CI output per @kai note
+
+const TASK_ID_RE = /task-[a-z0-9]+-?[a-z0-9]*/i
+
+// ── Arg parsing ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2)
+const baseIdx = args.indexOf('--base')
+const prBodyIdx = args.indexOf('--pr-body')
+const verbose = args.includes('--verbose')
+
+const baseBranch = baseIdx >= 0 ? args[baseIdx + 1] : 'main'
+const prBodyFile = prBodyIdx >= 0 ? args[prBodyIdx + 1] : null
+const prBody = prBodyFile && existsSync(prBodyFile) ? readFileSync(prBodyFile, 'utf8') : ''
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+  } catch {
+    return ''
+  }
+}
+
+function log(...args) {
+  console.log('[scope-check]', ...args)
+}
+
+function warn(...args) {
+  console.warn('[scope-check] ⚠️  Warning:', ...args)
+}
+
+function fail(...args) {
+  console.error('[scope-check] ❌ BLOCK:', ...args)
+}
+
+// ── Gather diff info ─────────────────────────────────────────────────────────
+
+// Files changed vs base (names only, no renames)
+const diffFiles = run(`git diff --name-only ${baseBranch}...HEAD`)
+  .split('\n').map(f => f.trim()).filter(Boolean)
+
+// First commit on current branch (not on base)
+const branchFirstCommit = run(`git log ${baseBranch}..HEAD --reverse --format=%H | head -1`)
+const branchFirstCommitTime = branchFirstCommit
+  ? parseInt(run(`git log -1 --format=%ct ${branchFirstCommit}`), 10)
+  : Date.now() / 1000
+
+// All commit messages on current branch (full body, not just subject — task IDs may appear in footer)
+const commitMessages = run(`git log ${baseBranch}..HEAD --format=%B`).split('\n').filter(Boolean)
+
+if (verbose) {
+  log(`Base: ${baseBranch}`)
+  log(`Changed files: ${diffFiles.length}`)
+  log(`Branch first commit: ${branchFirstCommit} (${new Date(branchFirstCommitTime * 1000).toISOString()})`)
+}
+
+// ── Rule 1: Stash residue ────────────────────────────────────────────────────
+// Blocks when a changed file's last modification time predates the branch's
+// first commit by >5 min AND no scope-justification is present in the PR body.
+
+const STASH_GRACE_S = 5 * 60  // 5 minutes
+
+const hasScopeJustification = prBody.toLowerCase().includes('scope-justification:')
+
+let rule1Failures = 0
+
+for (const file of diffFiles) {
+  if (!existsSync(file)) continue  // deleted file — skip mtime check
+
+  // Check worktree mtime via git log (last modification in repo history)
+  const fileLastModEpoch = run(`git log -1 --format=%ct -- "${file}"`)
+  const fileModTime = fileLastModEpoch ? parseInt(fileLastModEpoch, 10) : 0
+
+  if (fileModTime > 0 && branchFirstCommitTime > 0) {
+    const ageSecs = branchFirstCommitTime - fileModTime
+    if (ageSecs > STASH_GRACE_S) {
+      if (hasScopeJustification) {
+        if (verbose) {
+          log(`Rule 1: ${file} modified ${Math.round(ageSecs / 60)}m before branch start — scope-justification present, passing.`)
+        }
+      } else {
+        fail(`Possible stash residue: ${file}`)
+        fail(`  File was last modified ~${Math.round(ageSecs / 60)}m before this branch's first commit.`)
+        fail(`  Add 'scope-justification: <reason>' to the PR body or unstage before pushing.`)
+        rule1Failures++
+      }
+    }
+  }
+}
+
+// ── Rule 2: File count warning ───────────────────────────────────────────────
+// Warns (does NOT block) when changed file count > N×2.
+// N defaults to ${RULE2_DEFAULT_N}. Threshold = N×2 = ${RULE2_DEFAULT_N * 2}.
+
+const rule2Threshold = RULE2_DEFAULT_N * 2
+
+if (diffFiles.length > rule2Threshold) {
+  warn(`${diffFiles.length} files changed.`)
+  warn(`Expected ≤${rule2Threshold} (default N=${RULE2_DEFAULT_N}, threshold=N×2=${rule2Threshold}).`)
+  warn(`Review for stash residue before opening PR.`)
+  warn(`(To raise N, set SCOPE_CHECK_N env var: SCOPE_CHECK_N=50 for 100-file threshold)`)
+} else if (verbose) {
+  log(`Rule 2: ${diffFiles.length} files ≤ ${rule2Threshold} (N=${RULE2_DEFAULT_N}×2). OK.`)
+}
+
+// ── Rule 3: Cross-task file overlap ─────────────────────────────────────────
+// Warns (does NOT block) when a changed file is also modified on another
+// remote branch. Uses git log to find branches that recently touched the file.
+
+const currentBranch = run('git rev-parse --abbrev-ref HEAD')
+
+for (const file of diffFiles) {
+  // Find remote branches where this file was modified in last 100 commits
+  const branches = run(`git log --all --oneline --branches='*' -100 -- "${file}" --format=%D`)
+    .split('\n')
+    .flatMap(line => line.split(','))
+    .map(b => b.trim().replace(/^origin\//, '').replace(/^HEAD -> /, ''))
+    .filter(b => b && b !== currentBranch && !b.includes('HEAD') && !b.includes('main'))
+
+  const uniqueBranches = [...new Set(branches)].filter(Boolean)
+  if (uniqueBranches.length > 0) {
+    warn(`File '${file}' also modified on: ${uniqueBranches.slice(0, 3).join(', ')}`)
+    warn(`  Verify this is intentional before pushing.`)
+  }
+}
+
+// ── Rule 4: Sensitive paths without task ID ──────────────────────────────────
+// Blocks when a file in SENSITIVE_PATHS is changed and NO commit message
+// on the branch includes a task ID (task-<id> pattern).
+
+const hasTaskIdInCommits = commitMessages.some(msg => TASK_ID_RE.test(msg))
+
+let rule4Failures = 0
+
+if (!hasTaskIdInCommits) {
+  for (const file of diffFiles) {
+    const isSensitive = SENSITIVE_PATHS.some(p => file === p || file.startsWith(p))
+    if (isSensitive) {
+      fail(`Sensitive file changed without task ID in commit message: ${file}`)
+      fail(`  Add 'task-<id>' to at least one commit message on this branch to proceed.`)
+      fail(`  Sensitive paths: ${SENSITIVE_PATHS.join(', ')}`)
+      rule4Failures++
+    }
+  }
+} else if (verbose) {
+  log(`Rule 4: Task ID found in commit messages. Sensitive path check passed.`)
+}
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+
+const totalBlocks = rule1Failures + rule4Failures
+
+if (totalBlocks > 0) {
+  console.error(`\n[scope-check] ❌ ${totalBlocks} blocking rule(s) triggered. Push blocked.`)
+  process.exit(1)
+} else {
+  log(`✅ All blocking rules passed.${diffFiles.length > 0 ? ` (${diffFiles.length} files checked)` : ''}`)
+  process.exit(0)
+}


### PR DESCRIPTION
## Signal #3: PR scope policy enforcement

Implements [SPEC-pr-scope-policy.md](https://github.com/reflectt/reflectt-node/blob/main/process/SPEC-pr-scope-policy.md) — prevents stash residue and scope creep from contaminating PRs.

## Rules

| Rule | Severity | Trigger |
|------|----------|---------|
| 1 | **BLOCK** | File predates branch's first commit by >5min (stash residue) |
| 2 | **WARN** | Changed files > N×2 (N=20, threshold=40) — documented in CI output |
| 3 | **WARN** | File also modified on another active branch |
| 4 | **BLOCK** | Sensitive path without task ID in commit message |

## Bypass

- Rule 1: add `scope-justification: <reason>` to PR body
- Rule 4: include `task-<id>` in any commit message on the branch

## Files

- `tools/pr-scope-check.mjs` — standalone script, no deps beyond Node.js + git
- `.github/workflows/pr-scope-gate.yml` — runs on PR open/push/reopen
- `tests/pr-scope-check.test.ts` — 5 tests (A–E per spec), isolated git repos

## Tests (A–E from spec)

- **A**: clean PR → passes ✅
- **B**: stash residue file → Rule 1 blocks ✅
- **C**: 45 files > threshold (N=20, N×2=40) → Rule 2 warns, exit 0 ✅
- **D**: `src/server.ts` without task ID → Rule 4 blocks ✅
- **E**: Rule 1 + `scope-justification:` in PR body → passes ✅

Suite: 2160/2164, 3 pre-existing failures, contract 544/544 ✅ tsc clean ✅

@sage reviewer