### PR TITLE
fix(insights): add word boundaries to ci/cd/pr patterns in auto-tagger

### DIFF
--- a/src/insight-auto-tagger.ts
+++ b/src/insight-auto-tagger.ts
@@ -126,16 +126,19 @@ export const DEFAULT_AUTO_TAG_RULES: AutoTagRule[] = [
     patterns: [
       '\\bdeploy(ment|ed)?\\b',
       // release/build only match when paired with infra/CI context words
-      'release.+(?:pipeline|ci|cd|fly|vercel|docker|infra)',
-      '(?:pipeline|ci|cd|fly|vercel|docker|infra).+release',
-      'build.+(?:fail|ci|cd|pipeline|infra|docker)',
-      '(?:ci|cd|pipeline|docker).+build',
+      // NOTE: \bci\b and \bcd\b require word boundaries — bare "ci"/"cd" match
+      // as substrings in words like "velocity", "decisions", "decide", etc.
+      'release.+(?:pipeline|\\bci\\b|\\bcd\\b|fly|vercel|docker|infra)',
+      '(?:pipeline|\\bci\\b|\\bcd\\b|fly|vercel|docker|infra).+release',
+      'build.+(?:fail|\\bci\\b|\\bcd\\b|pipeline|infra|docker)',
+      '(?:\\bci\\b|\\bcd\\b|pipeline|docker).+build',
       '\\bci\\b.+(?:fail|block|broken|pass)',
       '(?:fail|block|broken).+\\bci\\b',
-      'pr.+stall',
-      'stall.+pr',
-      'distribution.+pr',
-      'merged.+pr',
+      '\\bprs?\\b.+stall',
+      'stall.+\\bprs?\\b',
+      'distribution.+\\bprs?\\b',
+      '\\bprs?\\b.+merged',
+      'merged.+\\bprs?\\b',
       '\\bpipeline\\b',
     ],
   },


### PR DESCRIPTION
## Problem

Link's PR tightening deployment patterns introduced a regression: bare `ci` and `cd` in non-capturing groups matched as substrings in words like `velocity` (velo**ci**ty), `decisions` (de**ci**sions), and `product` (p**r**oduct). This caused process-family insights to be misclassified as deployment.

**Examples caught by this fix:**
- `product decisions defer to Ryan — velocity stalls on build direction` → was: deployment, now: process ✅
- `team velocity stalls on release strategy` → was: deployment, now: process ✅
- `product build decisions defer to Ryan` → was: deployment, now: process ✅

**Good cases preserved:**
- `Distribution PRs stalling — filed 3 PRs from audit` → deployment ✅
- `CI pipeline failing on main` → deployment ✅

## Root cause

Patterns like `(?:ci|cd|pipeline|docker).+build` and `pr.+stall` lacked word boundaries, making them substring-match triggers rather than word-level anchors.

## Fix

Added `\b` boundaries to `ci`, `cd`, and `pr` in all deployment patterns. Also extended `pr` → `prs?` to handle the plural form (PRs).

## Tests

All 42 unit tests pass. Builds on top of Link's branch (`link/fix-autotagger-deployment-patterns`).

Task: task-1773587464766-wun9whpnt
Reviewer: @sage