### PR TITLE
fix(watchdog): add design lane — artdirector/uipolish get lane-scoped idle suppression

### DIFF
--- a/src/lane-config.ts
+++ b/src/lane-config.ts
@@ -31,11 +31,12 @@ export interface LaneConfig {
 // These are the fallback when TEAM-ROLES.yaml has no `lanes:` section.
 
 export const DEFAULT_LANES: LaneConfig[] = [
-  { name: 'engineering', agents: ['link', 'pixel'], readyFloor: 2, wipLimit: 2 },
-  { name: 'content',     agents: ['echo'],          readyFloor: 2, wipLimit: 2 },
-  { name: 'operations',  agents: ['kai', 'sage'],   readyFloor: 1, wipLimit: 2 },
-  { name: 'research',    agents: ['scout'],         readyFloor: 1, wipLimit: 2 },
-  { name: 'rhythm',      agents: ['rhythm'],        readyFloor: 1, wipLimit: 2 },
+  { name: 'engineering', agents: ['link', 'pixel'],           readyFloor: 2, wipLimit: 2 },
+  { name: 'design',      agents: ['artdirector', 'uipolish'], readyFloor: 1, wipLimit: 2 },
+  { name: 'content',     agents: ['echo'],                    readyFloor: 2, wipLimit: 2 },
+  { name: 'operations',  agents: ['kai', 'sage'],             readyFloor: 1, wipLimit: 2 },
+  { name: 'research',    agents: ['scout'],                   readyFloor: 1, wipLimit: 2 },
+  { name: 'rhythm',      agents: ['rhythm'],                  readyFloor: 1, wipLimit: 2 },
 ]
 
 // ── Config paths ────────────────────────────────────────────────────────────

--- a/tests/idle-nudge-lane-aware.test.ts
+++ b/tests/idle-nudge-lane-aware.test.ts
@@ -105,3 +105,41 @@ describe('idle nudge lane-aware suppression', () => {
     await taskManager.deleteTask(task.id)
   })
 })
+
+// ── Lane-scoped suppression: artdirector / design lane (task-1773617908405) ──
+
+describe('artdirector lane-scoped idle suppression', () => {
+  it('getNextTask returns undefined for artdirector when only engineering tasks exist', async () => {
+    const engTask = await taskManager.createTask({
+      title: 'Engineering task — not for design lane',
+      assignee: 'link',
+      status: 'todo',
+      priority: 'P2',
+      createdBy: 'link',
+      done_criteria: ['n/a'],
+    })
+
+    // artdirector is in design lane — should not see engineering tasks
+    const next = taskManager.getNextTask('artdirector')
+    expect(next).toBeUndefined()
+
+    await taskManager.deleteTask(engTask.id)
+  })
+
+  it('getNextTask returns task for artdirector when a design task is assigned', async () => {
+    const designTask = await taskManager.createTask({
+      title: 'Design task for artdirector',
+      assignee: 'artdirector',
+      status: 'todo',
+      priority: 'P2',
+      createdBy: 'system',
+      done_criteria: ['n/a'],
+    })
+
+    const next = taskManager.getNextTask('artdirector')
+    expect(next).toBeDefined()
+    expect(next?.id).toBe(designTask.id)
+
+    await taskManager.deleteTask(designTask.id)
+  })
+})


### PR DESCRIPTION
Fixes task-1773617908405: false idle nudges for artdirector when design-lane queue is empty.

**Root cause**: `artdirector` and `uipolish` were absent from `DEFAULT_LANES`. `getAgentLane()` returned `null`, so `getNextTask('artdirector')` fell through to the global unassigned pool — finding tasks from engineering/ops/content lanes. Queue never appeared empty → `queue-empty-suppressed` never fired → idle nudge always triggered.

**Fix**: Add `design` lane to `DEFAULT_LANES` with `artdirector` and `uipolish`. `getNextTask('artdirector')` now scopes to design tasks only. Empty design queue → `undefined` → nudge suppressed.

**Side effects**: Also fixes WIP limits and cross-lane routing for design agents (previously unlimited WIP and could pull any unassigned task).

**Tests**: 4/4 idle-nudge-lane-aware (2 new test cases: artdirector sees no engineering tasks, artdirector sees own assigned tasks).