### PR TITLE
fix(canvas): queue canvas_push for cloud relay — background layer reaches browsers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12592,8 +12592,12 @@ export async function createServer(): Promise<FastifyInstance> {
       })
     }
 
-    // Emit on eventBus — forwarded immediately on pulse SSE stream
+    // Emit on eventBus — forwarded immediately on pulse SSE stream (local SSE subscribers)
     eventBus.emit({ id: `push-${now}-${Math.random().toString(36).slice(2, 6)}`, type: 'canvas_push', timestamp: now, data: payload })
+
+    // Queue for cloud relay — reaches browsers on app.reflectt.ai via syncCanvas push_events[]
+    // task-1773690756100
+    queueCanvasPushEvent({ ...payload, _event: 'canvas_push' })
 
     return { success: true, type, agentId }
   })


### PR DESCRIPTION
## Problem
POST /canvas/push emitted on local eventBus only. Cloud browsers on app.reflectt.ai never received background layer or rich push events — events were silently dropped.

## Fix
Call `queueCanvasPushEvent()` after the eventBus emit so events flush to cloud via syncCanvas push_events[] within 5s.

## Root cause
The takeover route correctly calls `queueCanvasPushEvent` (added in PR #1095) but the canvas/push route missed it.

Closes task-1773690756100