### PR TITLE
infra(node): wire Sentry error alerts to #ops

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -539,7 +539,7 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | GET | `/provisioning/webhooks` | List configured webhook routes for this host. |
 | POST | `/provisioning/webhooks` | Add a webhook route. Body: `{ provider, path?, events?, active? }`. |
 | DELETE | `/provisioning/webhooks/:id` | Remove a webhook route by ID. |
-| POST | `/webhooks/incoming/:provider` | Receive incoming webhooks from external providers (GitHub, Stripe, etc.). Auto-routes through delivery engine to configured targets. Returns 202 Accepted. |
+| POST | `/webhooks/incoming/:provider` | Receive incoming webhooks from external providers (GitHub, Sentry, Stripe, etc.). Auto-routes through delivery engine to configured targets. Provider `sentry` posts formatted error alerts to #ops channel (supports HMAC-SHA256 signature verification via `SENTRY_CLIENT_SECRET` env var). Returns 202 Accepted. |
 | POST | `/webhooks/deliver` | Enqueue a webhook for durable delivery. Body: `{ provider, eventType, payload, targetUrl, idempotencyKey?, metadata? }`. Returns event with idempotency key. |
 | GET | `/webhooks/events` | List webhook events. Query: `status`, `provider`, `limit`, `offset`. |
 | GET | `/webhooks/events/:id` | Get a webhook event by ID. |

