### PR TITLE
fix(watchdog): suppress idle nudge when ready queue is empty

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -277,6 +277,7 @@ export type IdleNudgeDecision = {
     | 'presence-task-mismatch'
     | 'recent-task-comment'
     | 'task-focus-window'
+    | 'queue-empty-suppressed'
     | 'queue-clear'
     | 'queue-clear-restart-window'
     | 'eligible'
@@ -2026,6 +2027,16 @@ class TeamHealthMonitor {
 
       // Engagement nudge: if agent is idle and has no active doing lane, prompt them to pull/claim work.
       if (lane.laneReason === 'no-active-lane') {
+        // Queue-empty gate: suppress idle nudge when the ready queue is empty.
+        // An agent with nothing to pull is compliant, not idle — nudging them is noise.
+        // Check both unassigned todo tasks and tasks assigned to this agent.
+        const readyForAgent = taskManager.listTasks({ status: 'todo' })
+          .filter(t => !t.assignee || (t.assignee || '').toLowerCase() === agent.toLowerCase())
+        if (readyForAgent.length === 0) {
+          decisions.push({ ...baseDecision, decision: 'none', reason: 'queue-empty-suppressed', renderedMessage: null })
+          continue
+        }
+
         const signature = `queue-clear:${agent}`
         if (state && state.lastSignature === signature && state.unchangedNudgeCount >= 2) {
           decisions.push({ ...baseDecision, decision: 'none', reason: 'max-repeat-reached', renderedMessage: null })


### PR DESCRIPTION
Fixes false-positive idle nudges when the queue itself is empty.

**Root cause** (@artdirector flagged via digest): watchdog fires `queue-clear` nudge (`you appear idle, pull work now`) without checking whether there's anything available to pull. Agents like @coo, @cos, @kindling, @quill, @funnel were getting nudged purely because continuity loop hadn't replenished their lanes — not because they were slacking.

**Fix**: Before the `no-active-lane` nudge fires, query todo tasks that are either unassigned or assigned to this agent. If `readyForAgent.length === 0`, emit `reason='queue-empty-suppressed'` and skip. New reason added to `IdleNudgeDecision` type union.

**Impact**: Eliminates an entire class of noise alerts. Agents with empty queues are now correctly classified as compliant rather than idle.