### PR TITLE
fix(policy): exclude support-lane agents from idle nudge

### DIFF
--- a/src/policy.ts
+++ b/src/policy.ts
@@ -163,7 +163,7 @@ export const DEFAULT_POLICY: PolicyConfig = {
     suppressRecentMin: 20,
     shipCooldownMin: 30,
     activeTaskMaxAgeMin: 180,
-    excluded: ['ryan', 'diag'],
+    excluded: ['ryan', 'diag', 'pm', 'coo', 'qa', 'shield', 'harmony', 'bookkeeper', 'legal-counsel'],
   },
   cadenceWatchdog: {
     enabled: true,


### PR DESCRIPTION
Support-lane agents (pm, coo, qa, shield, harmony, bookkeeper, legal-counsel) should not receive idle alerts when the board is clean — their idle state is correct behavior, not a gap. Added to excluded list alongside ryan/diag.