### PR TITLE
feat(voice): emit canvas_message SSE on voice transcript completion

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8193,6 +8193,20 @@ export async function createServer(): Promise<FastifyInstance> {
 
     if (transcript.length > 4000) transcript = transcript.slice(0, 4000)
 
+    // Emit canvas_message so pulse SSE subscribers (browser, Android) get the transcript immediately
+    eventBus.emit({
+      id: `cmsg-voice-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      type: 'canvas_message' as const,
+      timestamp: Date.now(),
+      data: {
+        type: 'voice_transcript',
+        agentId,
+        agentColor: AGENT_IDENTITY_COLORS[agentId] ?? '#9ca3af',
+        transcript,
+        sttProvider,
+      },
+    })
+
     // Delegate to the same voice pipeline as POST /voice/input
     // Inline the pipeline logic (mirrors /voice/input handler)
     const session = createVoiceSession(agentId)


### PR DESCRIPTION
## What

Adds canvas_message SSE emission to POST /voice/audio when transcription completes.

## Why

POST /voice/audio already had a full Whisper pipeline (local → OpenAI fallback), but wasn't emitting a canvas_message event on the pulse SSE stream. Android VoiceRepository and browser clients need this to receive transcripts in real-time.

## Event Shape
```json
{
  "type": "canvas_message",
  "data": {
    "type": "voice_transcript",
    "agentId": "link",
    "agentColor": "#60a5fa",
    "transcript": "Hello world",
    "sttProvider": "local-whisper"
  }
}
```

## Testing
- tsc clean
- 218 test files, 2440 tests pass, 0 failures
- Route-docs contract passes

Closes task-1773662735453