### PR TITLE
fix(canvas): add canvas_takeover to pulse SSE stream filter

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12616,7 +12616,7 @@ export async function createServer(): Promise<FastifyInstance> {
     const listenerId = `pulse-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     eventBus.on(listenerId, (event) => {
       if (closed) return
-      if (event.type !== 'canvas_burst' && event.type !== 'canvas_spark' && event.type !== 'canvas_milestone' && event.type !== 'canvas_expression' && event.type !== 'canvas_message' && event.type !== 'canvas_push' && event.type !== 'canvas_artifact') return
+      if (event.type !== 'canvas_burst' && event.type !== 'canvas_spark' && event.type !== 'canvas_milestone' && event.type !== 'canvas_expression' && event.type !== 'canvas_message' && event.type !== 'canvas_push' && event.type !== 'canvas_artifact' && event.type !== 'canvas_takeover') return
       try {
         reply.raw.write(`event: ${event.type}\ndata: ${JSON.stringify({ ...event.data as object, t: event.timestamp })}\n\n`)
       } catch { closed = true }


### PR DESCRIPTION
## Bug

`canvas_takeover` events were being emitted on the eventBus but the pulse SSE stream filter was dropping them. The listener only forwarded: canvas_burst, canvas_spark, canvas_milestone, canvas_expression, canvas_message, canvas_push, canvas_artifact.

`canvas_takeover` was missing → frontend never received takeover claim/release events → takeover appeared to do nothing.

## Fix

One-line addition to the pulse stream event type whitelist.

## Testing
- 220 test files, 2456 tests pass
- tsc clean

task-1773672750043