### PR TITLE
fix(watchdog): explicit blocked_external suppression gate in idle nudge

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -278,6 +278,7 @@ export type IdleNudgeDecision = {
     | 'recent-task-comment'
     | 'task-focus-window'
     | 'queue-empty-suppressed'
+    | 'blocked-external-suppressed'
     | 'queue-clear'
     | 'queue-clear-restart-window'
     | 'eligible'
@@ -2022,6 +2023,17 @@ class TeamHealthMonitor {
       const hasValidatingTask = tasks.some((t: any) => (t.assignee || '').toLowerCase() === agent && t.status === 'validating')
       if (hasValidatingTask) {
         decisions.push({ ...baseDecision, decision: 'none', reason: 'validating-task-suppressed', renderedMessage: null })
+        continue
+      }
+
+      // Explicit blocked_external gate: agent has a task waiting on a human dependency.
+      // This is a hard signal — suppress all idle nudges regardless of queue state.
+      // Fires even if getNextTask() would return a task (a new task doesn't unblock the dependency).
+      const hasBlockedExternal = tasks.some(
+        (t: any) => (t.assignee || '').toLowerCase() === agent && (t.metadata as any)?.blocked_external === true
+      )
+      if (hasBlockedExternal) {
+        decisions.push({ ...baseDecision, decision: 'none', reason: 'blocked-external-suppressed', renderedMessage: null })
         continue
       }
 


### PR DESCRIPTION
Fixes false idle nudges for agents with `blocked_external=true` tasks.

**Root cause**: A `blocked_external` doing task with stale `updatedAt` gets classified as `no-active-lane` by `resolveIdleNudgeLane` — the task is too old to count as 'fresh'. The stale-lane path suppresses, but the no-active-lane path proceeds to the queue-check and then fires the nudge.

**Fix**: Explicit `blocked-external-suppressed` gate added after `validating-task-suppressed`, before the lane-reason branches. Any agent with a `metadata.blocked_external=true` task is suppressed unconditionally — this is a hard human-dependency signal.

**Issue #1 investigation**: `metadata.blocked_external` IS persisted to SQLite and survives restarts. Confirmed on kindling's current task. The restart didn't clear the flag — the watchdog was just classifying the stale task incorrectly.

New type union entry: `'blocked-external-suppressed'` in `IdleNudgeDecision.reason`.