### PR TITLE
chore: bump version to 0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Bump for voice pipeline release. v0.1.21 already published — need version bump to publish new code.