### PR TITLE
fix(test): pin LOCAL_WHISPER_BIN in local-whisper CI tests

### DIFF
--- a/tests/local-whisper.test.ts
+++ b/tests/local-whisper.test.ts
@@ -31,8 +31,10 @@ afterEach(() => {
 
 describe('local-whisper availability check', () => {
   it('returns true when whisper CLI exits successfully', async () => {
+    // Pin LOCAL_WHISPER_BIN so detectWhisperBin() skips `which`/`brew` lookups
+    // (those return empty stdout from the mock, causing null detection).
+    process.env.LOCAL_WHISPER_BIN = '/mock/whisper'
     const { execFile } = await import('node:child_process')
-    const { promisify } = await import('node:util')
     // Mock execFile to call callback with no error
     vi.mocked(execFile).mockImplementation((_bin: any, _args: any, _opts: any, cb: any) => {
       if (typeof cb === 'function') cb(null, '', '')
@@ -45,6 +47,7 @@ describe('local-whisper availability check', () => {
   })
 
   it('returns false when whisper CLI is not found', async () => {
+    process.env.LOCAL_WHISPER_BIN = '/mock/whisper'
     const { execFile } = await import('node:child_process')
     vi.mocked(execFile).mockImplementation((_bin: any, _args: any, _opts: any, cb: any) => {
       if (typeof cb === 'function') cb(new Error('ENOENT'), '', '')


### PR DESCRIPTION
## Problem

PR #1028 introduced `detectWhisperBin()` which calls `execFileAsync('which', ['whisper'])` and `execFileAsync('brew', ['--prefix', 'openai-whisper'])` before the actual `--help` check. The existing unit tests mocked `execFile` to return empty stdout — which causes both detection steps to return falsy, so detection falls through to `null`. `isLocalWhisperAvailable()` then returns `false` in CI (no whisper binary on path).

## Fix

Set `process.env.LOCAL_WHISPER_BIN = '/mock/whisper'` in the two availability tests so `detectWhisperBin()` short-circuits at step 1 (env var override) and the mock only needs to handle the `--help` call it was already designed for.

## Verification

`npx vitest run tests/local-whisper.test.ts` — 6/6 pass locally.

This unblocks PR #1029 (usage sync) which hits this as a CI blocker.