### PR TITLE
feat(api): agent notifications + presence backend primitives

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -427,6 +427,21 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | POST | `/presence/:agent/focus` | Toggle focus mode. Body: `{ "active": true, "level": "soft|deep", "durationMin": 60, "reason": "shipping PR" }`. Soft: suppresses system nudges, allows direct mentions. Deep: suppresses everything except blocker/review pings. |
 | GET | `/presence-loop` | Presence loop demo page — serves an HTML page that polls `/presence` to show live agent status changes. |
 
+## Agent Notifications
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/agent-notifications` | Create a notification. Body: `{ "target_agent": "link", "title": "Review PR", "source_agent": "kai", "type": "review|task|mention|alert|info|system", "body": "...", "priority": "low|medium|high|critical", "task_id": "...", "metadata": {}, "expires_at": 0 }`. Returns 201 + notification object. |
+| POST | `/agent-notifications/:id/ack` | Acknowledge a notification. Body: `{ "decision": "seen|accept|defer|dismiss" }`. Returns updated notification. |
+| GET | `/agent-notifications` | List notifications for an agent. Query: `agent` (required), `status` (default `pending`), `limit` (default 50). Returns `{ notifications, total }`. |
+
+## Agent Presence (structured)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/agent-presence` | Upsert agent presence + log to history. Body: `{ "agent": "link", "status": "working|idle|blocked|reviewing|offline", "task": "...", "focus_level": "soft|deep", "metadata": {} }`. Returns current presence. |
+| GET | `/agent-presence` | Read current agent presence. Query: `agent` (required). Returns `{ presence }`. |
+
 ## Memory
 
 | Method | Path | Description |

