### PR TITLE
fix(tasks): relax validating gate for non-code/ops tasks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1056,6 +1056,9 @@ const NON_CODE_LANE_KEYWORDS = [
 ]
 
 function isNonCodeLane(metadata: Record<string, unknown>): boolean {
+  // Explicit top-level flag: metadata.non_code=true
+  if (metadata.non_code === true) return true
+
   const lane = normalizeLaneValue(metadata.lane)
   if (NON_CODE_LANE_KEYWORDS.some(k => lane.includes(k))) return true
 

--- a/src/taskPrecheck.ts
+++ b/src/taskPrecheck.ts
@@ -128,9 +128,25 @@ export function runPrecheck(taskId: string, targetStatus: string): PrecheckResul
   // ── validating ──────────────────────────────────────────────────────
 
   if (targetStatus === 'validating') {
-    // Detect non-code task (explicit flag or lane-based)
+    // Detect non-code task — mirrors server.ts isNonCodeLane logic.
+    // Checks (in priority order):
+    //   1. metadata.non_code === true (top-level explicit flag)
+    //   2. review_handoff.non_code / doc_only / config_only
+    //   3. metadata.lane in non-code keyword list (ops/strategy/research/etc.)
+    const NON_CODE_LANE_KEYWORDS = [
+      'design', 'docs', 'documentation', 'content',
+      'ops', 'operations', 'finance', 'legal', 'admin',
+      'strategy', 'assessment', 'support', 'marketing',
+      'back-office', 'backoffice', 'research', 'planning',
+    ]
     const handoff = meta.review_handoff as Record<string, unknown> | undefined
-    const isNonCode = handoff?.non_code === true || handoff?.doc_only === true || handoff?.config_only === true
+    const lane = String(meta.lane ?? '').toLowerCase().trim()
+    const isNonCode =
+      meta.non_code === true ||
+      handoff?.non_code === true ||
+      handoff?.doc_only === true ||
+      handoff?.config_only === true ||
+      NON_CODE_LANE_KEYWORDS.some(k => lane.includes(k))
 
     // Artifact path
     const artifactPath = meta.artifact_path as string | undefined
@@ -370,6 +386,39 @@ function buildTemplate(
   }
 
   if (targetStatus === 'validating') {
+    const NON_CODE_LANE_KEYWORDS = [
+      'design', 'docs', 'documentation', 'content',
+      'ops', 'operations', 'finance', 'legal', 'admin',
+      'strategy', 'assessment', 'support', 'marketing',
+      'back-office', 'backoffice', 'research', 'planning',
+    ]
+    const meta = (task.metadata as Record<string, unknown>) || {}
+    const handoff = meta.review_handoff as Record<string, unknown> | undefined
+    const lane = String(meta.lane ?? '').toLowerCase().trim()
+    const isNonCode =
+      meta.non_code === true ||
+      handoff?.non_code === true ||
+      handoff?.doc_only === true ||
+      handoff?.config_only === true ||
+      NON_CODE_LANE_KEYWORDS.some(k => lane.includes(k))
+
+    if (isNonCode) {
+      // Non-code template: analysis, ops, strategy, docs tasks
+      // No PR/commit/qa_bundle required — review_handoff with non_code=true is sufficient
+      return {
+        status: 'validating',
+        metadata: {
+          artifact_path: autoDefaults['metadata.artifact_path'] || `process/TASK-${shortId}.md`,
+          review_handoff: {
+            task_id: task.id,
+            artifact_path: `process/TASK-${shortId}.md`,
+            known_caveats: '<required: "none" or description>',
+            non_code: true,
+          },
+        },
+      }
+    }
+
     return {
       status: 'validating',
       metadata: {

--- a/tests/non-code-task-gate.test.ts
+++ b/tests/non-code-task-gate.test.ts
@@ -137,6 +137,54 @@ describe('Non-code task gate', () => {
     expect(body.task?.status).toBe('validating')
   })
 
+  it('allows task with top-level metadata.non_code=true to validating without PR fields', async () => {
+    const srv = await getApp()
+    const task = await createTestTask({ lane: 'engineering', non_code: true })
+
+    await srv.inject({ method: 'PATCH', url: `/tasks/${task.id}`, payload: { status: 'doing' } })
+
+    const res = await srv.inject({
+      method: 'PATCH',
+      url: `/tasks/${task.id}`,
+      payload: {
+        status: 'validating',
+        metadata: {
+          non_code: true,
+          artifact_path: `process/TASK-${task.id.split('-').pop()}.md`,
+          review_handoff: {
+            task_id: task.id,
+            artifact_path: `process/TASK-${task.id.split('-').pop()}.md`,
+            known_caveats: 'none',
+            non_code: true,
+          },
+        },
+      },
+    })
+
+    const body = JSON.parse(res.body)
+    expect(res.statusCode).toBe(200)
+    expect(body.task?.status).toBe('validating')
+  })
+
+  it('taskPrecheck returns non-code template for ops-lane task', async () => {
+    const { runPrecheck } = await import('../src/taskPrecheck.js')
+    const task = await createTestTask({ lane: 'ops' })
+
+    const result = runPrecheck(task.id, 'validating')
+    // Should not flag pr_url or commit_sha as errors
+    const errorFields = result.items.filter(i => i.severity === 'error').map(i => i.field)
+    expect(errorFields).not.toContain('metadata.review_handoff.pr_url')
+    expect(errorFields).not.toContain('metadata.review_handoff.commit_sha')
+    expect(errorFields).not.toContain('metadata.review_handoff.test_proof')
+    // Template should be non-code format (no pr_url/commit_sha placeholders)
+    const template = result.template as Record<string, unknown> | null
+    const handoff = (template?.metadata as any)?.review_handoff as Record<string, unknown> | undefined
+    expect(handoff).toBeDefined()
+    expect(handoff?.non_code).toBe(true)
+    expect(handoff?.pr_url).toBeUndefined()
+    expect(handoff?.commit_sha).toBeUndefined()
+  })
+
   it('error message mentions non_code=true as escape hatch', async () => {
     const srv = await getApp()
     const task = await createTestTask({ lane: 'engineering' })


### PR DESCRIPTION
## Problem (Pattern 7 from insight triage)
Validating required a full code-shaped qa_bundle (pr_url, commit_sha, review_packet, changed_files) even for strategy/ops/analysis tasks. Agents hit this 4+ times during the insight triage.

Root cause: taskPrecheck.ts isNonCode detection was misaligned with server.ts — precheck only checked review_handoff flags, ignoring metadata.lane and top-level metadata.non_code. Ops/strategy tasks got error-severity blocks on pr_url and commit_sha with no clear escape hatch in the template.

## Changes

**taskPrecheck.ts — aligned isNonCode detection**
Now mirrors server.ts: checks metadata.non_code, review_handoff flags, AND metadata.lane in NON_CODE_LANE_KEYWORDS (ops/strategy/research/planning/docs/etc.)

**taskPrecheck.ts — non-code template**
Template builder returns non-code format when isNonCode=true: review_handoff with non_code=true only. No pr_url/commit_sha/test_proof placeholders.

**server.ts — isNonCodeLane recognises metadata.non_code=true**
Previously only checked lane keywords and qa_bundle.non_code. Now metadata.non_code=true at top level is an explicit bypass.

## Tests
6/6 pass in non-code-task-gate.test.ts. Two new cases added.

Fixes task-1773587358650