### PR TITLE
fix(canvas): register capability routes in server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11295,11 +11295,14 @@ export async function createServer(): Promise<FastifyInstance> {
   // ── Canvas interactive routes (extracted to src/canvas-interactive.ts) ─────
   // POST /canvas/gaze, POST /canvas/briefing, POST /canvas/victory,
   // POST /canvas/spark, POST /canvas/express, GET /canvas/render/stream
-  const { canvasInteractiveRoutes } = await import("./canvas-interactive.js")
+  const { canvasInteractiveRoutes, registerCapabilityRoutes } = await import("./canvas-interactive.js")
   await app.register(canvasInteractiveRoutes, {
     eventBus,
     canvasStateMap,
   } as any)
+
+  // Register capability routes: GET/POST /canvas/capability
+  registerCapabilityRoutes(app)
 
   // ── Canvas activity stream — SSE with backfill ────────────────────────
   // New viewers get the last 20 canvas events immediately on connect (backfill),


### PR DESCRIPTION
## What
 exports `registerCapabilityRoutes()`, but server.ts wasn't calling it. This fix wires the call after `canvasInteractiveRoutes()`.

## The bug
- `/canvas/capability` endpoints were defined in canvas-interactive.ts but never registered
- Running node returned 404 for both GET and POST /canvas/capability

## The fix
```ts
// server.ts
- const { canvasInteractiveRoutes } = await import("./canvas-interactive.js")
+ const { canvasInteractiveRoutes, registerCapabilityRoutes } = await import("./canvas-interactive.js")

// After canvasInteractiveRoutes() registration:
+ registerCapabilityRoutes(app)
```

## Verification
```
\$ curl http://localhost:4445/canvas/capability
{"capabilities":[{"agentId":"link","agentName":"Link","capabilities":[...]}]

\$ curl -X POST http://localhost:4445/canvas/capability \
  -H 'Content-Type: application/json' \
  -d '{"agentId":"link","agentName":"Link","capabilities":[{"id":"tasks","status":"active"}]}'
{"ok":true,"agentId":"link","count":1}
```

## Test plan
- [x] Build passes
- [x] GET /canvas/capability returns empty array on cold start
- [x] POST /canvas/capability registers agent and broadcasts SSE
- [x] SSE backfill sends capability_setup on connect