### PR TITLE
feat(canvas): agent thought endpoint — expressions via presence

### DIFF
--- a/incidents/watchdog-incidents.jsonl
+++ b/incidents/watchdog-incidents.jsonl
@@ -106,3 +106,4 @@
 {"type":"stale_working","at":1772412027791,"agent":"link","taskId":"task-1771849175579-apuqqi0fd","thresholdMs":2700000,"lastUpdateAt":1772409304819,"workingSinceAt":1772409304817}
 {"type":"stale_working","at":1772943984404,"agent":"pixel","taskId":"task-1772899959780-o1gjus1es","thresholdMs":2700000,"lastUpdateAt":1772941235087,"workingSinceAt":1772941090159}
 {"type":"stale_working","at":1772945366960,"agent":"pixel","taskId":"task-1772899959780-o1gjus1es","thresholdMs":2700000,"lastUpdateAt":1772941235087,"workingSinceAt":1772943984415}
+{"type":"trio_general_silence","at":1773620730890,"thresholdMs":3300000,"lastUpdateAt":1773617372590}

--- a/public/docs.md
+++ b/public/docs.md
@@ -1216,6 +1216,7 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | POST | `/webhooks/purge` | Delete old processed payloads. Body: `{ maxAgeDays? }` (default 30). |
 | GET | `/trust-events` | List trust-collapse signals. Params: `agentId?`, `eventType?` (false_assertion\|stale_status_claim\|self_review_violation\|missing_acceptance_criteria_block\|escalation_bypass), `since?` (epoch ms), `limit?`. |
 | POST | `/agents/:agent/waiting` | Set agent to waiting state (blocked on human). Body: `{ reason (required), waitingFor?, taskId?, expiresAt? }`. Heartbeat emits `agent.status="waiting"` + `waitingFor` + `waitingTaskId`. Canvas maps to `state="needs-attention"` (amber pulse). |
+| POST | `/agents/:name/thought` | Agent posts a current thought/expression. Body: `{ text: string }` (max 200 chars). Attached to presence entry and emitted as canvas_expression. Flows to cloud heartbeat → canvas pulse. Client renders with 8s TTL. |
 | DELETE | `/agents/:agent/waiting` | Clear waiting state — agent is unblocked. Canvas state returns to normal. |
 | GET | `/approval-queue` | Unified approval queue — everything needing human decision. Params: `agentId?`, `category?` (review\|agent_action), `includeExpired?` (true), `limit?`. Returns: items[], count, hasExpired. Each item: id, category, title, description, urgency, owner, expiresAt, autoAction, isExpired. |
 | POST | `/approval-queue/:approvalId/decide` | Resolve an approval. Body: `{ decision: "approve"\|"reject"\|"defer", actor (required), comment? }`. Emits canvas_input SSE event. |

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -68,6 +68,7 @@ interface AgentInfo {
   lastSeen?: number
   waitingFor?: string   // populated when status === 'waiting'
   waitingTaskId?: string
+  thought?: string      // agent's current thought/expression — shown on canvas as AI-native content
 }
 
 interface TaskStateEntry {
@@ -721,6 +722,7 @@ function getAgents(): AgentInfo[] {
         waitingFor: p.waiting.waitingFor,
         waitingTaskId: p.waiting.taskId,
       } : {}),
+      ...(p?.thought ? { thought: p.thought } : {}),
     })
   }
 

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -43,6 +43,7 @@ export interface AgentPresence {
   last_active?: number // Last real activity (message, task action, etc.)
   focus?: FocusState
   waiting?: WaitingState  // populated when status === 'waiting'
+  thought?: string        // agent's current thought — expires after 8s TTL on canvas
 }
 
 export interface AgentActivity {

--- a/src/server.ts
+++ b/src/server.ts
@@ -14942,6 +14942,35 @@ export async function createServer(): Promise<FastifyInstance> {
     return { success: true, agent, status: 'idle' }
   })
 
+  // ── Agent thought — brief expression that flows to canvas via presence → pulse ──
+  // POST /agents/:name/thought { text: "..." }
+  // Thought is attached to agent's presence entry and synced to cloud heartbeat.
+  // Canvas renders it as ephemeral expression (8s TTL managed client-side).
+  app.post<{ Params: { name: string } }>('/agents/:name/thought', async (request, reply) => {
+    const name = String(request.params.name || '').trim().toLowerCase()
+    if (!name) return reply.code(400).send({ error: 'agent name is required' })
+    const body = request.body as { text?: string } ?? {}
+    const text = typeof body.text === 'string' ? body.text.trim().slice(0, 200) : ''
+    if (!text) return reply.code(400).send({ error: 'text is required (max 200 chars)' })
+
+    // Attach thought to presence
+    const presence = presenceManager.getPresence(name)
+    if (presence) {
+      presence.thought = text
+      presence.lastUpdate = Date.now()
+    }
+
+    // Also emit as canvas_expression so it appears immediately on pulse
+    eventBus.emit({
+      id: `thought-${Date.now()}-${name}`,
+      type: 'canvas_expression' as const,
+      data: { agent: name, text, kind: 'thought' },
+      timestamp: Date.now(),
+    })
+
+    return { success: true, agent: name, thought: text }
+  })
+
   // ── Bootstrap: dynamic agent config generation ──────────────────────
   app.get<{ Params: { agent: string } }>('/bootstrap/heartbeat/:agent', async (request) => {
     const agent = String(request.params.agent || '').trim().toLowerCase()


### PR DESCRIPTION
@pixel — here's the node-side plumbing for canvas expression.

**New endpoint:** `POST /agents/:name/thought`
**Body:** `{ text: 'thinking about...' }` (max 200 chars)

**How it flows:**
1. Attaches to `AgentPresence.thought`
2. Emits as `canvas_expression` SSE event (immediate)
3. Included in cloud heartbeat as `agents[].thought`
4. Canvas pulse delivers it to frontend

**Not information display.** This is for agents to express genuine thoughts — 'would a person say this out loud in a room?' test. 8s TTL on canvas client-side.

Coordinate with Pixel for the canvas rendering side.