### PR TITLE
fix(canvas): forward canvas_render events in SSE stream

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11635,7 +11635,7 @@ export async function createServer(): Promise<FastifyInstance> {
     const listenerId = `pulse-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     eventBus.on(listenerId, (event) => {
       if (closed) return
-      if (event.type !== 'canvas_burst' && event.type !== 'canvas_spark' && event.type !== 'canvas_milestone' && event.type !== 'canvas_expression' && event.type !== 'canvas_message' && event.type !== 'canvas_push' && event.type !== 'canvas_artifact' && event.type !== 'canvas_takeover') return
+      if (event.type !== 'canvas_burst' && event.type !== 'canvas_spark' && event.type !== 'canvas_milestone' && event.type !== 'canvas_expression' && event.type !== 'canvas_message' && event.type !== 'canvas_push' && event.type !== 'canvas_artifact' && event.type !== 'canvas_takeover' && event.type !== 'canvas_render') return
       try {
         reply.raw.write(`event: ${event.type}\ndata: ${JSON.stringify({ ...event.data as object, t: event.timestamp })}\n\n`)
       } catch { closed = true }


### PR DESCRIPTION
emitSyntheticState emits canvas_render on orb state changes, but canvas pulse SSE listener was not forwarding canvas_render. Result: orb state changes reached canvasStateMap but never reached frontend via SSE.\n\nAdded canvas_render to SSE forwarding filter.\n\nTask: audit evidence SSE emissions