### PR TITLE
fix(continuity-loop): gate auto-fill on idle state + skip blocked_external agents

### DIFF
--- a/src/continuity-loop.ts
+++ b/src/continuity-loop.ts
@@ -200,6 +200,20 @@ export async function tickContinuityLoop(): Promise<{
 
     if (unblockedTodo.length >= config.minReady) continue
 
+    // Auto-fill gate: only fill when agent is truly idle (todo=0 AND doing=0).
+    // If the agent is actively working on something, let them finish first.
+    // blocked_external doing tasks also skip — external dependency, not idleness.
+    const doingTasks = taskManager.listTasks({ status: 'doing', assignee: agent })
+    if (doingTasks.length > 0) continue
+
+    // Skip agents whose current task is blocked on an external dependency
+    const hasBlockedExternal = taskManager.listTasks({ assignee: agent })
+      .some(t => (t.metadata as any)?.blocked_external === true)
+    if (hasBlockedExternal) continue
+
+    // [continuity-loop] auto-fill triggered
+    console.log(`[continuity-loop] auto-fill: @${agent} queue empty (todo=0, doing=0) — generating tasks`)
+
     // Queue is below floor — attempt replenishment
     const deficit = config.minReady - unblockedTodo.length
 


### PR DESCRIPTION
Implements task-1773607280537 criteria:

1. **todo=0 AND doing=0 gate** — auto-fill only fires when the agent is truly idle. Previously replenished when `unblockedTodo < minReady` regardless of active doing tasks, causing premature queue fills while work was in flight.

2. **blocked_external skip** — agents with a `metadata.blocked_external=true` task are waiting on an external dependency, not idle. Skipping them prevents pointless replenishment until the blocker clears.

3. **`[continuity-loop] auto-fill` log** — emitted to stdout when fill triggers, making it visible in server logs.

tsc clean. continuity-loop tests: 12/12 pass.