### PR TITLE
feat(node): lane-template successor hook — auto-create next task on done

### DIFF
--- a/src/lane-template-successor.ts
+++ b/src/lane-template-successor.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Lane Template Successor Hook
+//
+// When a task is marked done, maybeCreateSuccessor() fires as async fire-and-forget.
+// It loads the lane template for the completed task's lane, checks idempotency,
+// queries the insight pool for a candidate, and creates a successor task.
+//
+// Spec: process/LANE-TEMPLATE-SUCCESSOR-SPEC.md
+// Task: task-1773516624288-l8eoxo92h
+
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+import type { Task } from './types.js'
+import type { LaneConfig } from './lane-config.js'
+import { getAgentLane } from './lane-config.js'
+import { listInsights } from './insights.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface LaneTemplate {
+  lane: string
+  description?: string
+  done_criteria_template?: string[]
+  successor_rule: {
+    strategy: string
+    insight_pool?: string
+    default_task: {
+      title: string
+      priority: string
+      assignee?: string
+      tags?: string[]
+      done_criteria?: string[]
+    }
+    idempotency_key_template: string
+    max_successors_per_parent?: number
+  }
+  transition_hook: string
+  transition_guard?: {
+    require_artifact?: boolean
+    require_reviewer_approval?: boolean
+    skip_if_successor_exists?: boolean
+  }
+}
+
+export interface SuccessorResult {
+  created: boolean
+  taskId?: string
+  reason: string
+}
+
+// ── Template loader ─────────────────────────────────────────────────────────
+
+async function loadLaneTemplate(lane: string): Promise<LaneTemplate | null> {
+  try {
+    const templatePath = join(__dirname, '..', 'defaults', 'lane-templates', `${lane}.json`)
+    const raw = await fs.readFile(templatePath, 'utf8')
+    return JSON.parse(raw) as LaneTemplate
+  } catch {
+    return null
+  }
+}
+
+// ── Idempotency check ───────────────────────────────────────────────────────
+
+function idempotencyKeyFor(lane: string, parentTaskId: string): string {
+  return `successor:${lane}:${parentTaskId}`
+}
+
+async function successorAlreadyExists(
+  taskManager: { listTasks?: () => Task[] },
+  idempotencyKey: string,
+): Promise<boolean> {
+  // Import the db query directly to avoid circular dependency with taskManager
+  const { getDb } = await import('./db.js')
+  const db = getDb()
+  // Look for any task with this idempotency_key in metadata
+  const rows = db.prepare(
+    `SELECT id FROM tasks WHERE json_extract(metadata, '$.idempotency_key') = ? LIMIT 1`
+  ).all(idempotencyKey) as Array<{ id: string }>
+  return rows.length > 0
+}
+
+// ── Insight pool query ──────────────────────────────────────────────────────
+
+function pickInsightCandidate(lane: string): { title: string; description?: string } | null {
+  try {
+    const { insights } = listInsights({ status: 'candidate', limit: 1 })
+    if (!insights || insights.length === 0) return null
+    const insight = insights[0]
+    return {
+      title: insight.title ?? null,
+      description: undefined,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ── Main hook ───────────────────────────────────────────────────────────────
+
+export async function maybeCreateSuccessor(
+  completedTask: Task,
+  // taskManager injected for testability; defaults to the singleton
+  deps?: {
+    createTask?: (data: Omit<Task, 'id' | 'createdAt' | 'updatedAt'>) => Promise<Task>
+    addTaskComment?: (taskId: string, author: string, content: string) => Promise<unknown>
+    /** Override idempotency check for testing */
+    checkIdempotency?: (key: string) => Promise<boolean>
+  },
+): Promise<SuccessorResult> {
+  const taskId = completedTask.id
+  const meta = (completedTask.metadata ?? {}) as Record<string, unknown>
+
+  // Determine lane from task metadata or assignee
+  const agentLaneConfig: LaneConfig | null = completedTask.assignee
+    ? getAgentLane(completedTask.assignee)
+    : null
+  const lane: string | null =
+    (typeof meta.lane === 'string' ? meta.lane : null) ??
+    agentLaneConfig?.name ?? null
+
+  if (!lane) {
+    return { created: false, reason: 'no lane — skipping successor creation' }
+  }
+
+  // Load template
+  const template = await loadLaneTemplate(lane)
+  if (!template) {
+    return { created: false, reason: `no template for lane "${lane}"` }
+  }
+
+  // Transition guard: require_artifact
+  const guard = template.transition_guard ?? {}
+  if (guard.require_artifact) {
+    const artifacts = meta.artifacts
+    const hasArtifact = Array.isArray(artifacts)
+      ? artifacts.length > 0
+      : typeof artifacts === 'string' && artifacts.length > 0
+    if (!hasArtifact) {
+      return { created: false, reason: 'require_artifact guard: no artifacts on completed task' }
+    }
+  }
+
+  // Idempotency: skip if successor already exists
+  const idempotencyKey = idempotencyKeyFor(lane, taskId)
+  const checkFn = deps?.checkIdempotency ?? ((key) => successorAlreadyExists({}, key))
+  const alreadyExists = await checkFn(idempotencyKey)
+  if (alreadyExists) {
+    return { created: false, reason: `idempotency: successor already exists (${idempotencyKey})` }
+  }
+
+  // Build successor task data
+  // Try insight pool first, fall back to default_task
+  const insightCandidate = pickInsightCandidate(lane)
+  const defaultTask = template.successor_rule.default_task
+
+  const successorTitle = insightCandidate?.title ?? defaultTask.title
+  const successorData: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> = {
+    title: successorTitle,
+    status: 'todo',
+    priority: (defaultTask.priority ?? 'P3') as Task['priority'],
+    assignee: defaultTask.assignee ?? completedTask.assignee ?? undefined,
+    done_criteria: defaultTask.done_criteria ?? [],
+    createdBy: 'lane-template-successor',
+    metadata: {
+      idempotency_key: idempotencyKey,
+      parent_task_id: taskId,
+      auto_generated: true,
+      lane,
+      tags: defaultTask.tags ?? [],
+      ...(insightCandidate ? { source: 'insight_pool' } : { source: 'default_task' }),
+    },
+  }
+
+  // Create the successor
+  let createFn = deps?.createTask
+  if (!createFn) {
+    const { taskManager } = await import('./tasks.js')
+    createFn = (data) => taskManager.createTask(data)
+  }
+
+  const successor = await createFn(successorData)
+
+  // Post a comment on the parent task linking to the new successor
+  let commentFn = deps?.addTaskComment
+  if (!commentFn) {
+    const { taskManager } = await import('./tasks.js')
+    commentFn = (id, author, content) => taskManager.addTaskComment(id, author, content)
+  }
+
+  await commentFn(
+    taskId,
+    'lane-template-successor',
+    `[auto] Successor task created: ${successor.id} — "${successor.title}" (lane: ${lane}, source: ${insightCandidate ? 'insight_pool' : 'default_task'})`,
+  )
+
+  return { created: true, taskId: successor.id, reason: `successor created from ${insightCandidate ? 'insight pool' : 'default task'}` }
+}

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -14,6 +14,7 @@ import { getDb, importJsonlIfNeeded, safeJsonStringify, safeJsonParse } from './
 import { isTestHarnessTask, TEST_TASK_EXCLUDE_SQL } from './test-task-filter.js'
 import { assertDuplicateClosureHasCanonicalRefs } from './duplicateClosureGuard.js'
 import { closeInsightById } from './insight-mutation.js'
+import { maybeCreateSuccessor } from './lane-template-successor.js'
 import { getAgentAliases } from './assignment.js'
 import { getAgentLane } from './lane-config.js'
 import type Database from 'better-sqlite3'
@@ -1778,6 +1779,15 @@ class TaskManager {
           }
         })()
       }
