### PR TITLE
feat(cloud): inject capability context into heartbeat response

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1998,6 +1998,22 @@ const CAPABILITY_CONTEXT_REFRESH_MS = Number(process.env.REFLECTT_CAPABILITY_CON
 const CAPABILITY_CONTEXT_FILE = join(REFLECTT_HOME, 'capability-context.md')
 let lastCapabilityContextFetchAt = 0
 
+/**
+ * Read the current capability context written by syncCapabilityContext().
+ * Returns the content (including the ## Team capabilities header) or null.
+ * Exported so server.ts can include it in the heartbeat response — the
+ * practical injection point for Claude Code agents in the packaged runtime.
+ */
+export function readCapabilityContext(): string | null {
+  try {
+    if (!existsSync(CAPABILITY_CONTEXT_FILE)) return null
+    const content = readFileSync(CAPABILITY_CONTEXT_FILE, 'utf-8').trim()
+    return content || null
+  } catch {
+    return null
+  }
+}
+
 async function syncCapabilityContext(): Promise<void> {
   if (!state.hostId || !config || !state.running) return
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -178,7 +178,7 @@ import { createRun, getRun, subscribeRun, approveRun, rejectRun, executeGithubIs
 import { validateIntent as macOSValidateIntent, isKillSwitchEngaged, engageKillSwitch, resetKillSwitch } from './macos-accessibility.js'
 import { calendarManager, type BlockType, type CreateBlockInput, type UpdateBlockInput } from './calendar.js'
 import { calendarEvents, type CreateEventInput, type UpdateEventInput, type AttendeeStatus } from './calendar-events.js'
-import { requestImmediateCanvasSync, queueCanvasPushEvent } from './cloud.js'
+import { requestImmediateCanvasSync, queueCanvasPushEvent, readCapabilityContext } from './cloud.js'
 import { startReminderEngine, stopReminderEngine, getReminderEngineStats } from './calendar-reminder-engine.js'
 import { startDeployMonitor, stopDeployMonitor } from './deploy-monitor.js'
 import { exportICS, exportEventICS, importICS, parseICS } from './calendar-ical.js'
@@ -13921,6 +13921,10 @@ export async function createServer(): Promise<FastifyInstance> {
       }
     } catch { /* agent-runs not available */ }
 
+    // Capability context — written by syncCapabilityContext() in cloud.ts.
+    // Included in heartbeat so Claude Code agents receive it on every check-in.
+    const capabilityContext = readCapabilityContext()
+
     return {
       agent, ts: Date.now(),
       active: slim(activeTask), next: pauseStatus.paused ? null : slim(nextTask),
@@ -13932,6 +13936,7 @@ export async function createServer(): Promise<FastifyInstance> {
       ...(pauseStatus.paused ? { paused: true, pauseMessage: pauseStatus.message, resumesAt: pauseStatus.entry?.pausedUntil ?? null } : {}),
       ...(bootMemories.length > 0 ? { memories: bootMemories } : {}),
       ...(activeRun ? { run: activeRun } : {}),
+      ...(capabilityContext ? { capabilityContext } : {}),
       ...(() => {
         const p = presenceManager.getAllPresence().find(p => p.agent === agent)
         return p?.waiting ? { waiting: p.waiting } : {}


### PR DESCRIPTION
## Summary

- Exports `readCapabilityContext()` from `src/cloud.ts` — reads `$REFLECTT_HOME/capability-context.md`, the file written by `syncCapabilityContext()` on every 5-min sync cycle
- Imports and calls it in the `/heartbeat/:agent` handler in `src/server.ts`  
- Adds `capabilityContext` field to the heartbeat response when content is present (omitted when null — no-op for nodes without cloud connected)

## Why

The previous injection path (`tools/agent/load_agent/implementation.ts`) was never reachable in the shipped npm package:
- `tools/` is excluded from tsconfig `include` (only `src/` compiles)
- `tools/` is excluded from npm package `files`
- `load_agent` was not registered in the node's MCP server
- No code in `src/` called it

The file write was live; the read was dead.

## Fix

The heartbeat (`GET /heartbeat/:agent`) is the existing, proven call-site that every Claude Code agent hits on each session check-in. Including `capabilityContext` here delivers it inline — no new tools, no new endpoints, no agent-side config required.

## Proof path

Once deployed, `GET /heartbeat/link` (or any agent) will include `capabilityContext` in the response when the node has a connected team with ready capabilities. That's the raw artifact for the #2204 proof gate.

## Gate

#2204 (`injectionStatus: 'active'` flip) remains held until @link posts a raw heartbeat response showing `capabilityContext` with the Supabase guidance block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)