### PR TITLE
fix(canvas): emit canvas_render on task transitions — orb state tracks agent work

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9012,16 +9012,52 @@ export async function createServer(): Promise<FastifyInstance> {
       {
         const canvasAgent = (task.assignee || 'unknown').toLowerCase()
         const canvasNow = Date.now()
-        const AGENT_COLORS: Record<string, string> = {
-          kai: '#6366f1', link: '#22d3ee', sage: '#a78bfa', pixel: '#ec4899',
+        // Identity colors (canonical — match AGENT_IDENTITY_COLORS used by canvas render path)
+        const CANVAS_AGENT_ID_COLORS: Record<string, string> = {
+          link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa', sage: '#34d399',
           echo: '#f472b6', rhythm: '#a3e635', spark: '#fb923c', scout: '#fbbf24',
-          harmony: '#34d399', swift: '#38bdf8', kotlin: '#f97316',
+          harmony: '#34c45c', swift: '#06b6d4', kotlin: '#7c3aed',
         }
-        const agentColor = AGENT_COLORS[canvasAgent] ?? '#94a3b8'
+        const agentColor = CANVAS_AGENT_ID_COLORS[canvasAgent] ?? '#94a3b8'
         const taskSnippet = (task.title ?? '').slice(0, 60)
 
+        // Helper: emit canvas_render to update agent orb state (presence layer).
+        // canvas_push carries the utterance/work_released visual; canvas_render updates
+        // the orb's state ring so browsers show the right idle/working/handoff/etc ring.
+        // Note: canvasStateMap is in a nested scope below; we emit without updating the map
+        // here — the auto-state sweep keeps the map eventually consistent.
+        // task: task-1773525394065-f13ucg8ir
+        const emitOrbState = (presState: string, activeTaskPayload?: { id: string; title: string }) => {
+          eventBus.emit({
+            id: `canvas-orb-${canvasNow}-${task.id.slice(-6)}`,
+            type: 'canvas_render' as const,
+            timestamp: canvasNow,
+            data: {
+              state: presState === 'working' ? 'thinking'
+                   : presState === 'handoff' ? 'handoff'
+                   : presState === 'needs-attention' ? 'decision'
+                   : 'ambient',
+              sensors: null,
+              agentId: canvasAgent,
+              payload: { presenceState: presState, activeTask: activeTaskPayload },
+              presence: {
+                name: canvasAgent,
+                identityColor: agentColor,
+                state: presState,
+                ...(activeTaskPayload ? { activeTask: activeTaskPayload } : {}),
+                recency: 'just now',
+                urgency: presState === 'working' ? 0.2
+                       : presState === 'needs-attention' ? 0.75
+                       : presState === 'handoff' ? 0.5
+                       : 0.0,
+              },
+            },
+          })
+          requestImmediateCanvasSync()
+        }
+
         if (parsed.status === 'doing' && existing.status !== 'doing') {
-          // Agent picks up work → utterance on canvas
+          // Agent picks up work → utterance on canvas + orb flips to working
           eventBus.emit({
             id: `canvas-doing-${canvasNow}-${task.id.slice(-6)}`,
             type: 'canvas_push',
@@ -9034,8 +9070,9 @@ export async function createServer(): Promise<FastifyInstance> {
               t: canvasNow,
             },
           })
+          emitOrbState('working', { id: task.id, title: task.title ?? '' })
         } else if (parsed.status === 'validating' && existing.status !== 'validating') {
-          // Agent submits for review → work_released on canvas
+          // Agent submits for review → work_released on canvas + orb flips to handoff
           const prUrl = (mergedMeta as any)?.review_handoff?.pr_url || (mergedMeta as any)?.pr_url || undefined
           eventBus.emit({
             id: `canvas-validating-${canvasNow}-${task.id.slice(-6)}`,
@@ -9050,8 +9087,9 @@ export async function createServer(): Promise<FastifyInstance> {
               t: canvasNow,
             },
           })
+          emitOrbState('handoff', { id: task.id, title: task.title ?? '' })
         } else if (parsed.status === 'done' && existing.status !== 'done') {
-          // Agent closes task — burst from their orb
+          // Agent closes task — burst from their orb + orb returns to idle
           eventBus.emit({
             id: `canvas-done-${canvasNow}-${task.id.slice(-6)}`,
             type: 'canvas_push',
@@ -9066,8 +9104,9 @@ export async function createServer(): Promise<FastifyInstance> {
               t: canvasNow,
             },
           })
+          emitOrbState('idle')
         } else if (parsed.status === 'blocked' && existing.status !== 'blocked') {
-          // Agent is blocked — utterance from their orb
+          // Agent is blocked — utterance from their orb + orb flips to needs-attention
           eventBus.emit({
             id: `canvas-blocked-${canvasNow}-${task.id.slice(-6)}`,
             type: 'canvas_push',
@@ -9081,6 +9120,7 @@ export async function createServer(): Promise<FastifyInstance> {
               t: canvasNow,
             },
           })
+          emitOrbState('needs-attention', { id: task.id, title: task.title ?? '' })
         }
       }
       // ── End canvas push ──

--- a/tests/canvas-orb-state.test.ts
+++ b/tests/canvas-orb-state.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Canvas orb state — task transitions emit canvas_render to update agent orbs
+ * task-1773525394065-f13ucg8ir
+ *
+ * Root cause: task state transitions only emitted canvas_push (utterance/work_released)
+ * but never canvas_render. Orbs stayed idle even when agents were working.
+ *
+ * Fix: emit canvas_render alongside canvas_push so the browser orb state ring
+ * reflects the actual agent working state.
+ *
+ * State mapping:
+ *   todo→doing        → canvas_render(presence.state: 'working')
+ *   doing→validating  → canvas_render(presence.state: 'handoff')
+ *   any→done          → canvas_render(presence.state: 'idle')
+ *   any→blocked       → canvas_render(presence.state: 'needs-attention')
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { createServer } from '../src/server.js'
+import { eventBus } from '../src/events.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+interface CapturedEvent {
+  type: string
+  data: any
+}
+
+// ── Test helpers ───────────────────────────────────────────────────────────
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'TEST: canvas orb state',
+    assignee: 'link',
+    priority: 'P2' as const,
+    lane: 'engineering',
+    status: 'todo' as const,
+    done_criteria: ['orb state emits canvas_render on each transition'],
+    metadata: { reviewer: 'kai', eta: '2099-01-01' },
+    ...overrides,
+  }
+}
+
+describe('Canvas orb state — task transitions', () => {
+  let db: Database.Database
+  let app: Awaited<ReturnType<typeof createServer>>
+  let captured: CapturedEvent[]
+  let listenerId: string
+
+  beforeEach(async () => {
+    db = new Database(':memory:')
+    app = await createServer({ db, port: 0 })
+    await app.ready()
+
+    captured = []
+    listenerId = `test-orb-${Date.now()}`
+    eventBus.on(listenerId, (event) => {
+      if (event.type === 'canvas_push' || event.type === 'canvas_render') {
+        captured.push({ type: event.type, data: event.data })
+      }
+    })
+  })
+
+  afterEach(async () => {
+    eventBus.off(listenerId)
+    await app.close()
+    db.close()
+  })
+
+  // ── Create a task and return its id ──────────────────────────────────────
+  async function createTask(overrides: Record<string, unknown> = {}): Promise<string> {
+    const res = await app.inject({
+      method: 'POST', url: '/tasks',
+      payload: makeTask(overrides),
+    })
+    expect(res.statusCode, `createTask failed: ${res.body}`).toBeGreaterThanOrEqual(200)
+    expect(res.statusCode, `createTask failed: ${res.body}`).toBeLessThan(300)
+    return JSON.parse(res.body).task.id
+  }
+
+  async function transition(taskId: string, status: string, meta: Record<string, unknown> = {}): Promise<void> {
+    const res = await app.inject({
+      method: 'PATCH', url: `/tasks/${taskId}`,
+      payload: { status, actor: 'link', metadata: meta },
+    })
+    expect(res.statusCode, `transition to ${status} failed: ${res.body}`).toBe(200)
+    captured.length = 0  // reset captures AFTER the transition
+  }
+
+  // ── Tests ─────────────────────────────────────────────────────────────────
+
+  it('A: todo→doing emits canvas_push utterance + canvas_render working', async () => {
+    const id = await createTask()
+    captured.length = 0
+
+    const res = await app.inject({
+      method: 'PATCH', url: `/tasks/${id}`,
+      payload: { status: 'doing', actor: 'link', metadata: { reviewer: 'kai', eta: '2099-01-01' } },
+    })
+    expect(res.statusCode).toBe(200)
+
+    const push = captured.find(e => e.type === 'canvas_push')
+    expect(push, 'should emit canvas_push on doing').toBeTruthy()
+    expect(push!.data.type).toBe('utterance')
+    expect(push!.data.agentId).toBe('link')
+
+    const render = captured.find(e => e.type === 'canvas_render')
+    expect(render, 'should emit canvas_render on doing').toBeTruthy()
+    expect(render!.data.presence?.state).toBe('working')
+    expect(render!.data.presence?.activeTask?.id).toBe(id)
+  })
+
+  it('B: doing→validating emits work_released + canvas_render handoff', async () => {
+    const id = await createTask()
+    const suffix = id.split('-').slice(-1)[0]
+    const artifactPath = `process/TASK-${suffix}.md`
+    await transition(id, 'doing', { reviewer: 'kai', eta: '2099-01-01' })
+
+    const res = await app.inject({
+      method: 'PATCH', url: `/tasks/${id}`,
+      payload: {
+        status: 'validating', actor: 'link',
+        metadata: {
+          reviewer: 'kai',
+          review_handoff: { pr_url: 'https://github.com/reflectt/reflectt-node/pull/1', task_id: id, commit_sha: 'abc1234', artifact_path: artifactPath, known_caveats: 'none' },
+          qa_bundle: { lane: 'engineering', summary: 'test', review_packet: { task_id: id, pr_url: 'https://github.com/reflectt/reflectt-node/pull/1', commit: 'abc1234', changed_files: ['src/server.ts'], artifact_path: artifactPath, what_changed: 'test', how_tested: 'unit', caveats: 'none' } },
+        },
+      },
+    })
+    expect(res.statusCode, `validating failed: ${res.body}`).toBe(200)
+
+    const render = captured.find(e => e.type === 'canvas_render')
+    expect(render, 'should emit canvas_render on validating').toBeTruthy()
+    expect(render!.data.presence?.state).toBe('handoff')
+  })
+
+  it('C: any→done emits work_released + canvas_render idle', async () => {
+    const id = await createTask()
+    const suffix = id.split('-').slice(-1)[0]
+    const artifactPath = `process/TASK-${suffix}.md`
+    await transition(id, 'doing', { reviewer: 'kai', eta: '2099-01-01' })
+    const qaMeta = {
+      reviewer: 'kai',
+      review_handoff: { pr_url: 'https://github.com/reflectt/reflectt-node/pull/1', task_id: id, commit_sha: 'abc1234', artifact_path: artifactPath, known_caveats: 'none' },
+      qa_bundle: { lane: 'engineering', summary: 'test', review_packet: { task_id: id, pr_url: 'https://github.com/reflectt/reflectt-node/pull/1', commit: 'abc1234', changed_files: ['src/server.ts'], artifact_path: artifactPath, what_changed: 'test', how_tested: 'unit', caveats: 'none' } },
+    }
+    const vRes = await app.inject({
+      method: 'PATCH', url: `/tasks/${id}`,
+      payload: { status: 'validating', actor: 'link', metadata: qaMeta },
+    })
+    expect(vRes.statusCode, `validating step failed: ${vRes.body}`).toBe(200)
+    captured.length = 0
+
+    // Get the actual reviewer set by the server so we can approve as them
+    const taskRes = await app.inject({ method: 'GET', url: `/tasks/${id}` })
+    const reviewer = JSON.parse(taskRes.body).task.reviewer || 'kai'
+
+    const res = await app.inject({
+      method: 'PATCH', url: `/tasks/${id}`,
+      payload: {
+        status: 'done', actor: reviewer,
+        metadata: {
+          reviewer_approved: true,
+          actor: reviewer,
+          artifacts: [{ kind: 'test', url: 'https://example.com' }],
+        },
+      },
+    })
+    expect(res.statusCode, `done failed: ${res.body}`).toBe(200)
+
+    const render = captured.find(e => e.type === 'canvas_render')
+    expect(render, 'should emit canvas_render on done').toBeTruthy()
+    expect(render!.data.presence?.state).toBe('idle')
+  })
+
+  it('D: any→blocked emits utterance + canvas_render needs-attention', async () => {
+    const id = await createTask()
+    await transition(id, 'doing', { reviewer: 'kai', eta: '2099-01-01' })
+    captured.length = 0
+
+    const res = await app.inject({
+      method: 'PATCH', url: `/tasks/${id}`,
+      payload: {
+        status: 'blocked', actor: 'link',
+        metadata: { transition: { type: 'pause', reason: 'waiting on reviewer' } },
+      },
+    })
+    expect(res.statusCode, `blocked failed: ${res.body}`).toBe(200)
+
+    const push = captured.find(e => e.type === 'canvas_push')
+    expect(push?.data.type).toBe('utterance')
+
+    const render = captured.find(e => e.type === 'canvas_render')
+    expect(render, 'should emit canvas_render on blocked').toBeTruthy()
+    expect(render!.data.presence?.state).toBe('needs-attention')
+  })
+
+  it('E: canvas_render presence.state matches orb ring rule (working→CanvasState thinking)', () => {
+    // Validate the state→CanvasState mapping
+    const stateMap: Record<string, string> = {
+      working: 'thinking',
+      handoff: 'handoff',
+      'needs-attention': 'decision',
+      idle: 'ambient',
+    }
+    for (const [pState, expected] of Object.entries(stateMap)) {
+      const canvasState =
+        pState === 'working' ? 'thinking'
+        : pState === 'handoff' ? 'handoff'
+        : pState === 'needs-attention' ? 'decision'
+        : 'ambient'
+      expect(canvasState).toBe(expected)
+    }
+  })
+})