--- a/src/agent-notifications.ts
+++ b/src/agent-notifications.ts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Agent Notifications — Storage & CRUD
+ *
+ * Provides structured notification delivery to agents with ack workflow.
+ * Stored in SQLite (agent_notifications table, migration v27).
+ */
+
+import type Database from 'better-sqlite3'
+
+// ── Types ──
+
+export type NotificationType = 'info' | 'task' | 'review' | 'mention' | 'alert' | 'system'
+export type NotificationPriorityLevel = 'low' | 'medium' | 'high' | 'critical'
+export type NotificationStatus = 'pending' | 'acked' | 'expired'
+export type AckDecision = 'seen' | 'accept' | 'defer' | 'dismiss'
+
+export interface AgentNotification {
+  id: string
+  target_agent: string
+  source_agent: string | null
+  type: NotificationType
+  title: string
+  body: string | null
+  priority: NotificationPriorityLevel
+  status: NotificationStatus
+  ack_decision: AckDecision | null
+  ack_at: number | null
+  task_id: string | null
+  metadata: Record<string, unknown> | null
+  created_at: number
+  expires_at: number | null
+}
+
+export interface CreateNotificationParams {
+  target_agent: string
+  source_agent?: string
+  type?: NotificationType
+  title: string
+  body?: string
+  priority?: NotificationPriorityLevel
+  task_id?: string
+  metadata?: Record<string, unknown>
+  expires_at?: number
+}
+
+export interface GetNotificationsOptions {
+  status?: NotificationStatus
+  limit?: number
+}
+
+// ── ID generation ──
+
+export function generateNotificationId(): string {
+  const ts = Date.now()
+  const rand = Math.random().toString(36).slice(2, 10)
+  return `notif-${ts}-${rand}`
+}
+
+// ── CRUD ──
+
+const PRIORITY_ORDER: Record<NotificationPriorityLevel, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+}
+
+export function createNotification(
+  db: Database.Database,
+  params: CreateNotificationParams,
+): AgentNotification {
+  const id = generateNotificationId()
+  const now = Date.now()
+  const notification: AgentNotification = {
+    id,
+    target_agent: params.target_agent,
+    source_agent: params.source_agent ?? null,
+    type: params.type ?? 'info',
+    title: params.title,
+    body: params.body ?? null,
+    priority: params.priority ?? 'medium',
+    status: 'pending',
+    ack_decision: null,
+    ack_at: null,
+    task_id: params.task_id ?? null,
+    metadata: params.metadata ?? null,
+    created_at: now,
+    expires_at: params.expires_at ?? null,
+  }
+
+  db.prepare(`
+    INSERT INTO agent_notifications
+      (id, target_agent, source_agent, type, title, body, priority, status,
+       ack_decision, ack_at, task_id, metadata, created_at, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    notification.id,
+    notification.target_agent,
+    notification.source_agent,
+    notification.type,
+    notification.title,
+    notification.body,
+    notification.priority,
+    notification.status,
+    notification.ack_decision,
+    notification.ack_at,
+    notification.task_id,
+    notification.metadata ? JSON.stringify(notification.metadata) : null,
+    notification.created_at,
+    notification.expires_at,
+  )
+
+  return notification
+}
+
+export function ackNotification(
+  db: Database.Database,
+  id: string,
+  decision: AckDecision,
+): AgentNotification | null {
+  const now = Date.now()
+  const result = db.prepare(`
+    UPDATE agent_notifications
+    SET status = 'acked', ack_decision = ?, ack_at = ?
+    WHERE id = ? AND status = 'pending'
+  `).run(decision, now, id)
+
+  if (result.changes === 0) return null
+
+  return getNotificationById(db, id)
+}
+
+export function getNotificationById(
+  db: Database.Database,
+  id: string,
+): AgentNotification | null {
+  const row = db.prepare('SELECT * FROM agent_notifications WHERE id = ?').get(id) as Record<string, unknown> | undefined
+  if (!row) return null
+  return deserializeNotification(row)
+}
+
+export function getNotifications(
+  db: Database.Database,
+  agentId: string,
+  opts?: GetNotificationsOptions,
+): { notifications: AgentNotification[]; total: number } {
+  const status = opts?.status ?? 'pending'
+  const limit = opts?.limit ?? 50
+
+  const rows = db.prepare(`
+    SELECT * FROM agent_notifications
+    WHERE target_agent = ? AND status = ?
+    ORDER BY
+      CASE priority
+        WHEN 'critical' THEN 0
+        WHEN 'high' THEN 1
+        WHEN 'medium' THEN 2
+        WHEN 'low' THEN 3
+      END ASC,
+      created_at ASC
+    LIMIT ?
+  `).all(agentId, status, limit) as Record<string, unknown>[]
+
+  const totalRow = db.prepare(`
+    SELECT COUNT(*) as cnt FROM agent_notifications
+    WHERE target_agent = ? AND status = ?
+  `).get(agentId, status) as { cnt: number }
+
+  return {
+    notifications: rows.map(deserializeNotification),
+    total: totalRow.cnt,
+  }
+}
+
+// ── Helpers ──
+
+function deserializeNotification(row: Record<string, unknown>): AgentNotification {
+  return {
+    id: row.id as string,
+    target_agent: row.target_agent as string,
+    source_agent: row.source_agent as string | null,
+    type: row.type as NotificationType,
+    title: row.title as string,
+    body: row.body as string | null,
+    priority: row.priority as NotificationPriorityLevel,
+    status: row.status as NotificationStatus,
+    ack_decision: row.ack_decision as AckDecision | null,
+    ack_at: row.ack_at as number | null,
+    task_id: row.task_id as string | null,
+    metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : (row.metadata as Record<string, unknown> | null),
+    created_at: row.created_at as number,
+    expires_at: row.expires_at as number | null,
+  }
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -660,6 +660,42 @@ export function runMigrations(db: Database.Database): void {
         CREATE INDEX IF NOT EXISTS idx_canvas_sessions_id_ts ON canvas_sessions(session_id, ts);
       `,
     },
+    {
+      version: 27,
+      sql: `
+        -- Agent notifications: structured notification delivery with ack workflow
+        CREATE TABLE IF NOT EXISTS agent_notifications (
+          id            TEXT PRIMARY KEY,
+          target_agent  TEXT NOT NULL,
+          source_agent  TEXT,
+          type          TEXT NOT NULL DEFAULT 'info',
+          title         TEXT NOT NULL,
+          body          TEXT,
+          priority      TEXT NOT NULL DEFAULT 'medium',
+          status        TEXT NOT NULL DEFAULT 'pending',
+          ack_decision  TEXT,
+          ack_at        INTEGER,
+          task_id       TEXT,
+          metadata      TEXT,
+          created_at    INTEGER NOT NULL,
+          expires_at    INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_notif_target ON agent_notifications(target_agent, status);
+        CREATE INDEX IF NOT EXISTS idx_agent_notif_created ON agent_notifications(created_at);
+
+        -- Agent presence log: historical presence state for analytics
+        CREATE TABLE IF NOT EXISTS agent_presence_log (
+          id          INTEGER PRIMARY KEY AUTOINCREMENT,
+          agent       TEXT NOT NULL,
+          status      TEXT NOT NULL,
+          task        TEXT,
+          focus_level TEXT,
+          metadata    TEXT,
+          recorded_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_presence_log_agent ON agent_presence_log(agent, recorded_at);
+      `,
+    },
   ]
 
   const insertMigration = db.prepare('INSERT INTO _migrations (version) VALUES (?)')
