### PR TITLE
fix(tests): resolve 4 pre-existing test failures on main

### DIFF
--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2610,6 +2610,13 @@ describe('Idle Nudge lane-state transitions', () => {
   it('nudges queue-clear agents to pull /tasks/next after warn threshold', async () => {
     const agent = 'lane-queue-clear-nudge'
     await cleanupAgentTasks(agent)
+    // Seed a pullable todo task so the queue-empty gate doesn't suppress the nudge
+    await req('POST', '/tasks', {
+      title: 'TEST: pullable task for queue-clear nudge',
+      assignee: agent, reviewer: 'test-reviewer', priority: 'P2',
+      createdBy: 'test-runner', eta: '1h', done_criteria: ['nudge fires correctly'],
+      status: 'todo',
+    })
     await req('POST', `/presence/${agent}`, { status: 'working' })
 
     const tickNowMs = Date.now() + (50 * 60_000) // > warnMin (45m)

--- a/tests/heartbeat-bootstrap.test.ts
+++ b/tests/heartbeat-bootstrap.test.ts
@@ -27,8 +27,8 @@ describe('GET /heartbeat/:agent', () => {
   it('shows active task when agent has doing task', async () => {
     const cr = await app.inject({
       method: 'POST', url: '/tasks',
-      payload: { title: 'HB test', description: 'x', assignee: AGENT, reviewer: 'ryan',
-        priority: 'P2', createdBy: AGENT, eta: '~1h', done_criteria: ['t'],
+      payload: { title: 'TEST: HB active task for heartbeat', description: 'x', assignee: AGENT, reviewer: 'ryan',
+        priority: 'P2', createdBy: AGENT, eta: '~1h', done_criteria: ['heartbeat shows active task'],
         metadata: { wip_override: true, lane: 'test' } },
     })
     const taskId = JSON.parse(cr.body).task.id

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -13,6 +13,10 @@ import { rmSync } from 'fs'
 const testHome = mkdtempSync(join(tmpdir(), 'reflectt-test-'))
 process.env.REFLECTT_HOME = testHome
 
+// Set NODE_ENV=test so DoR gate, noise budget, and other production guards
+// are bypassed in test mode (matches the skipDoR check in POST /tasks).
+process.env.NODE_ENV = 'test'
+
 // Ensure cleanup after all tests
 process.on('exit', () => {
   try {

--- a/tests/tasks-active-inbox-compact.test.ts
+++ b/tests/tasks-active-inbox-compact.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
   const createRes = await app.inject({
     method: 'POST', url: '/tasks',
     payload: {
-      title: 'Active task test',
+      title: 'TEST: Active task test for compact mode',
       description: 'Description for testing',
       assignee: AGENT,
       reviewer: 'ryan',


### PR DESCRIPTION
## What

Fixes all 4 pre-existing test failures that were requiring `--admin` to merge PRs.

## Root Causes

### Failures 1-3: tasks-active + heartbeat tests (3 tests)
Task titles (`'Active task test'`, `'HB test'`) didn't use the `TEST:` prefix convention, so:
- `POST /tasks` passed (DoR gate skipped via NODE_ENV)
- `PATCH /tasks/:id { status: 'doing' }` **failed** — the done_criteria gate and WIP cap only skip for `TEST:`-prefixed titles

**Fix:** Prefix test task titles with `TEST:` and use 3+ word done_criteria.

### Failure 4: idle-nudge queue-clear (1 test)
Test expected `decision: 'warn'` for an agent with zero tasks, but the **queue-empty gate** (added after the test was written) correctly suppresses nudges when no pullable tasks exist → `decision: 'none', reason: 'queue-empty-suppressed'`.

**Fix:** Seed a pullable todo task before triggering the idle-nudge tick.

### Bonus: NODE_ENV=test in setup.ts
Set `NODE_ENV=test` in the global test setup so the DoR gate on `POST /tasks` is consistently bypassed (was only working for `TEST:`-prefixed titles before).

## Results
```
Test Files  216 passed (216)
Tests       2419 passed | 1 skipped (2420)
```

**Zero failures.** 🟢

Closes task-1773661219176