### PR TITLE
feat(health): add GET /health/version endpoint

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -107,6 +107,7 @@ Remote hosts (multi-host installs) phone-home via a lightweight heartbeat so the
 | GET | `/health/chat` | Chat subsystem health: message counts, drop counters per agent (total + rolling 1h + reasons). Returns `{ totalMessages, rooms, subscribers, drops }`. |
 | GET | `/health/chat` | Chat subsystem health: message counts, drop counters per agent (total + rolling 1h + reasons). Returns `{ totalMessages, rooms, subscribers, drops }`. |
 | GET | `/health/errors` | Request error metrics: total errors, total requests, error rate, and last 20 errors for debugging. Returns `{ total_errors, total_requests, error_rate, recent[], timestamp }`. |
+| GET | `/health/version` | Version summary for ops tooling + cloud dashboard. Returns `{ version, commit, uptime_ms, host_id, node_env }`. |
 | GET | `/health/keepalive` | Self-keepalive status for CF/serverless: warm boot detection, ping state, cold start count, environment info. |
 | GET | `/health/ping` | Ultra-lightweight keepalive — no DB access. Returns `{ status, uptime_seconds, ts }`. Use for cron triggers, load balancers, uptime monitors. |
 | GET | `/health/watchdog` | Richer keepalive with cold_start flag, task/chat stats, boot_info, and remediation hints. For monitoring dashboards. See `docs/KEEPALIVE.md`. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -2519,6 +2519,17 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
+  // ── Version summary — used by cloud dashboard + ops tooling ──────────────
+  app.get('/health/version', async () => {
+    return {
+      version: BUILD_VERSION,
+      commit: BUILD_COMMIT,
+      uptime_ms: Date.now() - BUILD_STARTED_AT,
+      host_id: process.env.REFLECTT_HOST_ID ?? process.env.HOSTNAME ?? 'unknown',
+      node_env: process.env.NODE_ENV ?? 'production',
+    }
+  })
+
   app.get('/health/reflection-pipeline', async () => {
     const health = computeReflectionPipelineHealth(Date.now())
     return {


### PR DESCRIPTION
Closes task-1773548372204-v7sv0yp11.

## What
New lightweight endpoint for ops tooling + cloud dashboard.

`GET /health/version` returns:
```json
{
  "version": "0.1.15",
  "commit": "d5e2303a",
  "uptime_ms": 12345678,
  "host_id": "b8465d7e-...",
  "node_env": "production"
}
```

Lighter than `/health` (no DB stats, no task/chat metrics). Cloud dashboard can poll this to verify deployed version matches expected without the overhead of the full health check.

## Docs contract
+1 route (546 total). `public/docs.md` updated.

@sage — review.