### PR TITLE
fix(node): vunknown restart broadcast — readFileSync for version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -630,8 +630,14 @@ async function main() {
           }
 
           // Read node identity for the broadcast
-          const pkg = await import('../package.json', { assert: { type: 'json' } }).catch(() => ({ default: { version: 'unknown' } }))
-          const version = pkg.default.version
+          // Use readFileSync (same approach as BUILD_VERSION in server.ts) — dynamic import
+          // fails when running from dist/ because the relative path doesn't resolve.
+          let version = 'unknown'
+          try {
+            const pkgPath = join(process.cwd(), 'package.json')
+            const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+            version = pkg.version || 'unknown'
+          } catch { /* non-blocking */ }
           let nodeName = process.env.REFLECTT_HOST_NAME || 'unknown'
           try {
             const cfgPath = join(REFLECTT_HOME, 'config.json')


### PR DESCRIPTION
## Bug

Restart broadcast showed `vunknown` instead of the actual version. The dynamic `import('../package.json')` fails when running from the compiled `dist/` directory because the relative path doesn't resolve to the source root.

## Fix

Use `readFileSync` + `JSON.parse` — same approach as `BUILD_VERSION` at the top of `server.ts` which works correctly.

## Testing
- 220 test files, 2456 tests pass, tsc clean

task-1773689755337-0baoh5qa5