### PR TITLE
feat(canvas): canvas_input.v1 — surface_tap + presence_dot_tap events

### DIFF
--- a/process/TASK-mm7aif7nj.md
+++ b/process/TASK-mm7aif7nj.md
@@ -1,0 +1,19 @@
+# Task: task-1773622427927-mm7aif7nj — filter approval cards to human-only
+
+## PR
+https://github.com/reflectt/reflectt-node/pull/1071 (pending)
+
+## Root Cause
+When any task enters `validating`, the approval card emitter fires unconditionally.
+Agent-to-agent reviews (e.g. pixel reviewing kotlin's PR) leak to the canvas as
+approval cards that Ryan sees — confusing and noisy.
+
+## Fix
+- KNOWN_AGENT_IDS set: link, kai, pixel, sage, scout, echo, rhythm, spark, swift, kotlin, harmony
+- If `task.reviewer` matches a known agent, skip the canvas card entirely
+- Human reviewers (ryan, admin, empty) still get approval cards
+- Agent reviews still logged for debugging
+
+## Tests
+- tests/approval-card-filter.test.ts — 4 tests: human reviewers shown, agent reviewers hidden,
+  case-insensitive, whitespace trimmed

--- a/src/server.ts
+++ b/src/server.ts
@@ -9409,7 +9409,23 @@ export async function createServer(): Promise<FastifyInstance> {
       }
 
       // ── Approval card: proactively surface approval card on canvas when task enters validating ──
+      // Only emit for human reviewers — agent-to-agent reviews should NOT appear on canvas.
+      // If the reviewer is a known agent name, skip the card entirely.
       if (parsed.status === 'validating' && existing.status !== 'validating') {
+        const KNOWN_AGENT_IDS = new Set([
+          'link', 'kai', 'pixel', 'sage', 'scout', 'echo',
+          'rhythm', 'spark', 'swift', 'kotlin', 'harmony',
+        ])
+        const reviewerId = (task.reviewer ?? '').toLowerCase().trim()
+        const isAgentReviewer = KNOWN_AGENT_IDS.has(reviewerId)
+
+        // Skip canvas card for agent-to-agent reviews — humans don't need to see these
+        if (isAgentReviewer) {
+          // Still log for debugging, but no canvas card
+          console.log(`[ApprovalCard] Skipped canvas card for agent-to-agent review: ${task.id} (reviewer: ${reviewerId})`)
+        }
+
+        if (!isAgentReviewer) {
         const taskMetaForCard = task.metadata as Record<string, unknown> | undefined
         const prUrlForCard = (taskMetaForCard?.pr_url as string | undefined)
           ?? (taskMetaForCard?.review_handoff as Record<string, unknown> | undefined)?.pr_url as string | undefined
@@ -9444,6 +9460,7 @@ export async function createServer(): Promise<FastifyInstance> {
           data: approvalPushData,
         })
         queueCanvasPushEvent(approvalPushData)
+        } // end if (!isAgentReviewer)
       }
 
       // ── Canvas push: self-emit utterance on task state transitions ──

--- a/tests/approval-card-filter.test.ts
+++ b/tests/approval-card-filter.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Tests for the approval card agent-reviewer filter.
+ * Verifies that agent-to-agent reviews don't produce canvas approval cards.
+ */
+
+const KNOWN_AGENT_IDS = new Set([
+  'link', 'kai', 'pixel', 'sage', 'scout', 'echo',
+  'rhythm', 'spark', 'swift', 'kotlin', 'harmony',
+])
+
+function shouldShowApprovalCard(reviewer: string | undefined): boolean {
+  const reviewerId = (reviewer ?? '').toLowerCase().trim()
+  return !KNOWN_AGENT_IDS.has(reviewerId)
+}
+
+describe('approval card agent filter', () => {
+  it('shows card for human reviewers', () => {
+    expect(shouldShowApprovalCard('ryan')).toBe(true)
+    expect(shouldShowApprovalCard('Ryan Campbell')).toBe(true)
+    expect(shouldShowApprovalCard('admin')).toBe(true)
+    expect(shouldShowApprovalCard(undefined)).toBe(true)
+    expect(shouldShowApprovalCard('')).toBe(true)
+  })
+
+  it('hides card for known agent reviewers', () => {
+    expect(shouldShowApprovalCard('kai')).toBe(false)
+    expect(shouldShowApprovalCard('pixel')).toBe(false)
+    expect(shouldShowApprovalCard('link')).toBe(false)
+    expect(shouldShowApprovalCard('sage')).toBe(false)
+    expect(shouldShowApprovalCard('kotlin')).toBe(false)
+    expect(shouldShowApprovalCard('swift')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(shouldShowApprovalCard('Kai')).toBe(false)
+    expect(shouldShowApprovalCard('PIXEL')).toBe(false)
+    expect(shouldShowApprovalCard('Link')).toBe(false)
+  })
+
+  it('trims whitespace', () => {
+    expect(shouldShowApprovalCard(' kai ')).toBe(false)
+    expect(shouldShowApprovalCard('  pixel  ')).toBe(false)
+  })
+})


### PR DESCRIPTION
Per render-protocol spec. Extends POST /canvas/input to accept surface receptivity events.

Changes:
- Added surface_tap, presence_dot_tap to CANVAS_INPUT_ACTIONS
- Added zone field (floor_trigger, presence_dot, decision_card) for surface_tap
- type accepted as alias for action (canvas_input.v1 spec compat)
- actor optional for surface events (was required)
- Route/docs contract: 556/556

task-1773619579977-kusz4ty9s