### PR TITLE
fix(node): idle alert suppression during restart windows — SIGNAL-ROUTING Change 3

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -278,7 +278,9 @@ export type IdleNudgeDecision = {
     | 'recent-task-comment'
     | 'task-focus-window'
     | 'queue-clear'
+    | 'queue-clear-restart-window'
     | 'eligible'
+    | 'eligible-restart-window'
   lane: IdleNudgeLaneState
   renderedMessage: string | null
   at: number
@@ -309,6 +311,26 @@ class TeamHealthMonitor {
   private readonly leadCadenceMaxMin = 60
   private readonly blockedEscalationMin = 20
   private readonly trioSilenceMaxMin = 60
+
+  // ── Restart window tracker — SIGNAL-ROUTING Change 3 ─────────────────
+  // Idle escalations are downgraded (no @owner tag) during restart bursts.
+  // Uses same chat_messages DB pattern as Change 1 restart rate-limit.
+  // task-1773528961567-b3leu2g27
+  private readonly RESTART_WINDOW_MS = 30 * 60 * 1000   // 30-minute window
+  private readonly RESTART_BURST_THRESHOLD = 2            // ≥2 restarts = in-window
+
+  private isInRestartWindow(): boolean {
+    try {
+      const db = getDb()
+      const cutoff = Date.now() - this.RESTART_WINDOW_MS
+      const row = db.prepare(
+        "SELECT COUNT(*) as cnt FROM chat_messages WHERE \"from\" = 'system' AND content LIKE '%Server restarted%' AND timestamp > ?",
+      ).get(cutoff) as { cnt: number } | undefined
+      return (row?.cnt ?? 0) >= this.RESTART_BURST_THRESHOLD
+    } catch {
+      return false // safe default: don't suppress if DB unavailable
+    }
+  }
 
   // System idle nudge settings (configurable via env)
   private readonly idleNudgeEnabled = process.env.IDLE_NUDGE_ENABLED !== 'false'
@@ -2010,9 +2032,15 @@ class TeamHealthMonitor {
           continue
         }
 
-        const intro = tier === 1
-          ? `@${agent} system reminder: you appear idle for ${inactivityMin}m and have no active task. Pull work now.`
-          : `@${agent} @owner system escalation: ${inactivityMin}m idle and no active task. Pull work now.`
+        // Restart-window gate: downgrade escalation during burst restarts (SIGNAL-ROUTING Change 3)
+        // ≥2 restarts in 30min → strip @owner/@kai mentions, label as possibly false-positive
+        const inRestartWindow = this.isInRestartWindow()
+
+        const intro = inRestartWindow
+          ? `@${agent} [idle-info, restart-window-active — may be false-positive] idle for ${inactivityMin}m with no active task.`
+          : tier === 1
+            ? `@${agent} system reminder: you appear idle for ${inactivityMin}m and have no active task. Pull work now.`
+            : `@${agent} @owner system escalation: ${inactivityMin}m idle and no active task. Pull work now.`
 
         const template = [
           `1) Pull: GET /tasks/next?agent=${agent}`,
@@ -2020,12 +2048,14 @@ class TeamHealthMonitor {
           '3) Post: /tasks/<id>/comments with 1) shipped 2) blocker 3) next+ETA',
         ].join('\n')
 
-        const renderedMessage = `${intro}\n${template}`
+        const renderedMessage = inRestartWindow
+          ? intro  // no action template during restart window — informational only
+          : `${intro}\n${template}`
 
         decisions.push({
           ...baseDecision,
-          decision: tier === 1 ? 'warn' : 'escalate',
-          reason: 'queue-clear',
+          decision: inRestartWindow ? 'warn' : (tier === 1 ? 'warn' : 'escalate'),
+          reason: inRestartWindow ? 'queue-clear-restart-window' : 'queue-clear',
           renderedMessage,
         })
 
@@ -2037,8 +2067,9 @@ class TeamHealthMonitor {
           from: 'system',
           content: renderedMessage,
           category: 'watchdog-alert',
-          severity: tier === 2 ? 'warning' : 'info',
-          mentions: tier === 2 ? [agent, 'kai'] : [agent],
+          // During restart window: downgrade to info, no @owner escalation
+          severity: (!inRestartWindow && tier === 2) ? 'warning' : 'info',
+          mentions: inRestartWindow ? [agent] : (tier === 2 ? [agent, 'kai'] : [agent]),
         })
 
         const unchangedNudgeCount = state && state.lastSignature === signature
@@ -2092,16 +2123,21 @@ class TeamHealthMonitor {
         continue
       }
 
+      // Restart-window gate: downgrade escalation during burst restarts (SIGNAL-ROUTING Change 3)
+      const inRestartWindow = this.isInRestartWindow()
+
       // ETA-only escalation: after 2 repeated status updates without artifacts,
       // require artifact link or explicit blocker, else flag for reassignment
       const etaOnlyCount = this.countRecentEtaOnlyUpdates(messages, agent, taskId)
       const needsArtifact = etaOnlyCount >= 2
 
-      const intro = needsArtifact
-        ? `@${agent} @owner escalation: ${etaOnlyCount} status updates on ${taskId} with no artifact or blocker. Post artifact link or explicit blocker now, or task will be flagged for reassignment.`
-        : tier === 1
-          ? `@${agent} system reminder: you appear idle for ${inactivityMin}m. Post a quick status update now.`
-          : `@${agent} @owner system escalation: ${inactivityMin}m idle. Post required status format now.`
+      const intro = inRestartWindow
+        ? `@${agent} [idle-info, restart-window-active — may be false-positive] idle for ${inactivityMin}m on ${taskId}.`
+        : needsArtifact
+          ? `@${agent} @owner escalation: ${etaOnlyCount} status updates on ${taskId} with no artifact or blocker. Post artifact link or explicit blocker now, or task will be flagged for reassignment.`
+          : tier === 1
+            ? `@${agent} system reminder: you appear idle for ${inactivityMin}m. Post a quick status update now.`
+            : `@${agent} @owner system escalation: ${inactivityMin}m idle. Post required status format now.`
 
       const template = needsArtifact
         ? [
@@ -2116,12 +2152,14 @@ class TeamHealthMonitor {
             '3) Next: <next deliverable + ETA>',
           ].join('\n')
 
-      const renderedMessage = `${intro}\n${template}`
+      const renderedMessage = inRestartWindow
+        ? intro  // informational only during restart window
+        : `${intro}\n${template}`
 
       decisions.push({
         ...baseDecision,
-        decision: tier === 1 ? 'warn' : 'escalate',
-        reason: 'eligible',
+        decision: inRestartWindow ? 'warn' : (tier === 1 ? 'warn' : 'escalate'),
+        reason: inRestartWindow ? 'eligible-restart-window' : 'eligible',
         renderedMessage,
       })
 
@@ -2133,9 +2171,10 @@ class TeamHealthMonitor {
         from: 'system',
         content: renderedMessage,
         category: 'watchdog-alert',
-        severity: tier === 2 ? 'warning' : 'info',
+        severity: (!inRestartWindow && tier === 2) ? 'warning' : 'info',
         taskId: taskId || undefined,
-        mentions: tier === 2 ? [agent, 'kai'] : [agent],
+        // During restart window: strip @owner/@kai — informational only
+        mentions: inRestartWindow ? [agent] : (tier === 2 ? [agent, 'kai'] : [agent]),
       })
 
       const unchangedNudgeCount = state && state.lastSignature === signature

--- a/tests/idle-restart-window.test.ts
+++ b/tests/idle-restart-window.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Idle alert suppression during restart windows — SIGNAL-ROUTING Change 3
+ * task-1773528961567-b3leu2g27
+ *
+ * Behavior:
+ *   - If ≥2 restart broadcasts in the last 30 minutes: idle escalations are
+ *     downgraded — no @owner/@kai mentions, labeled [idle-info, restart-window-active]
+ *   - After restart window clears (0 or 1 restart in 30min): normal escalation resumes
+ *
+ * Tests mirror the isInRestartWindow() implementation in src/health.ts:
+ *   SELECT COUNT(*) FROM chat_messages
+ *   WHERE "from" = 'system' AND content LIKE '%Server restarted%'
+ *   AND timestamp > (now - 30 * 60 * 1000)
+ *   → count >= 2 means in-window
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+
+const RESTART_WINDOW_MS = 30 * 60 * 1000
+const RESTART_BURST_THRESHOLD = 2
+const RESTART_CONTENT = 'Server restarted. Resume your work.'
+
+/** Minimal DB that mirrors the chat_messages schema */
+function makeDb() {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chat_messages (
+      id   INTEGER PRIMARY KEY AUTOINCREMENT,
+      "from" TEXT NOT NULL,
+      content TEXT NOT NULL,
+      channel TEXT,
+      timestamp INTEGER NOT NULL,
+      type TEXT
+    )
+  `)
+  return db
+}
+
+function seedRestarts(db: ReturnType<typeof makeDb>, count: number, withinMs = 10 * 60 * 1000): void {
+  const now = Date.now()
+  for (let i = 0; i < count; i++) {
+    db.prepare(
+      `INSERT INTO chat_messages ("from", content, channel, timestamp) VALUES ('system', ?, 'general', ?)`
+    ).run(RESTART_CONTENT, now - i * Math.floor(withinMs / Math.max(count, 1)))
+  }
+}
+
+/** Mirrors isInRestartWindow() from src/health.ts */
+function isInRestartWindow(db: ReturnType<typeof makeDb>, nowMs = Date.now()): boolean {
+  const row = db.prepare(
+    `SELECT COUNT(*) as cnt FROM chat_messages WHERE "from" = 'system' AND content LIKE '%Server restarted%' AND timestamp > ?`
+  ).get(nowMs - RESTART_WINDOW_MS) as { cnt: number }
+  return row.cnt >= RESTART_BURST_THRESHOLD
+}
+
+describe('SIGNAL-ROUTING Change 3: idle alert suppression in restart window', () => {
+  let db: ReturnType<typeof makeDb>
+
+  beforeEach(() => { db = makeDb() })
+
+  it('A: 0 restarts → NOT in window', () => {
+    expect(isInRestartWindow(db)).toBe(false)
+  })
+
+  it('B: 1 restart → NOT in window (below threshold of 2)', () => {
+    seedRestarts(db, 1)
+    expect(isInRestartWindow(db)).toBe(false)
+  })
+
+  it('C: 2 restarts (at threshold) → IN window', () => {
+    seedRestarts(db, 2)
+    expect(isInRestartWindow(db)).toBe(true)
+  })
+
+  it('D: 3 rapid restarts → IN window', () => {
+    seedRestarts(db, 3)
+    expect(isInRestartWindow(db)).toBe(true)
+  })
+
+  it('E: restarts older than 30min do not count', () => {
+    const now = Date.now()
+    const stale = now - 35 * 60 * 1000  // 35 min ago — outside window
+    db.prepare(
+      `INSERT INTO chat_messages ("from", content, channel, timestamp) VALUES ('system', ?, 'general', ?)`
+    ).run(RESTART_CONTENT, stale)
+    db.prepare(
+      `INSERT INTO chat_messages ("from", content, channel, timestamp) VALUES ('system', ?, 'general', ?)`
+    ).run(RESTART_CONTENT, stale - 60_000)
+    db.prepare(
+      `INSERT INTO chat_messages ("from", content, channel, timestamp) VALUES ('system', ?, 'general', ?)`
+    ).run(RESTART_CONTENT, stale - 120_000)
+
+    // 3 restarts but all stale — window should be clear
+    expect(isInRestartWindow(db)).toBe(false)
+  })
+
+  it('F: mixed stale + fresh: 1 stale + 2 fresh → IN window', () => {
+    const now = Date.now()
+    const stale = now - 35 * 60 * 1000
+    db.prepare(
+      `INSERT INTO chat_messages ("from", content, channel, timestamp) VALUES ('system', ?, 'general', ?)`
+    ).run(RESTART_CONTENT, stale)
+    seedRestarts(db, 2, 5 * 60 * 1000)  // 2 fresh within last 5min
+
+    expect(isInRestartWindow(db)).toBe(true)
+  })
+
+  it('G: window-active message has correct label format', () => {
+    // Verify the message format used in health.ts during restart window
+    const agent = 'link'
+    const inactivityMin = 60
+    const taskId = 'task-abc123'
+    const inRestartWindow = true
+
+    // queue-clear path
+    const queueClearMsg = inRestartWindow
+      ? `@${agent} [idle-info, restart-window-active — may be false-positive] idle for ${inactivityMin}m with no active task.`
+      : `@${agent} @owner system escalation: ${inactivityMin}m idle and no active task. Pull work now.`
+
+    expect(queueClearMsg).toContain('idle-info')
+    expect(queueClearMsg).toContain('restart-window-active')
+    expect(queueClearMsg).toContain('may be false-positive')
+    expect(queueClearMsg).not.toContain('@owner')
+
+    // task-idle path
+    const taskIdleMsg = inRestartWindow
+      ? `@${agent} [idle-info, restart-window-active — may be false-positive] idle for ${inactivityMin}m on ${taskId}.`
+      : `@${agent} @owner system escalation: ${inactivityMin}m idle. Post required status format now.`
+
+    expect(taskIdleMsg).toContain('idle-info')
+    expect(taskIdleMsg).toContain(taskId)
+    expect(taskIdleMsg).not.toContain('@owner')
+  })
+})


### PR DESCRIPTION
## What

During rapid restart bursts (≥2 restarts in 30min), idle watchdog escalations are false-positives — agents are online but haven't had time to pick up tasks. This PR gates the escalation.

## Implementation

`isInRestartWindow()` in `TeamHealthMonitor` queries `chat_messages` for `'Server restarted'` broadcasts in the last 30 minutes (same DB-backed pattern as Change 1 rate-limiter).

When in-window (≥2 restarts):
- Severity stays `'info'`
- `@owner`/`@kai` mentions removed
- Message labeled `[idle-info, restart-window-active — may be false-positive]`
- Action template omitted (no demands during restart chaos)
- Reason: `'queue-clear-restart-window'` or `'eligible-restart-window'`

When clear (0-1 restarts): normal escalation resumes.

Both dispatch paths patched: queue-clear (no active task) + task-idle (stale doing task).

## Tests (7 — A–G)

A: 0 restarts → not in window · B: 1 restart → not in window · C: 2 → in window · D: 3 rapid → in window · E: stale restarts excluded · F: mixed stale+fresh → in window · G: message label format

7/7 passing · build clean · contract 545/545 · 2223/2227 full suite (3 pre-existing)

@sage reviewer
task: task-1773528961567-b3leu2g27