### PR TITLE
feat(canvas): wire focus, calendar, activity into canvas pulse

### DIFF
--- a/src/canvas-interactive.ts
+++ b/src/canvas-interactive.ts
@@ -490,3 +490,44 @@ export async function canvasInteractiveRoutes(
     })
   })
 }
+
+// ── ApprovalCard command ────────────────────────────────────────────────────────
+export interface ApprovalCardCommand {
+  type: 'render_approval'
+  id: string
+  agentName: string
+  agentColor?: string
+  title: string
+  description: string
+  risk: 'low' | 'medium' | 'high' | 'critical'
+  acceptLabel?: string
+  modifyLabel?: string
+  escalateLabel?: string
+  timeoutSeconds?: number
+  trustDelta?: number
+}
+
+export interface ApprovalDecisionEvent {
+  type: 'approval_decision'
+  id: string
+  decision: 'accept' | 'modify' | 'escalate'
+  modifiedValue?: string
+}
+
+// ── DecisionCard command ────────────────────────────────────────────────────────
+export interface DecisionCardCommand {
+  type: 'render_decision'
+  id: string
+  agentName: string
+  agentColor?: string
+  title: string
+  description?: string
+  options: Array<{ id: string; label: string; description?: string }>
+}
+
+export interface DecisionSelectEvent {
+  type: 'decision_select'
+  id: string
+  optionId: string
+}
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -11526,6 +11526,28 @@ export async function createServer(): Promise<FastifyInstance> {
       } catch { /* non-blocking */ }
     }
 
+    // Cache for focus, calendar, and activity (30s TTL — cheap to compute)
+    interface CanvasMetaCache { focus: ReturnType<typeof getFocus>; upcomingEvents: Array<{ id: string; summary: string; dtstart: number; organizer: string }>; recentActivity: Array<{ ts: number; type: string; subject: unknown }>; age: number }
+    let canvasMetaCache: CanvasMetaCache | null = null
+    const getCanvasMeta = (): CanvasMetaCache => {
+      const now = Date.now()
+      if (canvasMetaCache && (now - canvasMetaCache.age) < 30_000) return canvasMetaCache
+      const focus = getFocus()
+      let upcomingEvents: CanvasMetaCache['upcomingEvents'] = []
+      try {
+        const events = calendarEvents.listEvents({ from: now, to: now + 24 * 60 * 60 * 1000, limit: 5 })
+        upcomingEvents = events.map(e => ({ id: e.id, summary: e.summary, dtstart: e.dtstart, organizer: e.organizer }))
+      } catch { /* skip */ }
+      let recentActivity: CanvasMetaCache['recentActivity'] = []
+      try {
+        const twoHoursAgo = now - 2 * 60 * 60 * 1000
+        const activity = queryActivity({ range: '24h', type: ['task', 'chat'], limit: 10 })
+        recentActivity = activity.events.filter(e => e.ts_ms > twoHoursAgo).slice(0, 5).map(e => ({ ts: e.ts_ms, type: e.type, subject: e.subject }))
+      } catch { /* skip */ }
+      canvasMetaCache = { focus, upcomingEvents, recentActivity, age: now }
+      return canvasMetaCache
+    }
+
     const emitTick = () => {
       if (closed) return
       refreshAvatarCache()
@@ -11585,13 +11607,13 @@ export async function createServer(): Promise<FastifyInstance> {
         if (a.state !== 'floor' && a.state !== 'ambient') { dominantColor = a.color; break }
       }
 
-      // Include focus directive if set
-      const focus = getFocus()
+      // Include focus, calendar, and activity (cached, 30s TTL)
+      const meta = getCanvasMeta()
 
       const tick = {
         t: now,
         agents,
-        team: { rhythm, tension, ambientPulse, dominantColor, focus },
+        team: { rhythm, tension, ambientPulse, dominantColor, ...meta },
       }
 
       try {


### PR DESCRIPTION
Wires focus, calendar, and activity into canvas pulse. Part of canvas-first wiring sprint.\n\n- Focus directive in every canvas pulse tick (30s cached)\n- Calendar: upcoming 24h events surfaced (30s cached)\n- Activity: last 2h of task/chat activity surfaced (30s cached)\n- All in team section of pulse response\n- 30s TTL cache to avoid DB pressure on 2s tick\n\nTask: task-1774021310936-49gkmcwpe