### PR TITLE
chore: bump to 0.1.24 — voice pipeline release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Bumps version to 0.1.24 so Publish to npm workflow publishes the voice_output SSE pipeline.\n\nIncludes: POST /canvas/speak, voice_queued/voice_output SSE events, GET /audio/:id, capability registration, Kokoro TTS with ElevenLabs fallback.\n\nCI fix (PR #1144) is in main — idle-nudge-regression skipped on PRs, no double-bump in publish.\n\nTrigger: merge → GitHub release workflow publishes to npm.