### PR TITLE
feat(ops): add restart drift guard for critical tasks

### DIFF
--- a/src/restart-drift-guard.ts
+++ b/src/restart-drift-guard.ts
@@ -1,0 +1,104 @@
+// restart-drift-guard.ts
+// Runs on server startup to check critical task state and reassert ownership
+// Part of task-1773752635115-pa5gy3srk
+
+import { taskManager } from './tasks.js'
+import { chatManager } from './chat.js'
+
+const CRITICAL_TAG = 'critical'
+
+interface DriftFix {
+  taskId: string
+  field: string
+  oldValue: string | undefined
+  newValue: string
+}
+
+export async function runRestartDriftGuard(): Promise<DriftFix[]> {
+  const fixes: DriftFix[] = []
+  const now = Date.now()
+
+  // Get all tasks with critical tag
+  const criticalTasks = taskManager.listTasks({ 
+    tags: [CRITICAL_TAG] 
+  })
+
+  console.log(`[RestartDrift] Checking ${criticalTasks.length} critical tasks...`)
+
+  for (const task of criticalTasks) {
+    // Skip completed tasks
+    if (task.status === 'done' || task.status === 'cancelled') {
+      continue
+    }
+
+    // Check: assignee drift (task has critical tag but no assignee)
+    if (!task.assignee || task.assignee === 'unassigned') {
+      // Try to assign based on task metadata or default
+      const suggestedAssignee = task.metadata?.suggested_assignee as string | undefined
+      
+      if (suggestedAssignee) {
+        const patched = taskManager.patchTaskMetadata(task.id, {
+          assignee: suggestedAssignee
+        })
+        
+        if (patched) {
+          fixes.push({
+            taskId: task.id,
+            field: 'assignee',
+            oldValue: task.assignee || 'unassigned',
+            newValue: suggestedAssignee
+          })
+          
+          // Post comment about the fix
+          chatManager.sendMessage({
+            channel: 'task-comments',
+            from: 'system',
+            content: `[RestartDrift] ${task.id}: Auto-assigned to @${suggestedAssignee} — assignee was missing on startup.`
+          })
+        }
+      }
+    }
+
+    // Check: blocked flag drift (task should be blocked but isn't)
+    const shouldBeBlocked = task.metadata?.should_be_blocked === true
+    const isBlocked = task.metadata?.blocked === true
+    
+    if (shouldBeBlocked && !isBlocked) {
+      const patched = taskManager.patchTaskMetadata(task.id, {
+        blocked: true,
+        blocked_reason: 'auto-restored by restart-drift-guard'
+      })
+      
+      if (patched) {
+        fixes.push({
+          taskId: task.id,
+          field: 'blocked',
+          oldValue: 'false',
+          newValue: 'true (restored)'
+        })
+        
+        chatManager.sendMessage({
+          channel: 'task-comments',
+          from: 'system',
+          content: `[RestartDrift] ${task.id}: Auto-restored blocked=true — task was marked should_be_blocked but wasn't blocked on startup.`
+        })
+      }
+    }
+  }
+
+  console.log(`[RestartDrift] Applied ${fixes.length} fixes`)
+
+  // Post summary comment if any fixes were applied
+  if (fixes.length > 0) {
+    const fixSummary = fixes.map(f => `- ${f.taskId}: ${f.field} ${f.oldValue} → ${f.newValue}`).join('\n')
+    console.log(`[RestartDrift] Summary:\n${fixSummary}`)
+    
+    chatManager.sendMessage({
+      channel: 'general',
+      from: 'system',
+      content: `[RestartDrift] Startup check complete. Applied ${fixes.length} fixes:\n${fixSummary}`
+    })
+  }
+
+  return fixes
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,6 +57,7 @@ import { eventBus, VALID_EVENT_TYPES } from './events.js'
 import { presenceManager } from './presence.js'
 import type { NotificationType, NotificationPriorityLevel, AckDecision, NotificationStatus } from './agent-notifications.js'
 import { startSweeper, getSweeperStatus, sweepValidatingQueue, flagPrDrift, generateDriftReport } from './executionSweeper.js'
+import { runRestartDriftGuard } from './restart-drift-guard.js'
 import { autoPopulateCloseGate, tryAutoCloseTask, getMergeAttemptLog } from './prAutoMerge.js'
 import { getDuplicateClosureCanonicalRefError } from './duplicateClosureGuard.js'
 import { recordReviewMutation, diffReviewFields, getAuditEntries, loadAuditLedger } from './auditLedger.js'
@@ -16649,6 +16650,11 @@ If your heartbeat shows **no active task** and **no next task**:
     if (count > 0) console.log(`[ActivationFunnel] Loaded ${count} funnel events`)
   }).catch(err => {
     console.error('[ActivationFunnel] Failed to load funnel data:', err)
+  })
+
+  // ── Restart Drift Guard: reassert critical task ownership post-restart ──
+  runRestartDriftGuard().catch(err => {
+    console.error('[RestartDrift] Failed to run drift guard:', err)
   })
 
   // GET /execution-health — sweeper status + current violations


### PR DESCRIPTION
## Summary
- New `src/restart-drift-guard.ts` runs on server startup
- Checks critical tasks for assignee drift (missing assignee)
- Checks for `should_be_blocked` metadata drift  
- Auto-fixes safe fields and posts summary to #general

## Changes
- `src/restart-drift-guard.ts`: New file with drift guard logic
- `src/server.ts`: Import and call `runRestartDriftGuard()` at startup

## Done Criteria
- [x] Startup/restart hook executes drift check
- [x] At least assignee drift auto-corrected for flagged tasks (via `suggested_assignee` metadata)
- [x] Single summary output posted after each restart run
- [ ] Runbook entry added for manual override (can add note in process/)

## Notes
- Uses `suggested_assignee` metadata to know who should own a task
- Uses `should_be_blocked` metadata to restore blocked state
- Both are safe, reversible fields to auto-fix

Task: task-1773752635115-pa5gy3srk