--- a/src/sentry-webhook.ts
+++ b/src/sentry-webhook.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Sentry Webhook → #ops Bridge
+ *
+ * Parses Sentry webhook payloads (issue alerts, metric alerts, etc.)
+ * and formats them as chat messages for the #ops channel.
+ *
+ * Sentry webhook payload docs:
+ * https://docs.sentry.io/organization/integrations/integration-platform/webhooks/
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface SentryIssueData {
+  id?: string
+  title?: string
+  culprit?: string
+  metadata?: {
+    type?: string
+    value?: string
+    filename?: string
+    function?: string
+  }
+  count?: string | number
+  userCount?: number
+  firstSeen?: string
+  shortId?: string
+  project?: { slug?: string; name?: string; id?: string }
+  level?: string
+  status?: string
+}
+
+interface SentryActor {
+  type?: string
+  id?: string
+  name?: string
+}
+
+interface SentryWebhookPayload {
+  action?: string           // 'triggered' | 'resolved' | 'assigned' | 'archived' | 'unresolved'
+  data?: {
+    issue?: SentryIssueData
+    event?: Record<string, unknown>
+    triggered_rule?: string
+    metric_alert?: {
+      id?: string | number
+      title?: string
+      alert_rule?: { id?: number; name?: string }
+      status?: string
+    }
+  }
+  actor?: SentryActor
+  installation?: { uuid?: string }
+}
+
+// ── Severity Emoji ─────────────────────────────────────────────────────────
+
+function severityEmoji(level?: string): string {
+  switch (level) {
+    case 'fatal': return '💀'
+    case 'error': return '🔴'
+    case 'warning': return '🟡'
+    case 'info': return 'ℹ️'
+    default: return '🔴'
+  }
+}
+
+// ── Formatters ─────────────────────────────────────────────────────────────
+
+/**
+ * Format a Sentry webhook payload as a human-readable chat message.
+ * Returns null if the payload isn't actionable (e.g. installation hooks).
+ */
+export function formatSentryAlert(payload: SentryWebhookPayload): string | null {
+  const action = payload.action
+
+  // Issue alert (most common)
+  if (payload.data?.issue) {
+    return formatIssueAlert(action, payload.data.issue, payload.data.triggered_rule)
+  }
+
+  // Metric alert
+  if (payload.data?.metric_alert) {
+    const ma = payload.data.metric_alert
+    const ruleName = ma.alert_rule?.name ?? ma.title ?? 'Unknown metric alert'
+    const status = ma.status ?? action ?? 'triggered'
+    return `📊 **Metric Alert** — ${ruleName}\nStatus: ${status}`
+  }
+
+  // Unrecognized / installation / comment hooks — skip
+  return null
+}
+
+function formatIssueAlert(
+  action: string | undefined,
+  issue: SentryIssueData,
+  triggeredRule?: string,
+): string {
+  const emoji = severityEmoji(issue.level)
+  const title = issue.title ?? 'Unknown error'
+  const project = issue.project?.slug ?? issue.project?.name ?? 'unknown'
+  const shortId = issue.shortId ?? issue.id ?? '?'
+  const count = issue.count ?? '?'
+
+  // Build file/function hint
+  const file = issue.metadata?.filename ?? issue.culprit ?? null
+  const fn = issue.metadata?.function ?? null
+  const location = file ? (fn ? `${file} in ${fn}` : file) : null
+
+  // Action verb
+  const verb = action === 'resolved' ? '✅ Resolved'
+    : action === 'assigned' ? '👤 Assigned'
+    : action === 'archived' ? '📦 Archived'
+    : action === 'unresolved' ? '🔄 Reopened'
+    : `${emoji} Triggered`
+
+  const lines: string[] = [
+    `${verb}: **${title}**`,
+    `Project: ${project} · ${shortId} · ${count} event(s)`,
+  ]
+
+  if (location) {
+    lines.push(`📁 ${location}`)
+  }
+
+  if (triggeredRule) {
+    lines.push(`Rule: ${triggeredRule}`)
+  }
+
+  // Sentry issue URL (conventional format)
+  if (issue.project?.slug && issue.id) {
+    lines.push(`🔗 https://sentry.io/issues/${issue.id}/`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Verify Sentry webhook signature (HMAC-SHA256).
+ * Returns true if valid or if no secret is configured (permissive mode).
+ */
+export function verifySentrySignature(
+  rawBody: string | Buffer,
+  signatureHeader: string | undefined,
+  clientSecret: string | undefined,
+): boolean {
+  // If no secret configured, accept all (permissive mode for initial setup)
+  if (!clientSecret) return true
+  if (!signatureHeader) return false
+
+  try {
+    const crypto = require('crypto') as typeof import('crypto')
+    const expected = crypto
+      .createHmac('sha256', clientSecret)
+      .update(rawBody)
+      .digest('hex')
+    return crypto.timingSafeEqual(
+      Buffer.from(signatureHeader),
+      Buffer.from(expected),
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,6 +103,7 @@ import { getProvisioningManager } from './provisioning.js'
 import { getWebhookDeliveryManager } from './webhooks.js'
 import { enrichWebhookPayload } from './github-webhook-attribution.js'
 import { formatGitHubEvent } from './github-webhook-chat.js'
+import { formatSentryAlert, verifySentrySignature } from './sentry-webhook.js'
 import { exportBundle, importBundle } from './portability.js'
 import { getNotificationManager } from './notifications.js'
 import { getConnectivityManager } from './connectivity.js'
@@ -16602,6 +16603,27 @@ If your heartbeat shows **no active task** and **no next task**:
             },
           })
         }
+      }
+    }
+
+    // Post Sentry error alerts to #ops channel
+    if (provider === 'sentry') {
+      // Optional signature verification (HMAC-SHA256)
+      const sentrySecret = process.env.SENTRY_CLIENT_SECRET
+      const sentrySignature = request.headers['sentry-hook-signature'] as string | undefined
+      if (sentrySecret && !verifySentrySignature(JSON.stringify(body), sentrySignature, sentrySecret)) {
+        reply.code(401)
+        return { success: false, message: 'Invalid Sentry webhook signature' }
+      }
+
+      const opsMessage = formatSentryAlert(body as any)
+      if (opsMessage) {
+        chatManager.sendMessage({
+          from: 'sentry',
+          content: opsMessage,
+          channel: 'ops',
+          metadata: { source: 'sentry-webhook', action: (body as any)?.action, resource: request.headers['sentry-hook-resource'] as string | undefined },
+        }).catch(() => {}) // non-blocking
       }
     }
 

