### PR TITLE
fix(canvas): orbs visible — 60min stale cutoff + seed canvasStateMap from heartbeat

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11701,7 +11701,7 @@ export async function createServer(): Promise<FastifyInstance> {
   // Drives smooth canvas animation without polling. Each tick includes per-agent orb data + team mood.
   // Tick shape: { agents: [{ id, state, urgency, activeSpeaker, color, age }], team: { rhythm, tension, ambientPulse, dominantColor } }
   app.get('/canvas/pulse', async (request, reply) => {
-    const STALE_MS = 10 * 60 * 1000
+    const STALE_MS = 60 * 60 * 1000 // 60min — agents stay visible as long as they heartbeat
     const IDENTITY_COLORS: Record<string, string> = {
       kai: '#fb923c',
       pixel: '#a78bfa',
@@ -13831,6 +13831,26 @@ export async function createServer(): Promise<FastifyInstance> {
       ...(t.scheduledFor ? { scheduledFor: t.scheduledFor } : {}),
     } : null
     presenceManager.recordActivity(agent, 'heartbeat')
+
+    // Keep canvasStateMap fresh — agents visible on canvas as long as they heartbeat.
+    // Derive canvas state from task activity (same logic as emitOrbState).
+    {
+      const derivedState = activeTask
+        ? (activeTask.status === 'blocked' ? 'working' : 'working')
+        : (nextTask ? 'idle' : 'idle')
+      const prevEntry = canvasStateMap.get(agent)
+      canvasStateMap.set(agent, {
+        state: derivedState as any,
+        sensors: null,
+        payload: {
+          ...(prevEntry?.payload as Record<string, unknown> ?? {}),
+          presenceState: activeTask ? 'working' : 'idle',
+          sourceTasks: activeTask ? [{ id: activeTask.id, title: activeTask.title, status: activeTask.status }] : [],
+          _auto: true,
+        },
+        updatedAt: Date.now(),
+      })
+    }
 
     // Check pause status
     const pauseStatus = checkPauseStatus(agent)


### PR DESCRIPTION
## Problem
Canvas showed zero agent orbs. `/canvas/pulse` returned `agents:[]`.

Root cause: STALE_MS = 10 minutes in pulse tick. Agents update `canvasStateMap` when they emit orb state, but in practice this happens every 30–50 minutes during normal work. All entries were silently pruned — canvas = empty floor with no team.

## Two fixes

**1. Increase STALE_MS to 60 min** in `/canvas/pulse`  
Agents working on long tasks won't disappear mid-session.

**2. Seed `canvasStateMap` from `/heartbeat/:agent`**  
Agents heartbeat every 5–15 min. Now each heartbeat refreshes their canvas state entry: `working` if they have an active task, `idle` otherwise. This keeps orbs alive between explicit `/canvas/state` calls.

## Verified
`curl -N .../canvas/pulse` returns 12 agents after fix + node restart.