### PR TITLE
feat(cloud): poll canvas/query-queue for NAT-behind relay queries

### DIFF
--- a/process/TASK-mvyenno83.md
+++ b/process/TASK-mvyenno83.md
@@ -1,0 +1,16 @@
+# Process: task-1773609200822-mvyenno83 — canvas/query relay queue
+
+## Changes (node)
+- src/cloud.ts: pollCanvasQueryQueue() — polls every 5s on approval sync timer
+  - GET /api/hosts/:id/canvas/query-queue → fetch queued queries
+  - POST /canvas/query locally for each → response arrives via canvas_message SSE
+  - POST /api/hosts/:id/canvas/query-queue to ACK processed queryIds
+
+## Changes (cloud)
+- apps/api/src/presence-relay.ts: queueCanvasQuery(), handleGetCanvasQueryQueue(), handleAckCanvasQueries()
+- apps/api/src/index.ts: relay queue fallback when nodeUrl===null; two new routes (GET+POST /canvas/query-queue)
+
+## AC
+- [x] canvas/query returns 202+{queued:true} for NAT-behind nodes (no 503)
+- [x] node polls every 5s and processes queries locally → canvas_message SSE → browser
+- [x] managed hosts with direct nodeUrl are unaffected (proxy path unchanged)

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -481,6 +481,7 @@ export async function startCloudIntegration(): Promise<void> {
   state.approvalSyncTimer = setInterval(() => {
     syncRunApprovals().catch(() => {})
     pollAgentDecisions().catch(() => {}) // poll queued relay decisions (NAT-behind hosts)
+    pollCanvasQueryQueue().catch(() => {}) // poll queued canvas queries (NAT-behind hosts)
   }, APPROVAL_SYNC_INTERVAL_MS)
 
   // Run event sync — every 5s
@@ -2071,5 +2072,60 @@ async function cloudPost<T = unknown>(path: string, body: unknown): Promise<Clou
   } catch (err: any) {
     // Don't increment errors here — callers handle error counting
     return { success: false, error: err?.message || 'Request failed' }
+  }
+}
+
+// ---- Canvas Query Relay Poll ----
+// Node polls cloud for queued canvas queries (from NAT-behind hosts).
+// Processes each query locally via POST /canvas/query, then ACKs.
+// Response arrives via canvas_message event on pulse SSE — no HTTP wait.
+
+let lastCanvasQueryPollAt = 0
+const CANVAS_QUERY_POLL_INTERVAL_MS = 5_000 // 5s — faster than decisions (interactive UX)
+
+export async function pollCanvasQueryQueue(): Promise<void> {
+  if (!state.hostId || !config) return
+
+  const now = Date.now()
+  if (now - lastCanvasQueryPollAt < CANVAS_QUERY_POLL_INTERVAL_MS) return
+  lastCanvasQueryPollAt = now
+
+  try {
+    const result = await cloudGet<{
+      queries: Array<{ queryId: string; query: string; sessionId: string | null; agentId: string | null; queuedAt: number }>
+    }>(`/api/hosts/${state.hostId}/canvas/query-queue`)
+    if (!result.success) return
+
+    const queries = Array.isArray(result.data?.queries) ? result.data.queries : []
+    if (queries.length === 0) return
+
+    const acked: string[] = []
+
+    for (const q of queries) {
+      try {
+        const body: Record<string, unknown> = { query: q.query }
+        if (q.sessionId) body.sessionId = q.sessionId
+        if (q.agentId) body.agentId = q.agentId
+        const res = await fetch('http://127.0.0.1:4445/canvas/query', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(8000),
+        })
+        if (res.ok || res.status === 400) {
+          // 400 = malformed query — still ACK to avoid retry loops
+          acked.push(q.queryId)
+        }
+      } catch {
+        // Individual failure — leave in queue, retry next cycle
+      }
+    }
+
+    if (acked.length > 0) {
+      await cloudPost(`/api/hosts/${state.hostId}/canvas/query-queue`, { queryIds: acked })
+      console.log(`☁️  [CanvasQueryRelay] Processed ${acked.length}/${queries.length} queued queries`)
+    }
+  } catch {
+    // Non-critical — queries will be retried next cycle
   }
 }


### PR DESCRIPTION
## Summary
Node-side polling for canvas query relay queue. When Mac Daddy (or any NAT-behind node) receives a canvas query that was queued via the cloud relay (cloud PR #1273), this polls and processes it.

## How it works
`pollCanvasQueryQueue()` runs every 5s on the approval sync timer:
1. `GET /api/hosts/:id/canvas/query-queue` — fetch pending queries
2. `POST /canvas/query` locally for each — LLM processes, emits `canvas_message`
3. `POST /api/hosts/:id/canvas/query-queue` — ACK with processed queryIds

Response arrives via canvas_message → /canvas/pulse SSE → browser. No HTTP polling needed on client.

Paired with reflectt-cloud PR #1273.
Closes task-1773609200822-mvyenno83