### PR TITLE
fix(node): normalize activity stream event shape

### DIFF
--- a/src/activity-stream-normalizer.ts
+++ b/src/activity-stream-normalizer.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Activity Stream Event Normalizer
+ *
+ * Transforms raw eventBus events into a consistent shape:
+ * { id, type, agent, title, detail, taskId, prUrl, timestamp }
+ *
+ * This ensures all activity-stream SSE consumers receive events
+ * in a predictable format regardless of the source event type.
+ */
+
+export interface NormalizedActivityEvent {
+  id: string
+  type: string
+  agent: string | null
+  title: string
+  detail: string | null
+  taskId: string | null
+  prUrl: string | null
+  timestamp: number
+  /** Original raw data preserved for consumers that need full detail */
+  _raw?: unknown
+}
+
+interface RawEvent {
+  id: string
+  type: string
+  timestamp: number
+  data: Record<string, unknown>
+}
+
+/**
+ * Normalize a raw eventBus event into the standard activity-stream shape.
+ */
+export function normalizeActivityEvent(event: RawEvent): NormalizedActivityEvent {
+  const data = (event.data ?? {}) as Record<string, unknown>
+
+  // Extract agent from various field names
+  const agent = extractString(data, 'agentId')
+    ?? extractString(data, 'agent')
+    ?? extractString(data, 'name')
+    ?? extractNestedString(data, 'presence', 'name')
+    ?? null
+
+  // Extract title based on event type
+  const title = deriveTitle(event.type, data)
+
+  // Extract detail
+  const detail = extractString(data, 'transcript')
+    ?? extractString(data, 'text')
+    ?? extractNestedString(data, 'data', 'text')
+    ?? extractString(data, 'query')
+    ?? null
+
+  // Extract task reference
+  const taskId = extractString(data, 'taskId')
+    ?? extractString(data, 'task_id')
+    ?? extractNestedString(data, 'activeTask', 'id')
+    ?? extractNestedString(data, 'payload', 'activeTask', 'id' as any)
+    ?? null
+
+  // Extract PR URL
+  const prUrl = extractString(data, 'prUrl')
+    ?? extractString(data, 'pr_url')
+    ?? null
+
+  return {
+    id: event.id,
+    type: event.type,
+    agent,
+    title,
+    detail,
+    taskId,
+    prUrl,
+    timestamp: event.timestamp,
+    _raw: data,
+  }
+}
+
+/**
+ * Strip the _raw field for lightweight payloads.
+ */
+export function normalizeActivityEventSlim(event: RawEvent): Omit<NormalizedActivityEvent, '_raw'> {
+  const normalized = normalizeActivityEvent(event)
+  const { _raw, ...slim } = normalized
+  return slim
+}
+
+// ── Helpers ──
+
+function extractString(obj: Record<string, unknown>, key: string): string | null {
+  const val = obj[key]
+  return typeof val === 'string' && val.length > 0 ? val : null
+}
+
+function extractNestedString(obj: Record<string, unknown>, ...keys: string[]): string | null {
+  let current: unknown = obj
+  for (const key of keys) {
+    if (current == null || typeof current !== 'object') return null
+    current = (current as Record<string, unknown>)[key]
+  }
+  return typeof current === 'string' && current.length > 0 ? current : null
+}
+
+function deriveTitle(type: string, data: Record<string, unknown>): string {
+  switch (type) {
+    case 'canvas_message': {
+      const subType = extractString(data, 'type')
+      if (subType === 'voice_transcript') return 'Voice transcript'
+      if (subType === 'info') return 'Info'
+      if (data.isResponse) return 'Agent response'
+      if (data.query) return 'Canvas query'
+      return 'Message'
+    }
+    case 'canvas_render': {
+      const state = extractString(data, 'state')
+      const agent = extractString(data, 'agentId') ?? 'Agent'
+      if (state === 'thinking') return `${agent} thinking`
+      if (state === 'handoff') return `${agent} handing off`
+      if (state === 'decision') return `${agent} needs attention`
+      if (state === 'ambient') return `${agent} idle`
+      return `${agent} state: ${state ?? 'unknown'}`
+    }
+    case 'canvas_expression':
+      return extractString(data, 'expression') ?? 'Expression'
+    case 'canvas_burst':
+      return extractString(data, 'reason') ?? 'Activity burst'
+    default:
+      return type.replace(/_/g, ' ')
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11767,19 +11767,24 @@ export async function createServer(): Promise<FastifyInstance> {
   const activityRingBuffer: Array<{ id: string; type: string; timestamp: number; data: unknown }> = []
   const ACTIVITY_RING_SIZE = 30 // Keep slightly more than 20 for filtering headroom
 
+  // Normalize activity events into consistent shape
+  const { normalizeActivityEventSlim } = await import('./activity-stream-normalizer.js')
+
   // Subscribe to eventBus to populate ring buffer
   eventBus.on('activity-ring-collector', (event) => {
     if (!ACTIVITY_STREAM_TYPES.has(event.type)) return
-    activityRingBuffer.push({ id: event.id, type: event.type, timestamp: event.timestamp, data: event.data })
+    const normalized = normalizeActivityEventSlim({ id: event.id, type: event.type, timestamp: event.timestamp, data: event.data as Record<string, unknown> })
+    activityRingBuffer.push(normalized as any)
     if (activityRingBuffer.length > ACTIVITY_RING_SIZE) activityRingBuffer.shift()
   })
 
   const activityStreamSubscribers = new Map<string, { closed: boolean; send: (data: string) => void }>()
 
-  // Forward matching events to activity stream subscribers
+  // Forward matching events to activity stream subscribers (normalized shape)
   eventBus.on('activity-stream-relay', (event) => {
     if (!ACTIVITY_STREAM_TYPES.has(event.type)) return
-    const payload = JSON.stringify({ id: event.id, type: event.type, timestamp: event.timestamp, data: event.data })
+    const normalized = normalizeActivityEventSlim({ id: event.id, type: event.type, timestamp: event.timestamp, data: event.data as Record<string, unknown> })
+    const payload = JSON.stringify(normalized)
     for (const [subId, sub] of activityStreamSubscribers) {
       if (sub.closed) { activityStreamSubscribers.delete(subId); continue }
       try { sub.send(payload) } catch { activityStreamSubscribers.delete(subId) }

--- a/tests/activity-stream-normalizer.test.ts
+++ b/tests/activity-stream-normalizer.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest'
+import { normalizeActivityEvent, normalizeActivityEventSlim } from '../src/activity-stream-normalizer.js'
+
+describe('activity-stream-normalizer', () => {
+  it('normalizes a canvas_message voice transcript', () => {
+    const result = normalizeActivityEvent({
+      id: 'cmsg-voice-123',
+      type: 'canvas_message',
+      timestamp: 1000,
+      data: {
+        type: 'voice_transcript',
+        agentId: 'link',
+        agentColor: '#60a5fa',
+        transcript: 'Hello world',
+      },
+    })
+
+    expect(result.id).toBe('cmsg-voice-123')
+    expect(result.type).toBe('canvas_message')
+    expect(result.agent).toBe('link')
+    expect(result.title).toBe('Voice transcript')
+    expect(result.detail).toBe('Hello world')
+    expect(result.timestamp).toBe(1000)
+    expect(result._raw).toBeDefined()
+  })
+
+  it('normalizes a canvas_render event', () => {
+    const result = normalizeActivityEvent({
+      id: 'render-1',
+      type: 'canvas_render',
+      timestamp: 2000,
+      data: {
+        state: 'thinking',
+        agentId: 'kai',
+        payload: { presenceState: 'working', activeTask: { id: 'task-123', title: 'Build feature' } },
+        presence: { name: 'kai', state: 'working' },
+      },
+    })
+
+    expect(result.agent).toBe('kai')
+    expect(result.title).toBe('kai thinking')
+    expect(result.taskId).toBe('task-123')
+  })
+
+  it('normalizes a canvas_message query', () => {
+    const result = normalizeActivityEvent({
+      id: 'cmsg-q-1',
+      type: 'canvas_message',
+      timestamp: 3000,
+      data: {
+        query: 'What tasks are in progress?',
+        agentId: 'sage',
+        isResponse: false,
+      },
+    })
+
+    expect(result.agent).toBe('sage')
+    expect(result.title).toBe('Canvas query')
+    expect(result.detail).toBe('What tasks are in progress?')
+  })
+
+  it('normalizes a canvas_message response', () => {
+    const result = normalizeActivityEvent({
+      id: 'cmsg-r-1',
+      type: 'canvas_message',
+      timestamp: 4000,
+      data: {
+        agentId: 'link',
+        isResponse: true,
+        data: { text: 'Here are the results' },
+      },
+    })
+
+    expect(result.title).toBe('Agent response')
+    expect(result.detail).toBe('Here are the results')
+  })
+
+  it('normalizes a canvas_expression', () => {
+    const result = normalizeActivityEvent({
+      id: 'expr-1',
+      type: 'canvas_expression',
+      timestamp: 5000,
+      data: {
+        agentId: 'pixel',
+        expression: 'shipped',
+      },
+    })
+
+    expect(result.agent).toBe('pixel')
+    expect(result.title).toBe('shipped')
+  })
+
+  it('normalizes a canvas_burst', () => {
+    const result = normalizeActivityEvent({
+      id: 'burst-1',
+      type: 'canvas_burst',
+      timestamp: 6000,
+      data: {
+        reason: 'High activity',
+        agentId: 'echo',
+      },
+    })
+
+    expect(result.agent).toBe('echo')
+    expect(result.title).toBe('High activity')
+  })
+
+  it('returns null fields for missing data', () => {
+    const result = normalizeActivityEvent({
+      id: 'empty-1',
+      type: 'canvas_render',
+      timestamp: 7000,
+      data: {},
+    })
+
+    expect(result.agent).toBeNull()
+    expect(result.detail).toBeNull()
+    expect(result.taskId).toBeNull()
+    expect(result.prUrl).toBeNull()
+  })
+
+  it('slim version excludes _raw', () => {
+    const result = normalizeActivityEventSlim({
+      id: 'slim-1',
+      type: 'canvas_message',
+      timestamp: 8000,
+      data: { agentId: 'link', type: 'info' },
+    })
+
+    expect(result).not.toHaveProperty('_raw')
+    expect(result.agent).toBe('link')
+    expect(result.title).toBe('Info')
+  })
+
+  it('has all required normalized fields', () => {
+    const result = normalizeActivityEvent({
+      id: 'shape-1',
+      type: 'canvas_render',
+      timestamp: 9000,
+      data: { agentId: 'kai', state: 'ambient' },
+    })
+
+    // Verify all required fields exist
+    expect(result).toHaveProperty('id')
+    expect(result).toHaveProperty('type')
+    expect(result).toHaveProperty('agent')
+    expect(result).toHaveProperty('title')
+    expect(result).toHaveProperty('detail')
+    expect(result).toHaveProperty('taskId')
+    expect(result).toHaveProperty('prUrl')
+    expect(result).toHaveProperty('timestamp')
+  })
+})


### PR DESCRIPTION
## Summary

Normalizes activity-stream SSE events to a consistent shape so all consumers get predictable fields.

### Before
```json
{ "id": "...", "type": "canvas_message", "timestamp": 123, "data": { /* varies wildly */ } }
```

### After
```json
{ "id": "...", "type": "canvas_message", "agent": "link", "title": "Voice transcript", "detail": "Hello world", "taskId": null, "prUrl": null, "timestamp": 123 }
```

### Changes
- **`src/activity-stream-normalizer.ts`**: New module — `normalizeActivityEvent()` and `normalizeActivityEventSlim()`
- **`src/server.ts`**: Ring buffer collector and live relay now emit normalized events
- **9 new tests** covering all event types (canvas_message, canvas_render, canvas_expression, canvas_burst) + edge cases

### Tests
- Route-docs: 568/568 ✅
- Suite: 2455 pass, 0 regressions

### Task
task-1773681277736-eg8br2tjj