### PR TITLE
chore: bump version to 0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump for npm publish. Releases v0.1.28 containing lane-boundary fix #1194.