### PR TITLE
feat(node): calendar agent execution surface — GET /calendar/upcoming + spec-format POST

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1030,7 +1030,8 @@ Full calendar event system with iCal-compatible fields, attendees, RSVP, recurre
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/calendar/events` | Create event. Body: `{ summary, dtstart, dtend, organizer, description?, timezone?, rrule?, attendees?, location?, categories?, reminders?, status? }` |
+| GET | `/calendar/upcoming` | Next N days of events (agent execution surface). Query: `days` (default 7). Returns `{ events: [{ id, title, start, end, attendees, calendar, description, location, provider }] }` sorted chronologically. |
+| POST | `/calendar/events` | Create event. Spec format: `{ title, start, duration_minutes?, attendees?, calendar?, description? }` — returns 422 for past dates, 409 for duplicates. Legacy: `{ summary, dtstart, dtend, organizer, ... }`. |
 | GET | `/calendar/events` | List events. Query: `organizer`, `attendee`, `status`, `from`, `to` (epoch ms), `categories` (comma-separated), `limit`. |
 | GET | `/calendar/events/:id` | Get single event. |
 | PATCH | `/calendar/events/:id` | Update event fields. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -16645,14 +16645,107 @@ If your heartbeat shows **no active task** and **no next task**:
 
   // ── Calendar Events API ────────────────────────────────────────────────
 
-  // Create an event
+  // GET /calendar/upcoming — next N days of events (agent execution surface)
+  // Accepts ?days=7 (default 7). Returns spec-shaped response sorted chronologically.
+  app.get('/calendar/upcoming', async (request) => {
+    const q = request.query as Record<string, string>
+    const days = Math.max(1, Math.min(90, parseInt(q.days ?? '7', 10) || 7))
+    const now = Date.now()
+    const to = now + days * 24 * 60 * 60 * 1000
+
+    const events = calendarEvents.listEvents({ from: now, to, status: 'confirmed' })
+
+    return {
+      events: events.map(e => ({
+        id: e.id,
+        title: e.summary,
+        start: new Date(e.dtstart).toISOString(),
+        end: new Date(e.dtend).toISOString(),
+        attendees: e.attendees.map(a => a.name),
+        calendar: e.categories[0] ?? null,
+        description: e.description || null,
+        location: e.location || null,
+        provider: 'local',
+      })),
+    }
+  })
+
+  // Create an event (spec format + legacy CreateEventInput both accepted)
+  // Spec format: { title, start, duration_minutes?, attendees?, calendar?, description? }
+  // Legacy format: { summary, organizer, dtstart, dtend, ... }
+  // Error codes: 422 for past start time, 409 for exact duplicate (same title+start)
   app.post('/calendar/events', async (request, reply) => {
     try {
-      const body = request.body as CreateEventInput
-      if (!body || !body.summary || !body.organizer) {
-        return reply.code(400).send({ error: 'summary and organizer are required' })
+      const body = request.body as Record<string, unknown>
+      if (!body) return reply.code(400).send({ error: 'Request body is required' })
+
+      let input: CreateEventInput
+
+      if (typeof body.title === 'string' || typeof body.start === 'string') {
+        // Spec format — translate to internal CreateEventInput
+        const title = typeof body.title === 'string' ? body.title.trim() : ''
+        const startStr = typeof body.start === 'string' ? body.start : ''
+        if (!title) return reply.code(400).send({ error: 'title is required' })
+        if (!startStr) return reply.code(400).send({ error: 'start is required' })
+
+        const dtstart = Date.parse(startStr)
+        if (isNaN(dtstart)) return reply.code(400).send({ error: 'start must be a valid ISO 8601 datetime' })
+
+        // 422 for past dates
+        if (dtstart < Date.now()) {
+          return reply.code(422).send({ error: 'start must be in the future', code: 'PAST_DATE' })
+        }
+
+        const durationMinutes = typeof body.duration_minutes === 'number' ? body.duration_minutes : 60
+        const dtend = dtstart + durationMinutes * 60 * 1000
+
+        // 409 duplicate check: same title + same start time
+        const existing = calendarEvents.listEvents({ from: dtstart - 1000, to: dtstart + 1000 })
+        const duplicate = existing.find(e => e.summary.toLowerCase() === title.toLowerCase() && e.dtstart === dtstart)
+        if (duplicate) {
+          return reply.code(409).send({ error: 'Duplicate event: same title and start time already exists', existing_id: duplicate.id })
+        }
+
+        const rawAttendees = Array.isArray(body.attendees) ? body.attendees : []
+        const calendar = typeof body.calendar === 'string' ? body.calendar : undefined
+        input = {
+          summary: title,
+          description: typeof body.description === 'string' ? body.description : undefined,
+          dtstart,
+          dtend,
+          organizer: 'agent',
+          attendees: rawAttendees.map((a: unknown) => ({
+            name: typeof a === 'string' ? a : String(a),
+            email: typeof a === 'string' && a.includes('@') ? a : undefined,
+            status: 'needs-action' as const,
+          })),
+          categories: calendar ? [calendar] : [],
+        }
+      } else {
+        // Legacy format
+        const legacy = body as unknown as CreateEventInput
+        if (!legacy.summary || !legacy.organizer) {
+          return reply.code(400).send({ error: 'summary and organizer are required' })
+        }
+        // 422 for past dates in legacy format too
+        if (typeof legacy.dtstart === 'number' && legacy.dtstart < Date.now()) {
+          return reply.code(422).send({ error: 'dtstart must be in the future', code: 'PAST_DATE' })
+        }
+        input = legacy
       }
-      const event = calendarEvents.createEvent(body)
+
+      const event = calendarEvents.createEvent(input)
+
+      // Return spec-shaped response for spec-format requests, full event for legacy
+      if (typeof body.title === 'string') {
+        return reply.code(201).send({
+          id: event.id,
+          title: event.summary,
+          start: new Date(event.dtstart).toISOString(),
+          end: new Date(event.dtend).toISOString(),
+          provider: 'local',
+        })
+      }
       return reply.code(201).send({ success: true, event })
     } catch (err: any) {
       return reply.code(400).send({ error: err.message })

--- a/tests/calendar-upcoming.test.ts
+++ b/tests/calendar-upcoming.test.ts
@@ -1,0 +1,202 @@
+// Tests for calendar agent execution surface
+// GET /calendar/upcoming, POST /calendar/events (spec format), DELETE /calendar/events/:id
+//
+// Task: task-1773516610408-w3fsz0cgj
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import Fastify from 'fastify'
+
+let app: ReturnType<typeof Fastify>
+
+beforeAll(async () => {
+  const { createServer } = await import('../src/server.js')
+  app = await createServer()
+})
+
+beforeEach(async () => {
+  // Clear any events created in tests by deleting all upcoming events
+  const listRes = await app.inject({ method: 'GET', url: '/calendar/events?limit=200' })
+  if (listRes.statusCode === 200) {
+    const body = JSON.parse(listRes.body)
+    for (const evt of body.events ?? []) {
+      await app.inject({ method: 'DELETE', url: `/calendar/events/${evt.id}` })
+    }
+  }
+})
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function futureIso(offsetMs = 24 * 60 * 60 * 1000): string {
+  return new Date(Date.now() + offsetMs).toISOString()
+}
+
+describe('GET /calendar/upcoming', () => {
+  it('returns empty events array when no events exist', async () => {
+    const res = await app.inject({ method: 'GET', url: '/calendar/upcoming' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(Array.isArray(body.events)).toBe(true)
+  })
+
+  it('returns events within the next 7 days by default', async () => {
+    // Create an event tomorrow
+    const tomorrow = futureIso(24 * 60 * 60 * 1000)
+    await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { title: 'Standup', start: tomorrow, duration_minutes: 30 },
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/calendar/upcoming' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.events.some((e: { title: string }) => e.title === 'Standup')).toBe(true)
+  })
+
+  it('respects ?days param', async () => {
+    const in10days = futureIso(10 * 24 * 60 * 60 * 1000)
+    await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { title: 'Far Future Event', start: in10days, duration_minutes: 60 },
+    })
+
+    // ?days=7 should not include it
+    const short = await app.inject({ method: 'GET', url: '/calendar/upcoming?days=7' })
+    const shortBody = JSON.parse(short.body)
+    expect(shortBody.events.some((e: { title: string }) => e.title === 'Far Future Event')).toBe(false)
+
+    // ?days=14 should include it
+    const long = await app.inject({ method: 'GET', url: '/calendar/upcoming?days=14' })
+    const longBody = JSON.parse(long.body)
+    expect(longBody.events.some((e: { title: string }) => e.title === 'Far Future Event')).toBe(true)
+  })
+
+  it('response shape matches spec (id, title, start, end, attendees, provider)', async () => {
+    const start = futureIso(2 * 60 * 60 * 1000)
+    await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: {
+        title: 'Shape Test',
+        start,
+        duration_minutes: 45,
+        attendees: ['ryan@example.com'],
+        calendar: 'Work',
+      },
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/calendar/upcoming' })
+    const body = JSON.parse(res.body)
+    const evt = body.events.find((e: { title: string }) => e.title === 'Shape Test')
+    expect(evt).toBeDefined()
+    expect(evt.id).toBeDefined()
+    expect(evt.start).toBeDefined()
+    expect(evt.end).toBeDefined()
+    expect(Array.isArray(evt.attendees)).toBe(true)
+    expect(evt.provider).toBe('local')
+  })
+})
+
+describe('POST /calendar/events (spec format)', () => {
+  it('creates an event and returns 201 with spec shape', async () => {
+    const start = futureIso()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: {
+        title: '1:1 with Ryan',
+        start,
+        duration_minutes: 30,
+        attendees: ['ryan@example.com'],
+        calendar: 'Work',
+        description: 'Weekly sync',
+      },
+    })
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.body)
+    expect(body.id).toBeDefined()
+    expect(body.title).toBe('1:1 with Ryan')
+    expect(body.start).toBeDefined()
+    expect(body.end).toBeDefined()
+  })
+
+  it('defaults duration_minutes to 60 when omitted', async () => {
+    const start = futureIso(4 * 60 * 60 * 1000)
+    const res = await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { title: 'Long Meeting', start },
+    })
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.body)
+    const durationMs = Date.parse(body.end) - Date.parse(body.start)
+    expect(durationMs).toBe(60 * 60 * 1000)
+  })
+
+  it('returns 422 for past start time', async () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { title: 'Past Event', start: past },
+    })
+    expect(res.statusCode).toBe(422)
+    const body = JSON.parse(res.body)
+    expect(body.code).toBe('PAST_DATE')
+  })
+
+  it('returns 409 for exact duplicate (same title + start)', async () => {
+    const start = futureIso(6 * 60 * 60 * 1000)
+    const payload = { title: 'Duplicate Meeting', start, duration_minutes: 30 }
+
+    const first = await app.inject({ method: 'POST', url: '/calendar/events', payload })
+    expect(first.statusCode).toBe(201)
+
+    const second = await app.inject({ method: 'POST', url: '/calendar/events', payload })
+    expect(second.statusCode).toBe(409)
+    const body = JSON.parse(second.body)
+    expect(body.error).toMatch(/[Dd]uplicate/)
+  })
+
+  it('returns 400 when title is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { start: futureIso() },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('created event appears in GET /calendar/upcoming', async () => {
+    const start = futureIso(3 * 60 * 60 * 1000)
+    await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { title: 'Visible Event', start },
+    })
+    const upcoming = await app.inject({ method: 'GET', url: '/calendar/upcoming' })
+    const body = JSON.parse(upcoming.body)
+    expect(body.events.some((e: { title: string }) => e.title === 'Visible Event')).toBe(true)
+  })
+})
+
+describe('DELETE /calendar/events/:id', () => {
+  it('deletes an existing event and returns 200', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/calendar/events',
+      payload: { title: 'To Delete', start: futureIso(5 * 60 * 60 * 1000) },
+    })
+    const { id } = JSON.parse(res.body)
+
+    const del = await app.inject({ method: 'DELETE', url: `/calendar/events/${id}` })
+    expect(del.statusCode).toBe(200)
+    expect(JSON.parse(del.body).success).toBe(true)
+  })
+
+  it('returns 404 when event does not exist', async () => {
+    const res = await app.inject({ method: 'DELETE', url: '/calendar/events/nonexistent-id' })
+    expect(res.statusCode).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary

Implements the three calendar endpoints for agent execution per spec.

Agents can now read upcoming events, create new ones, and delete them.

## Changes

- **`GET /calendar/upcoming`** (new) — returns next 7 days of confirmed events in spec format: `{ id, title, start, end, attendees, calendar, description, location, provider }`. `?days=N` configurable.
- **`POST /calendar/events`** (upgraded) — now accepts spec format `{ title, start, duration_minutes?, attendees?, calendar?, description? }`:
  - **422** for past `start` dates (`PAST_DATE` code)
  - **409** for exact duplicate (same title + start)
  - `end` auto-computed from `duration_minutes` (defaults to 60min)
  - Legacy `CreateEventInput` format still accepted
- **`DELETE /calendar/events/:id`** — already existed and correct ✅
- **`docs.md`** — route contract updated (545/545)

## Tests

12 new tests (`tests/calendar-upcoming.test.ts`):
- GET /calendar/upcoming: empty, 7-day window, ?days param, response shape
- POST: 201 create, duration default, 422 past date, 409 duplicate, 400 missing title, visible in upcoming
- DELETE: 200 success, 404 not found

## Done Criteria
- ✅ GET /calendar/upcoming returns next 7 days sorted chronologically
- ✅ POST /calendar/events creates event, returns 422 for past dates, 409 for duplicates
- ✅ DELETE /calendar/events/:id deletes, returns 404 if missing
- ✅ All routes in docs.md (contract gate passes)
- ✅ Tests cover happy path + error cases
- ⚠️ Google OAuth2 + Apple CalDAV: auth flow out of scope per spec — endpoints use local storage (existing calendar-events.ts)

## Test Results

- calendar-upcoming.test.ts: 12/12 ✅
- Full suite: 2179/2182 (3 pre-existing canvas-approval-card failures)
- tsc: clean ✅ | route contract: 545/545 ✅

task: task-1773516610408-w3fsz0cgj