### PR TITLE
feat(node): notification delivery worker — push queued notifications to active agents

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -434,6 +434,8 @@ Preflight checks reconcile live task state (status, assignee, reviewer, recent c
 | POST | `/agent-notifications` | Create a notification. Body: `{ "target_agent": "link", "title": "Review PR", "source_agent": "kai", "type": "review|task|mention|alert|info|system", "body": "...", "priority": "low|medium|high|critical", "task_id": "...", "metadata": {}, "expires_at": 0 }`. Returns 201 + notification object. |
 | POST | `/agent-notifications/:id/ack` | Acknowledge a notification. Body: `{ "decision": "seen|accept|defer|dismiss" }`. Returns updated notification. |
 | GET | `/agent-notifications` | List notifications for an agent. Query: `agent` (required), `status` (default `pending`), `limit` (default 50). Returns `{ notifications, total }`. |
+| GET | `/agent-notifications/worker/stats` | Notification delivery worker stats: delivered/skipped/failed/expired counts, tick count, running status. |
+| POST | `/agent-notifications/worker/tick` | Manually trigger a delivery tick (useful for testing). Returns delivery results for the batch. |
 
 ## Agent Presence (structured)
 

--- a/src/agent-notifications.ts
+++ b/src/agent-notifications.ts
@@ -14,7 +14,7 @@ import type Database from 'better-sqlite3'
 
 export type NotificationType = 'info' | 'task' | 'review' | 'mention' | 'alert' | 'system'
 export type NotificationPriorityLevel = 'low' | 'medium' | 'high' | 'critical'
-export type NotificationStatus = 'pending' | 'acked' | 'expired'
+export type NotificationStatus = 'pending' | 'delivered' | 'acked' | 'expired' | 'failed'
 export type AckDecision = 'seen' | 'accept' | 'defer' | 'dismiss'
 
 export interface AgentNotification {

--- a/src/notification-worker.ts
+++ b/src/notification-worker.ts
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Notification Delivery Worker
+ *
+ * Polls agent_notifications for pending rows and delivers them to active agents.
+ * Respects interruption budget: agents with budget=closed skip non-urgent notifications.
+ *
+ * Delivery surface: chat DM (channel: 'notifications') or task comment when task_id is set.
+ * Marks notifications as delivered (status='delivered') or failed after one retry.
+ *
+ * task-1773659376304
+ */
+
+import type Database from 'better-sqlite3'
+import type { AgentNotification, NotificationPriorityLevel } from './agent-notifications.js'
+import type { PresenceManager } from './presence.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type InterruptionBudget = 'open' | 'focused' | 'closed'
+
+export interface DeliveryTarget {
+  agent: string
+  isActive: boolean
+  budget: InterruptionBudget
+}
+
+export interface DeliveryResult {
+  notificationId: string
+  delivered: boolean
+  reason?: string
+}
+
+export interface NotificationWorkerConfig {
+  /** Poll interval in ms (default: 30000 = 30s) */
+  pollIntervalMs?: number
+  /** Max notifications to process per tick (default: 20) */
+  batchSize?: number
+  /** Max age before expiring undelivered notifications (default: 24h) */
+  expireAfterMs?: number
+}
+
+// ── Interruption budget ────────────────────────────────────────────────────
+
+/** Map presence status to interruption budget */
+function presenceToBudget(status: string): InterruptionBudget {
+  switch (status) {
+    case 'working': return 'focused'
+    case 'reviewing': return 'focused'
+    case 'blocked': return 'open'
+    case 'waiting': return 'open'
+    case 'idle': return 'open'
+    case 'offline': return 'closed'
+    default: return 'open'
+  }
+}
+
+/** Whether a notification can interrupt at this budget level */
+function canInterrupt(priority: NotificationPriorityLevel, budget: InterruptionBudget): boolean {
+  if (budget === 'open') return true
+  if (budget === 'focused') return priority === 'critical' || priority === 'high'
+  // closed: only critical
+  return priority === 'critical'
+}
+
+// ── Delivery helpers ───────────────────────────────────────────────────────
+
+function formatNotificationMessage(notification: AgentNotification): string {
+  const emoji =
+    notification.priority === 'critical' ? '🚨' :
+    notification.priority === 'high' ? '🔴' :
+    notification.priority === 'medium' ? '📋' : 'ℹ️'
+
+  const source = notification.source_agent ? ` from @${notification.source_agent}` : ''
+  const taskRef = notification.task_id ? ` (${notification.task_id})` : ''
+
+  const lines = [
+    `${emoji} **${notification.title}**${source}${taskRef}`,
+  ]
+
+  if (notification.body) {
+    lines.push(notification.body)
+  }
+
+  lines.push(`_ID: ${notification.id} · Ack: POST /agent-notifications/${notification.id}/ack { decision: "seen"|"accept"|"defer"|"dismiss" }_`)
+
+  return lines.join('\n')
+}
+
+// ── Worker class ───────────────────────────────────────────────────────────
+
+export class NotificationDeliveryWorker {
+  private timer: ReturnType<typeof setInterval> | null = null
+  private readonly pollIntervalMs: number
+  private readonly batchSize: number
+  private readonly expireAfterMs: number
+  private stats = {
+    delivered: 0,
+    skipped: 0,
+    failed: 0,
+    expired: 0,
+    ticks: 0,
+    lastTickAt: 0,
+  }
+
+  constructor(
+    private readonly getDb: () => Database.Database,
+    private readonly presenceManager: PresenceManager,
+    private readonly sendMessage: (opts: { from: string; content: string; channel: string; metadata?: Record<string, unknown> }) => Promise<unknown>,
+    private readonly postTaskComment?: (taskId: string, author: string, content: string) => Promise<unknown>,
+    config?: NotificationWorkerConfig,
+  ) {
+    this.pollIntervalMs = config?.pollIntervalMs ?? 30_000
+    this.batchSize = config?.batchSize ?? 20
+    this.expireAfterMs = config?.expireAfterMs ?? 24 * 60 * 60 * 1000
+  }
+
+  /** Start the worker loop */
+  start(): void {
+    if (this.timer) return
+    console.log(`[NotifWorker] Started (poll every ${this.pollIntervalMs / 1000}s, batch ${this.batchSize})`)
+    // Run first tick after a short delay to let server warm up
+    setTimeout(() => this.tick().catch(err => console.error('[NotifWorker] tick error:', err)), 5000)
+    this.timer = setInterval(() => {
+      this.tick().catch(err => console.error('[NotifWorker] tick error:', err))
+    }, this.pollIntervalMs)
+    this.timer.unref()
+  }
+
+  /** Stop the worker loop */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+      console.log('[NotifWorker] Stopped')
+    }
+  }
+
+  /** Get worker stats */
+  getStats() {
+    return { ...this.stats, running: this.timer !== null }
+  }
+
+  /** Process one batch of pending notifications */
+  async tick(): Promise<DeliveryResult[]> {
+    this.stats.ticks++
+    this.stats.lastTickAt = Date.now()
+    const db = this.getDb()
+    const now = Date.now()
+    const results: DeliveryResult[] = []
+
+    // 1. Expire old notifications first
+    const expired = db.prepare(`
+      UPDATE agent_notifications
+      SET status = 'expired'
+      WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?
+    `).run(now)
+    if (expired.changes > 0) {
+      this.stats.expired += expired.changes
+      console.log(`[NotifWorker] Expired ${expired.changes} notification(s)`)
+    }
+
+    // Also expire very old notifications without explicit expires_at
+    const staleExpired = db.prepare(`
+      UPDATE agent_notifications
+      SET status = 'expired'
+      WHERE status = 'pending' AND expires_at IS NULL AND created_at < ?
+    `).run(now - this.expireAfterMs)
+    if (staleExpired.changes > 0) {
+      this.stats.expired += staleExpired.changes
+    }
+
+    // 2. Fetch pending notifications, ordered by priority then age
+    const pending = db.prepare(`
+      SELECT * FROM agent_notifications
+      WHERE status = 'pending'
+      ORDER BY
+        CASE priority
+          WHEN 'critical' THEN 0
+          WHEN 'high' THEN 1
+          WHEN 'medium' THEN 2
+          WHEN 'low' THEN 3
+        END,
+        created_at ASC
+      LIMIT ?
+    `).all(this.batchSize) as Array<Record<string, unknown>>
+
+    if (pending.length === 0) return results
+
+    // 3. Deliver each notification
+    for (const row of pending) {
+      const notification = deserializeRow(row)
+      const targetAgent = notification.target_agent
+
+      // Check agent presence
+      const presence = this.presenceManager.getPresence(targetAgent)
+      const budget = presence ? presenceToBudget(presence.status) : 'closed'
+
+      // Budget check
+      if (!canInterrupt(notification.priority, budget)) {
+        this.stats.skipped++
+        results.push({ notificationId: notification.id, delivered: false, reason: `budget=${budget}, priority=${notification.priority}` })
+        continue
+      }
+
+      // Attempt delivery
+      let delivered = false
+      let deliveryError: string | undefined
+
+      try {
+        if (notification.task_id && this.postTaskComment) {
+          // Deliver as task comment when task_id is set
+          await this.postTaskComment(notification.task_id, 'system', formatNotificationMessage(notification))
+          delivered = true
+        } else {
+          // Deliver as DM via chat
+          await this.sendMessage({
+            from: 'system',
+            content: formatNotificationMessage(notification),
+            channel: 'notifications',
+            metadata: { notification_id: notification.id, target_agent: targetAgent },
+          })
+          delivered = true
+        }
+      } catch (err) {
+        deliveryError = err instanceof Error ? err.message : String(err)
+        console.error(`[NotifWorker] Delivery failed for ${notification.id}:`, deliveryError)
+
+        // Retry once
+        try {
+          await this.sendMessage({
+            from: 'system',
+            content: formatNotificationMessage(notification),
+            channel: 'notifications',
+            metadata: { notification_id: notification.id, target_agent: targetAgent, retry: true },
+          })
+          delivered = true
+          deliveryError = undefined
+        } catch (retryErr) {
+          deliveryError = retryErr instanceof Error ? retryErr.message : String(retryErr)
+        }
+      }
+
+      // Update status
+      if (delivered) {
+        db.prepare(`
+          UPDATE agent_notifications
+          SET status = 'delivered', ack_at = ?
+          WHERE id = ?
+        `).run(now, notification.id)
+        this.stats.delivered++
+        results.push({ notificationId: notification.id, delivered: true })
+      } else {
+        db.prepare(`
+          UPDATE agent_notifications
+          SET status = 'failed', metadata = json_set(COALESCE(metadata, '{}'), '$.delivery_error', ?)
+          WHERE id = ?
+        `).run(deliveryError ?? 'unknown', notification.id)
+        this.stats.failed++
+        results.push({ notificationId: notification.id, delivered: false, reason: deliveryError })
+      }
+    }
+
+    if (results.length > 0) {
+      const delivered = results.filter(r => r.delivered).length
+      const skipped = results.filter(r => !r.delivered).length
+      console.log(`[NotifWorker] Processed ${results.length}: ${delivered} delivered, ${skipped} skipped/failed`)
+    }
+
+    return results
+  }
+}
+
+// ── Row deserialization ────────────────────────────────────────────────────
+
+function deserializeRow(row: Record<string, unknown>): AgentNotification {
+  return {
+    id: String(row.id),
+    target_agent: String(row.target_agent),
+    source_agent: row.source_agent ? String(row.source_agent) : null,
+    type: String(row.type) as AgentNotification['type'],
+    title: String(row.title),
+    body: row.body ? String(row.body) : null,
+    priority: String(row.priority) as AgentNotification['priority'],
+    status: String(row.status) as AgentNotification['status'],
+    ack_decision: row.ack_decision ? String(row.ack_decision) as AgentNotification['ack_decision'] : null,
+    ack_at: typeof row.ack_at === 'number' ? row.ack_at : null,
+    task_id: row.task_id ? String(row.task_id) : null,
+    metadata: row.metadata ? (typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata as Record<string, unknown>) : null,
+    created_at: typeof row.created_at === 'number' ? row.created_at : Date.now(),
+    expires_at: typeof row.expires_at === 'number' ? row.expires_at : null,
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2499,6 +2499,15 @@ export async function createServer(): Promise<FastifyInstance> {
   boardHealthWorker.updateConfig(policy.boardHealth)
   boardHealthWorker.start()
 
+  // Notification delivery worker — pushes pending agent-notifications to active agents
+  const { NotificationDeliveryWorker } = await import('./notification-worker.js')
+  const notificationWorker = new NotificationDeliveryWorker(
+    getDb,
+    presenceManager,
+    async (opts) => { await chatManager.sendMessage(opts) },
+  )
+  notificationWorker.start()
+
   // Activate noise budget enforcement — the 24h canary period is complete.
   // Canary mode (log-only) is still the default in case of fresh installs,
   // but on a running server we want real duplicate suppression.
@@ -15324,6 +15333,17 @@ If your heartbeat shows **no active task** and **no next task**:
 
     const result = agentNotifModule.getNotifications(getDb(), agent, { status, limit })
     return { notifications: result.notifications, total: result.total }
+  })
+
+  // GET /agent-notifications/worker/stats — delivery worker status
+  app.get('/agent-notifications/worker/stats', async () => {
+    return { success: true, stats: notificationWorker.getStats() }
+  })
+
+  // POST /agent-notifications/worker/tick — manually trigger delivery tick (for testing)
+  app.post('/agent-notifications/worker/tick', async () => {
+    const results = await notificationWorker.tick()
+    return { success: true, results }
   })
 
   // POST /agent-presence — upsert agent presence (delegates to PresenceManager + logs)

--- a/tests/notification-worker.test.ts
+++ b/tests/notification-worker.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NotificationDeliveryWorker } from '../src/notification-worker.js'
+import type Database from 'better-sqlite3'
+
+// Mock DB that stores notifications in memory
+function createMockDb() {
+  const notifications: Array<Record<string, unknown>> = []
+
+  const mockStmt = (sql: string) => {
+    return {
+      run: (...args: unknown[]) => {
+        if (sql.includes('UPDATE') && sql.includes("status = 'expired'")) {
+          let changes = 0
+          for (const n of notifications) {
+            if (n.status === 'pending') {
+              if (sql.includes('expires_at IS NOT NULL') && n.expires_at && (n.expires_at as number) < (args[0] as number)) {
+                n.status = 'expired'; changes++
+              } else if (sql.includes('expires_at IS NULL') && !n.expires_at && (n.created_at as number) < (args[0] as number)) {
+                n.status = 'expired'; changes++
+              }
+            }
+          }
+          return { changes }
+        }
+        if (sql.includes('UPDATE') && sql.includes("status = 'delivered'")) {
+          const id = args[1] as string
+          const n = notifications.find(x => x.id === id)
+          if (n) { n.status = 'delivered'; n.ack_at = args[0] }
+          return { changes: n ? 1 : 0 }
+        }
+        if (sql.includes('UPDATE') && sql.includes("status = 'failed'")) {
+          const id = args[1] as string
+          const n = notifications.find(x => x.id === id)
+          if (n) n.status = 'failed'
+          return { changes: n ? 1 : 0 }
+        }
+        return { changes: 0 }
+      },
+      all: (..._args: unknown[]) => {
+        if (sql.includes('SELECT')) {
+          return notifications.filter(n => n.status === 'pending').slice(0, 20)
+        }
+        return []
+      },
+    }
+  }
+
+  const db = {
+    prepare: (sql: string) => mockStmt(sql),
+    _notifications: notifications,
+  } as unknown as Database.Database & { _notifications: typeof notifications }
+
+  return db
+}
+
+// Mock presence manager
+function createMockPresence(statuses: Record<string, string> = {}) {
+  return {
+    getPresence: (agent: string) => {
+      const status = statuses[agent]
+      if (!status) return null
+      return { agent, status, since: Date.now(), lastUpdate: Date.now() }
+    },
+  } as any
+}
+
+describe('NotificationDeliveryWorker', () => {
+  let db: ReturnType<typeof createMockDb>
+  let sendMessage: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    db = createMockDb()
+    sendMessage = vi.fn().mockResolvedValue({})
+  })
+
+  it('delivers pending notifications to active agents', async () => {
+    db._notifications.push({
+      id: 'notif-1', target_agent: 'link', source_agent: 'kai',
+      type: 'task', title: 'Review PR', body: null,
+      priority: 'medium', status: 'pending', ack_decision: null, ack_at: null,
+      task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+    })
+
+    const presence = createMockPresence({ link: 'idle' }) // open budget
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    const results = await worker.tick()
+    expect(results).toHaveLength(1)
+    expect(results[0].delivered).toBe(true)
+    expect(sendMessage).toHaveBeenCalledOnce()
+    expect(db._notifications[0].status).toBe('delivered')
+  })
+
+  it('skips offline agents (closed budget)', async () => {
+    db._notifications.push({
+      id: 'notif-2', target_agent: 'pixel', source_agent: null,
+      type: 'info', title: 'Low priority', body: null,
+      priority: 'low', status: 'pending', ack_decision: null, ack_at: null,
+      task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+    })
+
+    const presence = createMockPresence({ pixel: 'offline' }) // closed budget
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    const results = await worker.tick()
+    expect(results).toHaveLength(1)
+    expect(results[0].delivered).toBe(false)
+    expect(results[0].reason).toContain('budget=closed')
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('delivers critical notifications even to offline agents', async () => {
+    db._notifications.push({
+      id: 'notif-3', target_agent: 'sage', source_agent: null,
+      type: 'alert', title: 'Production down', body: null,
+      priority: 'critical', status: 'pending', ack_decision: null, ack_at: null,
+      task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+    })
+
+    const presence = createMockPresence({ sage: 'offline' })
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    const results = await worker.tick()
+    expect(results).toHaveLength(1)
+    expect(results[0].delivered).toBe(true)
+  })
+
+  it('respects focused budget — allows high but not medium', async () => {
+    db._notifications.push(
+      {
+        id: 'notif-high', target_agent: 'link', source_agent: null,
+        type: 'alert', title: 'High priority', body: null,
+        priority: 'high', status: 'pending', ack_decision: null, ack_at: null,
+        task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+      },
+      {
+        id: 'notif-med', target_agent: 'link', source_agent: null,
+        type: 'info', title: 'Medium priority', body: null,
+        priority: 'medium', status: 'pending', ack_decision: null, ack_at: null,
+        task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+      },
+    )
+
+    const presence = createMockPresence({ link: 'working' }) // focused budget
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    const results = await worker.tick()
+    expect(results).toHaveLength(2)
+    expect(results.find(r => r.notificationId === 'notif-high')?.delivered).toBe(true)
+    expect(results.find(r => r.notificationId === 'notif-med')?.delivered).toBe(false)
+  })
+
+  it('returns empty results when no pending notifications', async () => {
+    const presence = createMockPresence({})
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    const results = await worker.tick()
+    expect(results).toHaveLength(0)
+  })
+
+  it('retries on first failure then marks failed', async () => {
+    db._notifications.push({
+      id: 'notif-fail', target_agent: 'link', source_agent: null,
+      type: 'info', title: 'Will fail', body: null,
+      priority: 'medium', status: 'pending', ack_decision: null, ack_at: null,
+      task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+    })
+
+    const presence = createMockPresence({ link: 'idle' })
+    sendMessage.mockRejectedValue(new Error('delivery failed'))
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    const results = await worker.tick()
+    expect(results).toHaveLength(1)
+    expect(results[0].delivered).toBe(false)
+    expect(sendMessage).toHaveBeenCalledTimes(2) // original + 1 retry
+    expect(db._notifications[0].status).toBe('failed')
+  })
+
+  it('tracks stats correctly', async () => {
+    db._notifications.push({
+      id: 'notif-stat', target_agent: 'link', source_agent: null,
+      type: 'info', title: 'Stats test', body: null,
+      priority: 'medium', status: 'pending', ack_decision: null, ack_at: null,
+      task_id: null, metadata: null, created_at: Date.now(), expires_at: null,
+    })
+
+    const presence = createMockPresence({ link: 'idle' })
+    const worker = new NotificationDeliveryWorker(() => db, presence, sendMessage)
+
+    await worker.tick()
+    const stats = worker.getStats()
+    expect(stats.ticks).toBe(1)
+    expect(stats.delivered).toBe(1)
+    expect(stats.running).toBe(false) // not started
+  })
+})


### PR DESCRIPTION
## What

Notification delivery worker that polls `agent_notifications` for pending rows and pushes them to active agents via chat DM.

## Interruption Budget

Maps agent presence → budget level:
| Presence | Budget | Delivers |
|----------|--------|----------|
| idle/blocked/waiting | open | all priorities |
| working/reviewing | focused | high + critical only |
| offline/unknown | closed | critical only |

## Features
- **30s poll interval** (configurable via `pollIntervalMs`)
- **Batch processing** — 20 per tick (configurable)
- **Auto-expiry** — notifications with `expires_at` or older than 24h
- **Retry once** on delivery failure, then marks `status=failed`
- **Stats endpoint**: `GET /agent-notifications/worker/stats`
- **Manual tick**: `POST /agent-notifications/worker/tick` (for testing)

## New Files
- `src/notification-worker.ts` — worker class with budget logic
- `tests/notification-worker.test.ts` — 7 unit tests

## Testing
- 219 test files, 2447 tests pass, 0 failures
- tsc clean, route-docs contract passes (563 routes)

Closes task-1773659376304