### PR TITLE
refactor(node): extract canvas routes Phase 1 — slots, states, rejections

### DIFF
--- a/src/canvas-routes.ts
+++ b/src/canvas-routes.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Canvas Routes (Phase 1) — extracted from server.ts
+ *
+ * Fastify plugin that registers a first batch of /canvas/* endpoints.
+ * Each extracted route is replaced with this plugin in server.ts.
+ * Remaining routes stay in server.ts for Phase 2+ extraction.
+ *
+ * Extraction strategy: start with simple, self-contained routes.
+ * Complex routes with deep state coupling remain in server.ts.
+ *
+ * task-1773681272865
+ */
+
+import type { FastifyInstance } from 'fastify'
+
+// ── Types ──
+
+export type CanvasState = 'floor' | 'ambient' | 'thinking' | 'rendering' | 'decision' | 'handoff' | 'urgent' | 'presenting'
+
+export interface CanvasStateEntry {
+  state: CanvasState
+  sensors: string | null
+  payload: unknown
+  updatedAt: number
+}
+
+/**
+ * Dependencies injected from server.ts.
+ * Each dep is a narrow interface — no coupling to the full module.
+ */
+export interface CanvasRouteDeps {
+  canvasSlots: {
+    getActive: () => unknown[]
+    getAll: () => unknown[]
+    getStats: () => unknown
+  }
+  getRecentRejections: () => unknown[]
+}
+
+// ── Constants (moved from server.ts) ──
+
+export const CANVAS_STATES = [
+  'floor', 'listening', 'thinking', 'rendering', 'ambient', 'decision', 'urgent', 'handoff', 'presenting',
+]
+export const SENSOR_VALUES = [
+  'voice_active', 'screen_share', 'camera', 'typing', 'idle', 'scroll', 'hover', 'focus',
+]
+
+// ── Plugin ──
+
+export async function canvasReadRoutes(app: FastifyInstance, deps: CanvasRouteDeps) {
+
+  // GET /canvas/states — valid state + sensor values (discovery)
+  app.get('/canvas/states', async () => ({
+    states: CANVAS_STATES,
+    sensors: SENSOR_VALUES,
+    schema: {
+      state: 'floor | listening | thinking | rendering | ambient | decision | urgent | handoff',
+      sensors: 'null | mic | camera | mic+camera (non-dismissable trust indicator)',
+      agentId: 'required — which agent is driving the canvas',
+      payload: 'optional — text, media, decision, agents, summary',
+    },
+  }))
+
+  // GET /canvas/slots — current active slots
+  app.get('/canvas/slots', async () => {
+    return {
+      slots: deps.canvasSlots.getActive(),
+      stats: deps.canvasSlots.getStats(),
+    }
+  })
+
+  // GET /canvas/slots/all — all slots including stale (debug)
+  app.get('/canvas/slots/all', async () => {
+    return { slots: deps.canvasSlots.getAll() }
+  })
+
+  // GET /canvas/rejections — recent render rejections (debug)
+  app.get('/canvas/rejections', async () => {
+    return { rejections: deps.getRecentRejections() }
+  })
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -158,6 +158,7 @@ import { startShippedHeartbeat, stopShippedHeartbeat, getShippedHeartbeatStats }
 import { startOpenClawUsageSync, stopOpenClawUsageSync, syncOpenClawUsage } from './openclaw-usage-sync.js'
 import { initContactsTable, createContact, getContact, updateContact, deleteContact, listContacts, countContacts } from './contacts.js'
 import { processRender, logRejection, getRecentRejections, subscribeCanvas } from './canvas-multiplexer.js'
+import { canvasReadRoutes } from './canvas-routes.js'
 import { startTeamPulse, stopTeamPulse, postTeamPulse, computeTeamPulse, getTeamPulseConfig, configureTeamPulse, getTeamPulseHistory } from './team-pulse.js'
 import { runTeamDoctor } from './team-doctor.js'
 import { createStarterTeam } from './starter-team.js'
@@ -11002,19 +11003,13 @@ export async function createServer(): Promise<FastifyInstance> {
     return { agents: all, count: canvasStateMap.size }
   })
 
