### PR TITLE
feat(activation): canvas_opened + canvas_first_action events — activation funnel

### DIFF
--- a/src/activationEvents.ts
+++ b/src/activationEvents.ts
@@ -37,6 +37,8 @@ export type ActivationEventType =
   | 'first_task_completed'
   | 'first_team_message_sent'
   | 'day2_return_action'
+  | 'canvas_opened'
+  | 'canvas_first_action'
 
 /**
  * Reason codes for workspace_not_ready events.
@@ -245,6 +247,8 @@ export function getUserFunnelState(userId: string): UserFunnelState {
     first_task_completed: null,
     first_team_message_sent: null,
     day2_return_action: null,
+    canvas_opened: null,
+    canvas_first_action: null,
   }
 
   let currentStep = 0
@@ -303,7 +307,9 @@ export function getFunnelSummary(opts?: { raw?: boolean }): {
     first_task_completed: 0,
     first_team_message_sent: 0,
     day2_return_action: 0,
-  }
+      canvas_opened: 0,
+      canvas_first_action: 0,
+    }
 
   const funnelByUser: UserFunnelState[] = []
   let completedUsers = 0
@@ -623,6 +629,8 @@ export function getWeeklyTrends(weekCount = 12): WeeklyTrend[] {
       first_task_completed: 0,
       first_team_message_sent: 0,
       day2_return_action: 0,
+      canvas_opened: 0,
+      canvas_first_action: 0,
     }
 
     let newUsers = 0

--- a/src/canvas-routes.ts
+++ b/src/canvas-routes.ts
@@ -15,6 +15,7 @@
  */
 
 import type { FastifyInstance } from 'fastify'
+import { emitActivationEvent } from './activationEvents.js'
 
 // ── Types ──
 
@@ -54,7 +55,13 @@ export const SENSOR_VALUES = [
 export async function canvasReadRoutes(app: FastifyInstance, deps: CanvasRouteDeps) {
 
   // GET /canvas/states — valid state + sensor values (discovery)
-  app.get('/canvas/states', async () => ({
+  app.get('/canvas/states', async (request) => {
+    const query = request.query as Record<string, unknown>
+    const userId = typeof query.userId === 'string' && query.userId.trim()
+      ? query.userId.trim()
+      : 'anonymous'
+    emitActivationEvent('canvas_opened', userId).catch(() => {})
+    return ({
     states: CANVAS_STATES,
     sensors: SENSOR_VALUES,
     schema: {
@@ -63,7 +70,8 @@ export async function canvasReadRoutes(app: FastifyInstance, deps: CanvasRouteDe
       agentId: 'required — which agent is driving the canvas',
       payload: 'optional — text, media, decision, agents, summary',
     },
-  }))
+  })
+  })
 
   // GET /canvas/slots — current active slots
   app.get('/canvas/slots', async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -11783,6 +11783,11 @@ export async function createServer(): Promise<FastifyInstance> {
     // Also queue for cloud relay — reaches browsers via syncCanvas push_events[]
     queueCanvasPushEvent({ type: 'canvas_takeover', ...takeoverEventData, t: now })
 
+    // Track canvas_first_action activation event (idempotent — fires once per agentId)
+    // task-1773692063045-f3ggtwnbr
+    const { emitActivationEvent: emitAct } = await import('./activationEvents.js')
+    emitAct('canvas_first_action', agentId, { action: 'canvas_takeover' }).catch(() => {})
+
     return { success: true, id, expiresAt: now + duration }
   })
 
@@ -12598,6 +12603,11 @@ export async function createServer(): Promise<FastifyInstance> {
     // Queue for cloud relay — reaches browsers on app.reflectt.ai via syncCanvas push_events[]
     // task-1773690756100
     queueCanvasPushEvent({ ...payload, _event: 'canvas_push' })
+
+    // Track canvas_first_action activation event (idempotent — fires once per agentId)
+    // task-1773692063045-f3ggtwnbr
+    const { emitActivationEvent: emitActPush } = await import('./activationEvents.js')
+    emitActPush('canvas_first_action', agentId, { action: 'canvas_push', pushType: type }).catch(() => {})
 
     return { success: true, type, agentId }
   })


### PR DESCRIPTION
Replaces #1100 (conflict on old tree).

## Changes
- **canvas_opened**: tracked on `GET /canvas/states` with optional `?userId=` param. Idempotent, non-blocking.
- **canvas_first_action**: tracked on first `POST /canvas/takeover` or `POST /canvas/push` per agent. Fires once per agentId.

Both events are sidebar funnel metrics (not forward funnel gates). Baseline = 0% canvas discovery.

## Closes
task-1773692063045-f3ggtwnbr