### PR TITLE
fix(tasks): pull cloud tasks into local SQLite on interval

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -96,6 +96,7 @@ interface CloudState {
   credential: string | null
   heartbeatTimer: ReturnType<typeof setInterval> | null
   taskSyncTimer: ReturnType<typeof setInterval> | null
+  taskCloudPullTimer: ReturnType<typeof setInterval> | null
   chatSyncTimer: ReturnType<typeof setInterval> | null
   canvasSyncTimer: ReturnType<typeof setInterval> | null
   approvalSyncTimer: ReturnType<typeof setInterval> | null
@@ -228,6 +229,7 @@ let state: CloudState = {
   credential: null,
   heartbeatTimer: null,
   taskSyncTimer: null,
+  taskCloudPullTimer: null,
   chatSyncTimer: null,
   canvasSyncTimer: null,
   approvalSyncTimer: null,
@@ -424,6 +426,19 @@ export async function startCloudIntegration(): Promise<void> {
   state.taskSyncTimer = setInterval(() => {
     syncTasks().catch(() => {})
   }, config.taskSyncIntervalMs)
+
+  // Pull tasks FROM cloud (Supabase) into local SQLite on a fixed interval.
+  // This catches tasks created via the API while the node was offline or
+  // while local SQLite was non-empty (which skips the startup hydration).
+  const TASK_CLOUD_PULL_INTERVAL_MS = Number(process.env.REFLECTT_TASK_CLOUD_PULL_MS) || 30_000
+  state.taskCloudPullTimer = setInterval(async () => {
+    try {
+      const r = await taskManager.syncFromCloud()
+      if (r.added > 0 || r.updated > 0) {
+        console.log(`[cloud] taskCloudPull: +${r.added} added, ~${r.updated} updated`)
+      }
+    } catch {}
+  }, TASK_CLOUD_PULL_INTERVAL_MS)
 
   // Chat sync — event-driven with adaptive polling fallback
   // When active: 5s poll. When idle: 60s poll. Events always trigger immediate sync.
@@ -649,6 +664,10 @@ export function stopCloudIntegration(): void {
   if (state.taskSyncTimer) {
     clearInterval(state.taskSyncTimer)
     state.taskSyncTimer = null
+  }
+  if (state.taskCloudPullTimer) {
+    clearInterval(state.taskCloudPullTimer)
+    state.taskCloudPullTimer = null
   }
   if (state.chatSyncTimer) {
     clearInterval(state.chatSyncTimer)

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -446,6 +446,42 @@ class TaskManager {
     }
   }
 
+  /**
+   * Periodically pull tasks from cloud (Supabase) and merge into local SQLite.
+   * This ensures the node sees tasks created via the API, not just via local mutations.
+   * Called on a timer from cloud.ts alongside the existing syncTasks() push.
+   */
+  async syncFromCloud(): Promise<{ added: number; updated: number; errors: number }> {
+    if (!this.taskStateAdapter) return { added: 0, updated: 0, errors: 0 }
+
+    const result = { added: 0, updated: 0, errors: 0 }
+    try {
+      const remoteTasks = await this.taskStateAdapter.pullTasks()
+      for (const remoteTask of remoteTasks) {
+        try {
+          const localTask = queryTask(remoteTask.id)
+          if (!localTask) {
+            // New task from cloud — insert
+            this.writeTaskToDb(remoteTask)
+            result.added++
+          } else if ((remoteTask.updatedAt ?? 0) > (localTask.updatedAt ?? 0)) {
+            // Cloud version is newer — update local
+            this.writeTaskToDb(remoteTask)
+            result.updated++
+          }
+          // else: local is current or newer — skip
+        } catch (err) {
+          console.error(`[Tasks] syncFromCloud: error processing task ${remoteTask.id}:`, err)
+          result.errors++
+        }
+      }
+    } catch (err) {
+      console.error('[Tasks] syncFromCloud: pullTasks failed:', err)
+      result.errors++
+    }
+    return result
+  }
+
   private normalizeRecurringTask(recurring: RecurringTask): RecurringTask {
     return {
       ...recurring,


### PR DESCRIPTION
## Root cause
The node only pushed local task changes → cloud. It NEVER pulled cloud changes → local.

Cloud → local sync only happened on startup, and ONLY if SQLite was empty (`count === 0`).
If the node had tasks in SQLite (normal case), it would not pull new/updated tasks from Supabase.

This caused 2h+ task staleness when tasks were created via the API while the node was running.

## Fix

### tasks.ts — `syncFromCloud()` method
- Pulls all tasks from Supabase via `taskStateAdapter.pullTasks()`
- For each remote task: inserts if not exists locally, updates if cloud `updatedAt` is newer
- Returns counts: `{ added, updated, errors }`

### cloud.ts — periodic pull timer
- New `state.taskCloudPullTimer` interval (default: 30s, configurable via `REFLECTT_TASK_CLOUD_PULL_MS`)
- Logs new/updated task counts when sync happens
- Cleanup in `stopCloudIntegration()`

## Behavior change
- Tasks created via API now appear on the node within 30s (was: only after node restart with empty SQLite)
- No impact on existing push sync (local → cloud still works as before)

task-1774104000000