+    }
+
+    // ── Lane template successor hook ─────────────────────────────────────
+    // Fire-and-forget: never blocks the task-done response.
+    // Loads lane template, checks idempotency, creates successor if applicable.
+    if (updates.status === 'done' && task.status !== 'done') {
+      void maybeCreateSuccessor(updated).catch(err =>
+        console.error('[lane-template] successor creation failed:', err)
+      )
     }
 
     return updated

--- a/tests/lane-template-autogen-e2e.test.ts
+++ b/tests/lane-template-autogen-e2e.test.ts
@@ -1,0 +1,200 @@
+// Tests for lane-template successor hook (E2E)
+// Covers: A1 (successor created), A2 (idempotency), A3 (require_artifact guard), A4 (missing template)
+//
+// Task: task-1773516624288-l8eoxo92h
+// Spec: process/LANE-TEMPLATE-SUCCESSOR-SPEC.md
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { maybeCreateSuccessor } from '../src/lane-template-successor.js'
+import type { Task } from '../src/types.js'
+
+// ── Mock DB for idempotency checks ────────────────────────────────────────
+
+vi.mock('../src/db.js', () => {
+  const store = new Map<string, unknown[]>()
+  const db = {
+    prepare: (sql: string) => ({
+      all: (...args: unknown[]) => {
+        // Idempotency query: look for tasks with matching idempotency_key
+        if (sql.includes('idempotency_key')) {
+          const key = args[args.length - 1] as string
+          const rows = (store.get('tasks') ?? []) as Array<{ id: string; idempotency_key: string }>
+          return rows.filter(r => r.idempotency_key === key)
+        }
+        return []
+      },
+      run: (..._args: unknown[]) => ({ changes: 1 }),
+      get: (..._args: unknown[]) => null,
+    }),
+  }
+  return {
+    getDb: () => db,
+    importJsonlIfNeeded: () => {},
+    safeJsonStringify: (v: unknown) => JSON.stringify(v),
+    safeJsonParse: (v: string) => JSON.parse(v),
+    __store: store,
+  }
+})
+
+// ── Mock insights (empty pool by default) ─────────────────────────────────
+
+vi.mock('../src/insights.js', () => ({
+  listInsights: vi.fn().mockReturnValue({ insights: [], total: 0 }),
+}))
+
+// ── Mock lane-config ───────────────────────────────────────────────────────
+
+vi.mock('../src/lane-config.js', () => ({
+  getAgentLane: (agent: string) => {
+    if (agent === 'rhythm') return 'ops'
+    return null
+  },
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: `task-test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    title: 'ops: test task',
+    status: 'done',
+    priority: 'P2',
+    assignee: 'rhythm',
+    createdBy: 'test',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    done_criteria: [],
+    metadata: { lane: 'ops', artifacts: ['process/TASK-test.md'] },
+    ...overrides,
+  }
+}
+
+function makeDeps(createdIds: string[]) {
+  // Track created idempotency keys in-memory for the checkIdempotency dep
+  const createdKeys = new Set<string>()
+
+  const createTask = vi.fn(async (data: Omit<Task, 'id' | 'createdAt' | 'updatedAt'>) => {
+    const id = `task-succ-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    createdIds.push(id)
+    const key = (data.metadata as any)?.idempotency_key
+    if (key) createdKeys.add(key)
+    return { ...data, id, createdAt: Date.now(), updatedAt: Date.now() } as Task
+  })
+  const addTaskComment = vi.fn(async () => ({}))
+  const checkIdempotency = async (key: string) => createdKeys.has(key)
+
+  return { createTask, addTaskComment, checkIdempotency }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('lane-template successor hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('A1: completing an ops-lane task creates exactly one successor task', async () => {
+    const createdIds: string[] = []
+    const deps = makeDeps(createdIds)
+    const task = makeTask()
+
+    const result = await maybeCreateSuccessor(task, deps)
+
+    expect(result.created).toBe(true)
+    expect(result.taskId).toBeDefined()
+    expect(deps.createTask).toHaveBeenCalledOnce()
+    expect(deps.addTaskComment).toHaveBeenCalledOnce()
+
+    // Verify successor metadata
+    const [successorData] = deps.createTask.mock.calls[0]
+    const meta = successorData.metadata as Record<string, unknown>
+    expect(meta.auto_generated).toBe(true)
+    expect(meta.parent_task_id).toBe(task.id)
+    expect(typeof meta.idempotency_key).toBe('string')
+    expect(meta.idempotency_key).toContain('successor:ops:')
+  })
+
+  it('A2: completing the same task again does NOT create a second successor (idempotency)', async () => {
+    const createdIds: string[] = []
+    const deps = makeDeps(createdIds)
+    const task = makeTask({ id: 'task-idempotency-test' })
+
+    // First call — should create
+    const first = await maybeCreateSuccessor(task, deps)
+    expect(first.created).toBe(true)
+
+    // Second call — same task, should be blocked by idempotency
+    const second = await maybeCreateSuccessor(task, deps)
+    expect(second.created).toBe(false)
+    expect(second.reason).toMatch(/idempotency/)
+    expect(deps.createTask).toHaveBeenCalledOnce() // not twice
+  })
+
+  it('A3: a task without artifacts when require_artifact=true does NOT trigger successor creation', async () => {
+    const createdIds: string[] = []
+    const deps = makeDeps(createdIds)
+    // ops template has require_artifact: true — task has no artifacts
+    const task = makeTask({ metadata: { lane: 'ops' } }) // no artifacts field
+
+    const result = await maybeCreateSuccessor(task, deps)
+
+    expect(result.created).toBe(false)
+    expect(result.reason).toMatch(/require_artifact/)
+    expect(deps.createTask).not.toHaveBeenCalled()
+  })
+
+  it('A4: missing lane template file → no successor created, no error thrown', async () => {
+    const createdIds: string[] = []
+    const deps = makeDeps(createdIds)
+    // lane 'nonexistent-lane' has no template file
+    const task = makeTask({ metadata: { lane: 'nonexistent-lane', artifacts: ['x'] } })
+
+    const result = await maybeCreateSuccessor(task, deps)
+
+    expect(result.created).toBe(false)
+    expect(result.reason).toMatch(/no template/)
+    expect(deps.createTask).not.toHaveBeenCalled()
+  })
+
+  it('uses insight pool candidate when available', async () => {
+    const { listInsights } = await import('../src/insights.js') as any
+    listInsights.mockReturnValueOnce({
+      insights: [{ id: 'ins-1', title: 'improve ops alerting', summary: 'Fix alert lag' }],
+      total: 1,
+    })
+
+    const createdIds: string[] = []
+    const deps = makeDeps(createdIds)
+    const task = makeTask()
+
+    const result = await maybeCreateSuccessor(task, deps)
+
+    expect(result.created).toBe(true)
+    const [successorData] = deps.createTask.mock.calls[0]
+    expect(successorData.title).toBe('improve ops alerting')
+    expect((successorData.metadata as any).source).toBe('insight_pool')
+  })
+
+  it('falls back to default_task when insight pool is empty', async () => {
+    const createdIds: string[] = []
+    const deps = makeDeps(createdIds)
+    const task = makeTask()
+
+    const result = await maybeCreateSuccessor(task, deps)
+
+    expect(result.created).toBe(true)
+    const [successorData] = deps.createTask.mock.calls[0]
+    expect(successorData.title).toContain('ops') // default title contains 'ops'
+    expect((successorData.metadata as any).source).toBe('default_task')
+  })
+
+  it('returns gracefully when no lane is determinable', async () => {
+    const deps = makeDeps([])
+    const task = makeTask({ assignee: 'unknown-agent', metadata: {} })
+
+    const result = await maybeCreateSuccessor(task, deps)
+
+    expect(result.created).toBe(false)
+    expect(result.reason).toMatch(/no lane/)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the done→successor-task automation per spec at `process/LANE-TEMPLATE-SUCCESSOR-SPEC.md`.

When a task is marked done, the lane template (e.g. `defaults/lane-templates/ops.json`) fires a successor hook to create the next task automatically — zero @kai involvement needed.

## Changes

- **`src/lane-template-successor.ts`** (new) — `maybeCreateSuccessor()` module
  - Loads `defaults/lane-templates/<lane>.json`
  - Idempotency: checks `successor:<lane>:<parentId>` key, skips if exists
  - Transition guard: enforces `require_artifact` from template config
  - Strategy: tries insight pool candidate first, falls back to `default_task`
  - Posts comment on parent task with successor link
- **`src/tasks.ts`** — wired at `status === 'done'` transition as async fire-and-forget (never blocks, errors caught+logged)
- **`tests/lane-template-autogen-e2e.test.ts`** (new) — 7 tests:
  - A1: successor created on ops-lane task completion
  - A2: idempotency — second completion doesn't create duplicate
  - A3: `require_artifact` guard blocks creation when no artifacts
  - A4: missing template → no successor, no error
  - Insight pool + default fallback paths

## Test Results

- lane-template-autogen-e2e.test.ts: 7/7 ✅
- Full suite: 2162/2165 (3 pre-existing canvas-approval-card failures, unrelated)
- Route/docs contract: 544/544 ✅
- tsc: clean ✅

## Task

task-1773516624288-l8eoxo92h