### PR TITLE
fix(ops): route restart/reflection broadcasts to #ops; suppress stale review pings

### DIFF
--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -886,6 +886,25 @@ export function hasRequiredArtifacts(meta: Record<string, unknown>): boolean {
 async function escalateViolations(violations: SweepViolation[]): Promise<void> {
   if (violations.length === 0) return
 
+  // ── Race-guard: drop violations for tasks that have since closed or been approved ──
+  // Between sweep snapshot and dispatch, a task may have transitioned to done/cancelled
+  // or received reviewer approval. Sending pings for closed/approved tasks wastes agent
+  // cycles and erodes trust in review notifications.
+  const liveViolations = violations.filter(v => {
+    const lookup = taskManager.resolveTaskId(v.taskId)
+    if (!lookup.task) return false // task deleted — suppress
+    const { status, metadata } = lookup.task
+    if (status === 'done' || status === 'cancelled') return false // already closed
+    const meta = (metadata || {}) as Record<string, unknown>
+    if (meta.reviewer_approved === true || meta.review_state === 'approved') return false // already approved
+    return true
+  })
+  if (liveViolations.length === 0) {
+    logDryRun('sweeper_digest_suppressed_race', `all ${violations.length} violation(s) stale at dispatch time`)
+    return
+  }
+  violations = liveViolations
+
   // Digest-level dedupe: don't re-emit the same digest repeatedly while unchanged.
   // Scope: process-local/in-memory only. The suppression window survives repeated
   // sweeps in the same runtime, but resets on process restart.

--- a/src/index.ts
+++ b/src/index.ts
@@ -641,7 +641,7 @@ async function main() {
           await chatManager.sendMessage({
             from: 'system',
             content: `${mentions} Server restarted. Resume your work.\n📍 ${nodeName} · v${version} · ${ts}`,
-            channel: 'general',
+            channel: 'ops',
           })
           console.log(`🔔 Auto-wake: seeded presence + pinged ${agents.length} agents (${nodeName} v${version})`)
         }

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -6,7 +6,7 @@
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { serverConfig, openclawConfig, isDev, REFLECTT_HOME, DATA_DIR } from './config.js'
-import { readFileSync, existsSync, statSync } from 'fs'
+import { readFileSync, existsSync, statSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 // ── Auth helper ──────────────────────────────────────────────────────
@@ -215,6 +215,34 @@ export function registerManageRoutes(app: FastifyInstance, deps: {
       }
     }
 
+    // Write context snapshot so agents can resume without full state reconstruction
+    try {
+      const { taskManager } = await import('./tasks.js')
+      const { presenceManager } = await import('./presence.js')
+      const snapshot = {
+        restart_at: new Date().toISOString(),
+        restart_method: method,
+        doing_tasks: taskManager.listTasks({ status: 'doing' }).map(t => ({
+          id: t.id,
+          title: t.title,
+          assignee: t.assignee,
+          reviewer: t.reviewer,
+        })),
+        validating_tasks: taskManager.listTasks({ status: 'validating' }).map(t => ({
+          id: t.id,
+          title: t.title,
+          assignee: t.assignee,
+          reviewer: t.reviewer,
+        })),
+        presence: presenceManager.getAllPresence(),
+      }
+      const snapshotPath = join(DATA_DIR, 'restart-context.json')
+      writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2), 'utf-8')
+      console.log(`[manage] restart context snapshot written → ${snapshotPath}`)
+    } catch (err) {
+      console.warn('[manage] failed to write restart context snapshot:', (err as Error)?.message || err)
+    }
+
     // Respond first, then restart
     reply.send({
       status: 'restarting',
@@ -232,6 +260,23 @@ export function registerManageRoutes(app: FastifyInstance, deps: {
         process.kill(process.pid, 'SIGTERM')
       }
     }, 500)
+  })
+
+  // GET /manage/restart-context — read last restart snapshot (agents use on boot to resume)
+  app.get('/manage/restart-context', async (request, reply) => {
+    if (!checkManageAuth(request, reply)) return
+    const snapshotPath = join(DATA_DIR, 'restart-context.json')
+    if (!existsSync(snapshotPath)) {
+      reply.code(404)
+      return { error: 'No restart context snapshot found', hint: 'Snapshot is written on graceful restart via POST /manage/restart' }
+    }
+    try {
+      const raw = readFileSync(snapshotPath, 'utf-8')
+      return JSON.parse(raw)
+    } catch (err) {
+      reply.code(500)
+      return { error: 'Failed to read restart context', details: String((err as Error)?.message || err) }
+    }
   })
 
   // GET /manage/disk — data directory sizes (for capacity monitoring)

--- a/src/reflection-automation.ts
+++ b/src/reflection-automation.ts
@@ -152,7 +152,7 @@ export async function dispatchReflectionTier(
 
     case 'immediate': {
       const msg = `🪞 @${agent} task complete — good moment to reflect. POST /reflections.`
-      batchNag(config.channel || 'general', msg)
+      batchNag('ops', msg)
       return
     }
   }


### PR DESCRIPTION
## What
Addresses two of the three repeating patterns from the insight triage (tasks 1773582857800 + 1773582849549).

## Changes

### 1. Restart broadcasts → #ops (task-1773582857800)
`index.ts`: Auto-wake restart notification now routes to `#ops` instead of `#general`. Prevents the restart flood from interrupting agent focus in #general.

### 2. Reflection reminders → #ops (task-1773582857800)
`reflection-automation.ts`: The `immediate` post-task tier was posting to `config.channel || 'general'`. Changed to always use `'ops'`. The other tiers (digest/mention/escalate) already routed to #ops — this was the last #general leak.

### 3. Context snapshot on restart (task-1773582857800)
`manage.ts`: `POST /manage/restart` now writes `{DATA_DIR}/restart-context.json` before restarting. Snapshot contains doing/validating tasks + presence. Readable via new `GET /manage/restart-context` endpoint (auth-gated).

### 4. Race-guard in escalateViolations (task-1773582849549)
`executionSweeper.ts`: Added a pre-dispatch liveness check in `escalateViolations()`. Before batching the digest, each violation's task is re-fetched. Violations for tasks that are now `done`/`cancelled` or already approved (`reviewer_approved=true` / `review_state='approved'`) are dropped. Same pattern as the existing race-guard in `boardHealthWorker.checkReviewSla()`.

## Testing
- TypeScript compiles clean (pre-existing unrelated error in insight-auto-tagger.ts not introduced here)
- All four changes are surgical — no new dependencies

## Related
- task-1773582857800 (restart noise)
- task-1773582849549 (stale review pings)