### PR TITLE
fix(dashboard): Doctor page System Diagnostics rendering —

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1644,7 +1644,7 @@ async function loadDoctorPage() {
     const rows = [
       ['Status', data.status ?? '—'],
       ['Version', data.version ?? '—'],
-      ['Uptime', data.uptime != null ? `${Math.floor(data.uptime / 60)}m ${data.uptime % 60}s` : '—'],
+      ['Uptime', data.uptime_seconds != null ? `${Math.floor(data.uptime_seconds / 60)}m ${data.uptime_seconds % 60}s` : '—'],
       ['PID', data.pid ?? data.runtime?.pid ?? '—'],
       ['Node', data.nodeVersion ?? data.runtime?.nodeVersion ?? '—'],
       ['Port', data.port ?? data.runtime?.port ?? '—'],

--- a/src/server.ts
+++ b/src/server.ts
@@ -2480,6 +2480,9 @@ export async function createServer(): Promise<FastifyInstance> {
       version: BUILD_VERSION,
       commit: BUILD_COMMIT,
       uptime_seconds: uptimeSeconds,
+      pid: process.pid,
+      nodeVersion: process.version,
+      port: Number(process.env['PORT'] || process.env['REFLECTT_PORT'] || 4445),
       cold_start: uptimeSeconds < 60, // Flag recent restarts for monitoring
       openclaw: openclawConfig.gatewayToken
         ? { status: 'configured', gateway: openclawConfig.gatewayUrl }


### PR DESCRIPTION
## Problem
Doctor page shows — for Uptime, PID, Node version, and Port despite /health returning data.

## Root Cause
Two bugs:
1. Frontend read `data.uptime` — field doesn't exist. API returns `uptime_seconds`.
2. `pid`, `nodeVersion`, `port` were never included in the /health response, so all fallback chains resolved to `—`.

## Fix
- **server.ts**: Add `pid: process.pid`, `nodeVersion: process.version`, `port: Number(process.env.PORT || 4445)` to /health response
- **dashboard.js**: Fix uptime field name `data.uptime` → `data.uptime_seconds`

## Verified
- Build passes (tsc clean)
- /health now returns all four fields
- Doctor page will render correct values on next server restart

Closes task-1773582865447