### PR TITLE
chore: bump version to 0.1.23 for voice pipeline release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Bumps package.json to v0.1.23 so the Publish to npm workflow publishes the voice_output SSE release (PR #1140). Trigger release workflow after merge.