-  // GET /canvas/states — valid state + sensor values (discovery)
-  app.get('/canvas/states', async () => ({
-    states: CANVAS_STATES,
-    sensors: SENSOR_VALUES,
-    schema: {
-      state: 'floor | listening | thinking | rendering | ambient | decision | urgent | handoff',
-      sensors: 'null | mic | camera | mic+camera (non-dismissable trust indicator)',
-      agentId: 'required — which agent is driving the canvas',
-      payload: 'optional — text, media, decision, agents, summary',
-    },
-  }))
-
-  // GET /canvas/slots — current active slots
+  // ── Canvas read routes (Phase 1 extraction) ──────────────────────────
+  // GET /canvas/states, /canvas/slots, /canvas/slots/all, /canvas/rejections
+  // Extracted to src/canvas-routes.ts
+  await app.register(canvasReadRoutes, {
+    canvasSlots: { getActive: () => canvasSlots.getActive(), getAll: () => canvasSlots.getAll(), getStats: () => canvasSlots.getStats() },
+    getRecentRejections,
+  } as any)
   // POST /canvas/gaze — client fires when user holds cursor/gaze on an agent orb for ≥3 seconds.
   // The agent "notices" and responds: generates a one-line thought about what they're doing,
   // fires canvas_expression so the room responds (dim others, speak, show task).
@@ -11372,17 +11367,7 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
-  app.get('/canvas/slots', async () => {
-    return {
-      slots: canvasSlots.getActive(),
-      stats: canvasSlots.getStats(),
-    }
-  })
-
-  // GET /canvas/slots/all — all slots including stale (debug)
-  app.get('/canvas/slots/all', async () => {
-    return { slots: canvasSlots.getAll() }
-  })
+  // /canvas/slots + /canvas/slots/all → canvas-routes.ts plugin
 
   // GET /canvas/team/mood — derived collective mood of all active agents
   // Returns teamRhythm, tension, ambientPulse, dominantColor. Used by living canvas for atmosphere shifts.
@@ -12828,10 +12813,7 @@ export async function createServer(): Promise<FastifyInstance> {
     return { history: canvasSlots.getHistory(slot, limit) }
   })
 
-  // GET /canvas/rejections — recent contract rejections (for tuning)
-  app.get('/canvas/rejections', async () => {
-    return { rejections: getRecentRejections() }
-  })
+  // /canvas/rejections → canvas-routes.ts plugin
 
   // GET /canvas/stream — SSE stream of canvas render events
   app.get('/canvas/stream', async (request, reply) => {

--- a/tools/check-route-docs-contract.mjs
+++ b/tools/check-route-docs-contract.mjs
@@ -9,6 +9,7 @@ const DOCS_PATH = path.join(ROOT, 'public', 'docs.md')
 // Additional source files that register routes via helper functions
 const EXTRA_ROUTE_SOURCES = [
   path.join(ROOT, 'src', 'manage.ts'),
+  path.join(ROOT, 'src', 'canvas-routes.ts'),
 ]
 
 const IGNORE_ROUTES = new Set([


### PR DESCRIPTION
## Summary

Phase 1 of extracting canvas routes from server.ts (19,896 lines) into a dedicated module.

### Extracted routes (4)
- `GET /canvas/states` — valid state + sensor values (discovery)
- `GET /canvas/slots` — current active slots  
- `GET /canvas/slots/all` — all slots including stale (debug)
- `GET /canvas/rejections` — recent render rejections (debug)

### Architecture
- New `src/canvas-routes.ts` — Fastify plugin with injected dependencies
- `server.ts` registers the plugin, passing narrow dep interfaces
- Route-docs contract checker updated to scan extracted file

### Why Phase 1?
The remaining 30 canvas routes have deep coupling to module-level state (`canvasStateMap`, `eventBus`, `presenceManager`, voice pipeline, etc.). Each needs careful extraction with per-route verification. These 4 routes are fully self-contained.

### Tests
- Route-docs: 568/568 ✅
- Suite: 2446 pass, 0 regressions

### Task
task-1773681272865-4c0lio2ex