--- a/tests/sentry-webhook.test.ts
+++ b/tests/sentry-webhook.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { formatSentryAlert, verifySentrySignature } from '../src/sentry-webhook.js'
+
+describe('formatSentryAlert', () => {
+  it('formats a triggered issue alert', () => {
+    const result = formatSentryAlert({
+      action: 'triggered',
+      data: {
+        issue: {
+          id: '12345',
+          title: 'TypeError: Cannot read property of undefined',
+          culprit: 'src/server.ts',
+          metadata: { filename: 'src/server.ts', function: 'handleRequest' },
+          count: '42',
+          shortId: 'REFLECTT-1A',
+          project: { slug: 'reflectt-node', name: 'reflectt-node', id: '1' },
+          level: 'error',
+        },
+        triggered_rule: 'All errors',
+      },
+    })
+
+    expect(result).toContain('Triggered')
+    expect(result).toContain('TypeError: Cannot read property of undefined')
+    expect(result).toContain('reflectt-node')
+    expect(result).toContain('REFLECTT-1A')
+    expect(result).toContain('42 event(s)')
+    expect(result).toContain('src/server.ts in handleRequest')
+    expect(result).toContain('All errors')
+    expect(result).toContain('https://sentry.io/issues/12345/')
+  })
+
+  it('formats a resolved issue alert', () => {
+    const result = formatSentryAlert({
+      action: 'resolved',
+      data: {
+        issue: {
+          id: '999',
+          title: 'ReferenceError: x is not defined',
+          project: { slug: 'reflectt-node', name: 'reflectt-node', id: '1' },
+          level: 'error',
+          count: '5',
+          shortId: 'REFLECTT-2B',
+        },
+      },
+    })
+
+    expect(result).toContain('✅ Resolved')
+    expect(result).toContain('ReferenceError: x is not defined')
+  })
+
+  it('formats a metric alert', () => {
+    const result = formatSentryAlert({
+      action: 'triggered',
+      data: {
+        metric_alert: {
+          id: '1',
+          title: 'High error rate',
+          alert_rule: { id: 1, name: 'Error rate > 5%' },
+          status: 'critical',
+        },
+      },
+    })
+
+    expect(result).toContain('Metric Alert')
+    expect(result).toContain('Error rate > 5%')
+    expect(result).toContain('critical')
+  })
+
+  it('returns null for installation webhooks', () => {
+    const result = formatSentryAlert({
+      action: 'created',
+      data: {},
+    })
+    expect(result).toBeNull()
+  })
+
+  it('handles missing fields gracefully', () => {
+    const result = formatSentryAlert({
+      action: 'triggered',
+      data: {
+        issue: {
+          title: 'Some error',
+          level: 'warning',
+        },
+      },
+    })
+
+    expect(result).toContain('🟡')
+    expect(result).toContain('Some error')
+    expect(result).not.toContain('undefined')
+  })
+
+  it('handles fatal level with skull emoji', () => {
+    const result = formatSentryAlert({
+      action: 'triggered',
+      data: {
+        issue: {
+          title: 'OOM Crash',
+          level: 'fatal',
+          count: '1',
+          project: { slug: 'reflectt-node', name: 'reflectt-node', id: '1' },
+        },
+      },
+    })
+
+    expect(result).toContain('💀')
+  })
+})
+
+describe('verifySentrySignature', () => {
+  it('accepts when no secret is configured', () => {
+    expect(verifySentrySignature('{}', undefined, undefined)).toBe(true)
+  })
+
+  it('rejects when secret is set but no signature header', () => {
+    expect(verifySentrySignature('{}', undefined, 'my-secret')).toBe(false)
+  })
+
+  it('verifies valid HMAC-SHA256 signature', () => {
+    const crypto = require('crypto')
+    const body = '{"action":"triggered"}'
+    const secret = 'test-secret-key'
+    const sig = crypto.createHmac('sha256', secret).update(body).digest('hex')
+
+    expect(verifySentrySignature(body, sig, secret)).toBe(true)
+  })
+
+  it('rejects invalid signature', () => {
+    expect(verifySentrySignature('{"action":"triggered"}', 'bad-sig-value', 'my-secret')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Adds a Sentry webhook handler that parses error alerts and posts formatted messages to `#ops`.

## How

**New file: `src/sentry-webhook.ts`**
- `formatSentryAlert()` — parses Sentry issue alerts and metric alerts into human-readable messages
- `verifySentrySignature()` — optional HMAC-SHA256 verification via `SENTRY_CLIENT_SECRET` env var

**Wired into `POST /webhooks/incoming/sentry`** in server.ts:
- Signature verification (permissive if no secret configured)
- Formats the alert
- Posts to `#ops` channel via chatManager

### Alert format example
```
🔴 Triggered: **TypeError: Cannot read property of undefined**
Project: reflectt-node · REFLECTT-1A · 42 event(s)
📁 src/server.ts in handleRequest
Rule: All errors
🔗 https://sentry.io/issues/12345/
```

## Setup required
1. Create/locate Sentry project for reflectt-node
2. In Sentry → Settings → Integrations → Internal Integration:
   - Webhook URL: `https://<node-host>/webhooks/incoming/sentry`
   - Events: Issue alerts, Metric alerts
3. Optionally set `SENTRY_CLIENT_SECRET` env var for signature verification

## Testing
- 10 new unit tests (all pass)
- TypeScript compiles clean
- Route-docs contract passes (no new routes, updated existing docs)
- Full suite: 2425 pass (same 3 pre-existing failures)

Closes task-1773659301065