### PR TITLE
refactor(tasks): extract DONE_CRITERIA_PLACEHOLDER_RE to module level

### DIFF
--- a/process/TASK-q5u2sk3di.md
+++ b/process/TASK-q5u2sk3di.md
@@ -1,0 +1,16 @@
+# Task: task-1773617522840-q5u2sk3di — refactor(tasks): extract DONE_CRITERIA_PLACEHOLDER_RE to module level
+
+## Artifact
+PR: https://github.com/reflectt/reflectt-node/pull/1066 (pending)
+
+## Changes
+- src/server.ts:
+  - Added module-level `DONE_CRITERIA_PLACEHOLDER_RE` constant after `TASK_TYPES` (line 212)
+  - Removed inline `const DONE_CRITERIA_PLACEHOLDER_RE` from `checkDefinitionOfReady` function
+  - Removed inline `const PLACEHOLDER_RE` from POST /tasks creator-type gate
+  - Both usage sites now reference the shared constant — no behavior change
+
+## AC
+- [x] Single DONE_CRITERIA_PLACEHOLDER_RE constant defined at module level
+- [x] All usage sites reference the shared constant
+- [x] No behavior change — same regex pattern

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,6 +207,10 @@ const SendMessageSchema = z.object({
 
 // Task type determines required fields beyond the base schema
 const TASK_TYPES = ['bug', 'feature', 'process', 'docs', 'chore'] as const
+
+// Shared placeholder pattern for done_criteria validation.
+// Used in checkDefinitionOfReady (DoR gate) and POST /tasks creator-type gating.
+const DONE_CRITERIA_PLACEHOLDER_RE = /^\s*(tbd|todo|to-do|to do|placeholder|n\/a|na|none|fix later|coming soon|see description|wip|tbh|tbw)\s*$/i
 type TaskType = typeof TASK_TYPES[number]
 
 const CreateTaskSchema = z.object({
@@ -263,7 +267,6 @@ function checkDefinitionOfReady(data: z.infer<typeof CreateTaskSchema>): string[
   }
 
   // Done criteria quality: reject placeholder text (TBD, TODO, placeholder, etc.)
-  const DONE_CRITERIA_PLACEHOLDER_RE = /^\s*(tbd|todo|to-do|to do|placeholder|n\/a|na|none|fix later|coming soon|see description|wip|tbh|tbw)\s*$/i
   for (const criterion of data.done_criteria) {
     if (DONE_CRITERIA_PLACEHOLDER_RE.test(criterion)) {
       problems.push(`Done criterion "${criterion}" is a placeholder. Replace with a concrete, verifiable outcome.`)
@@ -7071,9 +7074,8 @@ export async function createServer(): Promise<FastifyInstance> {
         if (readinessProblems.length > 0) {
           const isUserCreated = !data.createdBy || data.createdBy === 'user'
           const hasEmptyCriteria = !data.done_criteria || data.done_criteria.length === 0
-          const PLACEHOLDER_RE = /^\s*(tbd|todo|to-do|to do|placeholder|n\/a|na|none|fix later|coming soon|see description|wip|tbh|tbw)\s*$/i
           const hasOnlyPlaceholders = data.done_criteria?.length > 0
-            && data.done_criteria.every((c: string) => PLACEHOLDER_RE.test(c))
+            && data.done_criteria.every((c: string) => DONE_CRITERIA_PLACEHOLDER_RE.test(c))
 
           // Human-created tasks with only empty done_criteria: warn-and-allow (not block).
           // Placeholder text always blocks (for both humans and agents).


### PR DESCRIPTION
## Summary

Two copies of the same placeholder regex existed in server.ts:
1. Inside `checkDefinitionOfReady()` as `const DONE_CRITERIA_PLACEHOLDER_RE`
2. Inside POST /tasks creator-type gate as `const PLACEHOLDER_RE`

Both are identical patterns. Extracted to a single module-level constant after `TASK_TYPES`.

## AC
- ✅ Single `DONE_CRITERIA_PLACEHOLDER_RE` constant defined at module level
- ✅ All usage sites reference the shared constant
- ✅ No behavior change — same regex pattern

task-1773617522840-q5u2sk3di