### PR TITLE
fix(ts): add now parameter to checkForStalls for testability, fix 30s throttle test

### DIFF
--- a/src/stall-detector.ts
+++ b/src/stall-detector.ts
@@ -149,10 +149,10 @@ export function recordAgentResponse(
 /**
  * Check all sessions for stalls and emit events
  */
-export function checkForStalls(config: StallDetectorConfig = DEFAULT_CONFIG): StallEvent[] {
+export function checkForStalls(config: StallDetectorConfig = DEFAULT_CONFIG, now = Date.now()): StallEvent[] {
   if (!config.enabled) return []
   
-  const now = Date.now()
+  // now injected for testability (defaults to Date.now())
   const emitted: StallEvent[] = []
   
   for (const [key, state] of sessionStates) {

--- a/tests/stall-detector.test.ts
+++ b/tests/stall-detector.test.ts
@@ -52,7 +52,7 @@ describe('StallDetector', () => {
     if (emitted1.length !== 0) throw new Error('Should not emit with higher threshold')
     
     // With 3 min threshold, 5 min should trigger
-    const emitted2 = checkForStalls({ thresholds: { newUserStallMinutes: 3, inSessionStallMinutes: 3, setupStallMinutes: 3 }, enabled: true }, now + 5 * 60 * 1000)
+    const emitted2 = checkForStalls({ thresholds: { newUserStallMinutes: 3, inSessionStallMinutes: 3, setupStallMinutes: 3 }, enabled: true }, now + 5 * 60 * 1000 + 31_000)
     if (emitted2.length !== 1) throw new Error('Should emit with lower threshold')
   })
 


### PR DESCRIPTION
Fix stall detector tests:\n- Add `now` parameter to `checkForStalls()` for testability (defaults to Date.now())\n- Fix test: advance clock by 31s to bypass 30-second throttle guard