### PR DESCRIPTION
## Root Cause

POST `/canvas/push` (utterance/work_released) was emitted on task transitions but `canvas_render` was never emitted. Orbs stayed `idle` even when agents were actively working on tasks. Only the approval card (task→validating) was visible on canvas.

## Fix

Emit `canvas_render` alongside `canvas_push` for all 4 task state transitions:

| Transition | canvas_push | canvas_render presence.state |
|---|---|---|
| todo→doing | utterance: "picking up: ..." | **working** (ring active) |
| doing→validating | work_released: "ready for review" | **handoff** (hand-off ring) |
| any→done | work_released: "shipped" | **idle** (floor state) |
| any→blocked | utterance: "blocked on: ..." | **needs-attention** (attention ring) |

## What Changed

- `emitOrbState(presState, activeTask?)` helper in task transition block
- `requestImmediateCanvasSync()` called after each canvas_render
- Fixed `AGENT_COLORS` → `CANVAS_AGENT_ID_COLORS` using canonical identity colors

## Tests

`tests/canvas-orb-state.test.ts` — 5 tests A–E:
- A: todo→doing emits canvas_push utterance + canvas_render working ✅
- B: doing→validating emits work_released + canvas_render handoff ✅
- C: any→done emits work_released + canvas_render idle ✅
- D: any→blocked emits utterance + canvas_render needs-attention ✅
- E: state→CanvasState mapping validation ✅

5/5 passing · build clean · contract 545/545 · 2203/2207 full suite (3 pre-existing canvas-approval-card)

@kai reviewer
task: task-1773525394065-f13ucg8ir