@@ -700,6 +736,7 @@ export function runMigrations(db: Database.Database): void {
     { version: 24, tables: ['agent_messages', 'artifacts'] },
     { version: 25, tables: ['webhook_payloads'] },
     { version: 26, tables: ['canvas_sessions'] },
+    { version: 27, tables: ['agent_notifications', 'agent_presence_log'] },
   ]
   const existingTables = new Set(
     (db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>)

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ import { buildContextInjection, getContextBudgets, getContextMemo, upsertContext
 import { deriveScopeId } from './scope-routing.js'
 import { eventBus, VALID_EVENT_TYPES } from './events.js'
 import { presenceManager } from './presence.js'
+import type { NotificationType, NotificationPriorityLevel, AckDecision, NotificationStatus } from './agent-notifications.js'
 import { startSweeper, getSweeperStatus, sweepValidatingQueue, flagPrDrift, generateDriftReport } from './executionSweeper.js'
 import { autoPopulateCloseGate, tryAutoCloseTask, getMergeAttemptLog } from './prAutoMerge.js'
 import { getDuplicateClosureCanonicalRefError } from './duplicateClosureGuard.js'
@@ -15237,6 +15238,119 @@ If your heartbeat shows **no active task** and **no next task**:
   app.get<{ Params: { agent: string } }>('/presence/:agent/focus', async (request) => {
     const focus = presenceManager.isInFocus(request.params.agent)
     return { agent: request.params.agent, focus }
+  })
+
+  // ── Agent Notifications ─────────────────────────────────────────────
+  // Structured notification delivery with ack workflow.
+  // Storage: agent_notifications table (migration v27).
+
+  const agentNotifModule = await import('./agent-notifications.js')
+
+  // POST /agent-notifications — create a notification
+  app.post('/agent-notifications', async (request, reply) => {
+    const body = request.body as Record<string, unknown>
+    const target_agent = String(body.target_agent || '').trim()
+    if (!target_agent) {
+      reply.code(400)
+      return { error: 'target_agent is required' }
+    }
+    const title = String(body.title || '').trim()
+    if (!title) {
+      reply.code(400)
+      return { error: 'title is required' }
+    }
+
+    const notification = agentNotifModule.createNotification(getDb(), {
+      target_agent,
+      source_agent: body.source_agent ? String(body.source_agent) : undefined,
+      type: body.type ? String(body.type) as NotificationType : undefined,
+      title,
+      body: body.body ? String(body.body) : undefined,
+      priority: body.priority ? String(body.priority) as NotificationPriorityLevel : undefined,
+      task_id: body.task_id ? String(body.task_id) : undefined,
+      metadata: body.metadata as Record<string, unknown> | undefined,
+      expires_at: body.expires_at ? Number(body.expires_at) : undefined,
+    })
+
+    reply.code(201)
+    return { success: true, notification }
+  })
+
+  // POST /agent-notifications/:id/ack — acknowledge a notification
+  app.post<{ Params: { id: string } }>('/agent-notifications/:id/ack', async (request, reply) => {
+    const { id } = request.params
+    const body = request.body as Record<string, unknown>
+    const decision = String(body.decision || '').trim() as AckDecision
+
+    if (!['seen', 'accept', 'defer', 'dismiss'].includes(decision)) {
+      reply.code(400)
+      return { error: 'decision must be one of: seen, accept, defer, dismiss' }
+    }
+
+    const notification = agentNotifModule.ackNotification(getDb(), id, decision)
+    if (!notification) {
+      reply.code(404)
+      return { error: 'Notification not found or already acked' }
+    }
+
+    return { success: true, notification }
+  })
+
+  // GET /agent-notifications?agent=:id — list notifications for an agent
+  app.get('/agent-notifications', async (request, reply) => {
+    const query = request.query as Record<string, string>
+    const agent = String(query.agent || '').trim()
+    if (!agent) {
+      reply.code(400)
+      return { error: 'agent query parameter is required' }
+    }
+
+    const status = query.status as NotificationStatus | undefined
+    const limit = query.limit ? parseInt(query.limit, 10) : undefined
+
+    const result = agentNotifModule.getNotifications(getDb(), agent, { status, limit })
+    return { notifications: result.notifications, total: result.total }
+  })
+
+  // POST /agent-presence — upsert agent presence (delegates to PresenceManager + logs)
+  app.post('/agent-presence', async (request) => {
+    const body = request.body as Record<string, unknown>
+    const agent = String(body.agent || '').trim()
+    if (!agent) {
+      return { error: 'agent is required' }
+    }
+
+    const status = String(body.status || 'idle') as import('./presence.js').PresenceStatus
+    const task = body.task ? String(body.task) : undefined
+
+    presenceManager.updatePresence(agent, status, task)
+
+    // Log to agent_presence_log for historical tracking
+    const focusLevel = body.focus_level ? String(body.focus_level) : null
+    const metadata = body.metadata ? JSON.stringify(body.metadata) : null
+    getDb().prepare(`
+      INSERT INTO agent_presence_log (agent, status, task, focus_level, metadata, recorded_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(agent, status, task ?? null, focusLevel, metadata, Date.now())
+
+    const presence = presenceManager.getPresence(agent)
+    return { success: true, presence }
+  })
+
+  // GET /agent-presence?agent=:id — read current agent presence
+  app.get('/agent-presence', async (request, reply) => {
+    const query = request.query as Record<string, string>
+    const agent = String(query.agent || '').trim()
+    if (!agent) {
+      reply.code(400)
+      return { error: 'agent query parameter is required' }
+    }
+
+    const presence = presenceManager.getPresence(agent)
+    if (!presence) {
+      return { presence: null, message: 'No presence data for this agent' }
+    }
+    return { presence }
   })
 
   // Get all agent activity metrics

--- a/tests/agent-notifications.test.ts
+++ b/tests/agent-notifications.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import {
+  createNotification,
+  ackNotification,
+  getNotifications,
+  getNotificationById,
+  generateNotificationId,
+} from '../src/agent-notifications.js'
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE agent_notifications (
+      id            TEXT PRIMARY KEY,
+      target_agent  TEXT NOT NULL,
+      source_agent  TEXT,
+      type          TEXT NOT NULL DEFAULT 'info',
+      title         TEXT NOT NULL,
+      body          TEXT,
+      priority      TEXT NOT NULL DEFAULT 'medium',
+      status        TEXT NOT NULL DEFAULT 'pending',
+      ack_decision  TEXT,
+      ack_at        INTEGER,
+      task_id       TEXT,
+      metadata      TEXT,
+      created_at    INTEGER NOT NULL,
+      expires_at    INTEGER
+    );
+    CREATE INDEX idx_agent_notif_target ON agent_notifications(target_agent, status);
+  `)
+  return db
+}
+
+describe('agent-notifications', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = setupDb()
+  })
+
+  describe('generateNotificationId', () => {
+    it('produces unique prefixed IDs', () => {
+      const a = generateNotificationId()
+      const b = generateNotificationId()
+      expect(a).toMatch(/^notif-\d+-[a-z0-9]+$/)
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('createNotification', () => {
+    it('creates a notification with required fields', () => {
+      const notif = createNotification(db, {
+        target_agent: 'link',
+        title: 'Review PR #100',
+      })
+
+      expect(notif.id).toMatch(/^notif-/)
+      expect(notif.target_agent).toBe('link')
+      expect(notif.title).toBe('Review PR #100')
+      expect(notif.status).toBe('pending')
+      expect(notif.type).toBe('info')
+      expect(notif.priority).toBe('medium')
+      expect(notif.ack_decision).toBeNull()
+    })
+
+    it('creates with all optional fields', () => {
+      const notif = createNotification(db, {
+        target_agent: 'link',
+        source_agent: 'kai',
+        type: 'review',
+        title: 'Review needed',
+        body: 'Please review PR #200',
+        priority: 'high',
+        task_id: 'task-123',
+        metadata: { pr: 200 },
+        expires_at: Date.now() + 86400000,
+      })
+
+      expect(notif.source_agent).toBe('kai')
+      expect(notif.type).toBe('review')
+      expect(notif.body).toBe('Please review PR #200')
+      expect(notif.priority).toBe('high')
+      expect(notif.task_id).toBe('task-123')
+      expect(notif.metadata).toEqual({ pr: 200 })
+      expect(notif.expires_at).toBeGreaterThan(Date.now())
+    })
+
+    it('persists to database', () => {
+      const notif = createNotification(db, {
+        target_agent: 'link',
+        title: 'Test',
+      })
+
+      const fetched = getNotificationById(db, notif.id)
+      expect(fetched).not.toBeNull()
+      expect(fetched!.title).toBe('Test')
+    })
+  })
+
+  describe('ackNotification', () => {
+    it('acks a pending notification', () => {
+      const notif = createNotification(db, {
+        target_agent: 'link',
+        title: 'Ack me',
+      })
+
+      const acked = ackNotification(db, notif.id, 'accept')
+      expect(acked).not.toBeNull()
+      expect(acked!.status).toBe('acked')
+      expect(acked!.ack_decision).toBe('accept')
+      expect(acked!.ack_at).toBeGreaterThan(0)
+    })
+
+    it('returns null for already-acked notification', () => {
+      const notif = createNotification(db, {
+        target_agent: 'link',
+        title: 'Ack me once',
+      })
+
+      ackNotification(db, notif.id, 'seen')
+      const result = ackNotification(db, notif.id, 'dismiss')
+      expect(result).toBeNull()
+    })
+
+    it('returns null for non-existent notification', () => {
+      const result = ackNotification(db, 'notif-doesnotexist', 'seen')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getNotifications', () => {
+    it('returns pending notifications for an agent', () => {
+      createNotification(db, { target_agent: 'link', title: 'A' })
+      createNotification(db, { target_agent: 'link', title: 'B' })
+      createNotification(db, { target_agent: 'kai', title: 'C' })
+
+      const result = getNotifications(db, 'link')
+      expect(result.total).toBe(2)
+      expect(result.notifications).toHaveLength(2)
+      expect(result.notifications.every(n => n.target_agent === 'link')).toBe(true)
+    })
+
+    it('filters by status', () => {
+      const notif = createNotification(db, { target_agent: 'link', title: 'Will ack' })
+      createNotification(db, { target_agent: 'link', title: 'Still pending' })
+      ackNotification(db, notif.id, 'seen')
+
+      const pending = getNotifications(db, 'link', { status: 'pending' })
+      expect(pending.total).toBe(1)
+      expect(pending.notifications[0].title).toBe('Still pending')
+
+      const acked = getNotifications(db, 'link', { status: 'acked' })
+      expect(acked.total).toBe(1)
+      expect(acked.notifications[0].title).toBe('Will ack')
+    })
+
+    it('orders by priority then created_at', () => {
+      createNotification(db, { target_agent: 'link', title: 'Low', priority: 'low' })
+      createNotification(db, { target_agent: 'link', title: 'Critical', priority: 'critical' })
+      createNotification(db, { target_agent: 'link', title: 'High', priority: 'high' })
+
+      const result = getNotifications(db, 'link')
+      expect(result.notifications[0].title).toBe('Critical')
+      expect(result.notifications[1].title).toBe('High')
+      expect(result.notifications[2].title).toBe('Low')
+    })
+
+    it('respects limit', () => {
+      for (let i = 0; i < 10; i++) {
+        createNotification(db, { target_agent: 'link', title: `N${i}` })
+      }
+
+      const result = getNotifications(db, 'link', { limit: 3 })
+      expect(result.notifications).toHaveLength(3)
+      expect(result.total).toBe(10)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds backend primitives for agent notifications and structured presence logging.

### Changes
- **Migration v27**: `agent_notifications` + `agent_presence_log` tables
- **New module**: `src/agent-notifications.ts` — CRUD + ack workflow (create, ack, list, get by ID)
- **5 new routes**:
  - `POST /agent-notifications` — create notification (201)
  - `POST /agent-notifications/:id/ack` — ack with decision (seen/accept/defer/dismiss)
  - `GET /agent-notifications?agent=:id` — list pending/acked, priority-ordered
  - `POST /agent-presence` — upsert presence + log to history
  - `GET /agent-presence?agent=:id` — read current presence
- **11 new tests** — all pass
- **Docs updated** — route-docs contract 561/561 ✅
- **No regressions** — 2439 tests pass

### Task
task-1773659363638-fie05nufp