### PR TITLE
fix(P0): filter agent-to-agent reviews from approval queue

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1453,7 +1453,19 @@ async function syncRunApprovals(): Promise<void> {
   lastApprovalSyncAt = now
 
   try {
-    const items = listApprovalQueue({ category: 'review', limit: 20 })
+    const KNOWN_AGENTS_SYNC = new Set([
+      'link', 'kai', 'pixel', 'sage', 'scout', 'echo',
+      'rhythm', 'spark', 'swift', 'kotlin', 'harmony',
+      'artdirector', 'uipolish', 'coo', 'cos', 'pm', 'qa',
+      'shield', 'kindling', 'quill', 'funnel', 'attribution',
+      'bookkeeper', 'legal-counsel', 'evi-scout',
+    ])
+    const rawItems = listApprovalQueue({ category: 'review', limit: 20 })
+    // Filter out agent-to-agent reviews — only sync human-required approvals to cloud
+    const items = rawItems.filter(item => {
+      const reviewer = (item.agentId ?? '').toLowerCase().trim()
+      return !reviewer || !KNOWN_AGENTS_SYNC.has(reviewer)
+    })
     if (items.length === 0 && approvalSyncErrors === 0) return // Skip push when empty and no prior errors
 
     const payload = items.map(item => ({

--- a/src/server.ts
+++ b/src/server.ts
@@ -18594,7 +18594,33 @@ If your heartbeat shows **no active task** and **no next task**:
       event: { id: run.id, event_type: 'approval_requested', payload: run.input },
     }))
 
-    const allItems = [...items, ...agentInterfaceItems]
+    // Filter out agent-to-agent reviews — humans don't need to see these on the canvas.
+    // Only show items where the reviewer is a human (not a known agent).
+    const KNOWN_AGENTS_APPROVAL = new Set([
+      'link', 'kai', 'pixel', 'sage', 'scout', 'echo',
+      'rhythm', 'spark', 'swift', 'kotlin', 'harmony',
+      'artdirector', 'uipolish', 'coo', 'cos', 'pm', 'qa',
+      'shield', 'kindling', 'quill', 'funnel', 'attribution',
+      'bookkeeper', 'legal-counsel', 'evi-scout',
+    ])
+
+    // Check if ?humanOnly=true (default true for canvas, false for dashboard)
+    const humanOnly = (request.query as Record<string, string>).humanOnly !== 'false'
+
+    const filteredItems = humanOnly
+      ? items.filter(item => {
+          // agentId on the event IS the reviewer for review_requested events
+          const reviewerAgent = (item.agentId ?? '').toLowerCase().trim()
+          if (reviewerAgent && KNOWN_AGENTS_APPROVAL.has(reviewerAgent)) return false
+          // Also check payload.reviewer if present
+          const payload = item.event?.payload as Record<string, unknown> | undefined
+          const payloadReviewer = (payload?.reviewer as string ?? '').toLowerCase().trim()
+          if (payloadReviewer && KNOWN_AGENTS_APPROVAL.has(payloadReviewer)) return false
+          return true
+        })
+      : items
+
+    const allItems = [...filteredItems, ...agentInterfaceItems]
     return {
       items: allItems,
       count: allItems.length,


### PR DESCRIPTION
Ryan sees 50 agent review cards on canvas every time. All are agent-to-agent reviews that don't need human decision.

Fix: GET /approval-queue defaults humanOnly=true, filtering items where reviewer (agentId) is a known agent. Cloud sync also filters before pushing.

@kai — URGENT. Ryan sees these every time he opens canvas.