### PR TITLE
fix(canvas): inject agent avatars into cloud sync payload — custom orbs reach browsers

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1414,6 +1414,23 @@ async function syncCanvas(): Promise<void> {
     checkNeedsAttentionTransitions(agents, state.hostId, config.cloudUrl, state.credential)
   }
 
+  // Inject agent avatars into sync payload — browsers on app.reflectt.ai read avatar
+  // from agent state (canvasStore), not from a separate API call. We merge avatar
+  // into each agent entry here so cloud browsers render custom orbs instead of circles.
+  // task-1773690756100
+  try {
+    const db = getDb()
+    const avatarRows = db.prepare("SELECT agent_id, settings FROM agent_config WHERE settings LIKE '%avatar%'").all() as Array<{ agent_id: string; settings: string }>
+    for (const row of avatarRows) {
+      try {
+        const s = JSON.parse(row.settings)
+        if (s.avatar?.content && agents[row.agent_id]) {
+          (agents[row.agent_id] as Record<string, unknown>).avatar = s.avatar.content
+        }
+      } catch { /* skip */ }
+    }
+  } catch { /* non-blocking */ }
+
   // Push to cloud — include slots, agent states, and any buffered canvas_push events
   const pushEventsToSend = pendingPushEvents.splice(0, pendingPushEvents.length)
   const result = await cloudPost<{ ok: boolean; slotCount: number }>(


### PR DESCRIPTION
## Root cause
Avatars set via `POST /agents/:name/identity/avatar` were stored in `agent_config` but never included in the `syncCanvas` POST to the cloud. Cloud browsers read agent state from `canvasStore` (populated by the sync POST), so avatar was always `undefined` → default circles rendered.

## Fix
Before posting to cloud, merge `avatar.content` string from `agent_config` into each agent entry. The cloud stores this in `canvasStore` and browsers receive it via the pulse SSE stream. The cloud's `use-host-state.ts` already maps it to the `avatar` field (PR #1334).

## Why not fix on cloud side
The cloud frontend can't call `GET /agents/avatars` directly — there's no proxy route for it. The sync POST is the correct single source of truth.

Closes task-1773690756100