### PR TITLE
release: v0.1.31 — capability context heartbeat injection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,3 +6,20 @@
 - `verifyTaskExists(taskId)` — checks task exists before SLA alert emission. Prevents ghost alerts for deleted tasks.
 
 Both are called in the SLA pipeline (`health.ts` + `boardHealthWorker.ts`) before any alert is sent.
+
+## Capability Context Injection (2026-04-09)
+
+### New: `syncCapabilityContext()` in `cloud.ts`
+
+Fetches `GET /api/hosts/:hostId/capabilities/context` from the cloud at startup and every 5 minutes. Writes the enriched `systemPromptHint` (which includes skill pack instructions for ready providers) to `$REFLECTT_HOME/capability-context.md`.
+
+- Called immediately after cloud registration, then piggybacked on the heartbeat timer
+- Rate-limited: max one fetch per `REFLECTT_CAPABILITY_CONTEXT_REFRESH_MS` (default: 5 minutes)
+- Fails silently — missing context degrades gracefully, never blocks agent startup
+- Clears the file when no capabilities are enabled
+
+### Updated: `load_agent` tool
+
+`tools/agent/load_agent/implementation.ts` now appends `capability-context.md` to every agent's system prompt after loading `prompt.md`. Agents automatically receive provider-native guidance (RLS rules, SDK patterns, anti-patterns) for any connected provider with a skill pack.
+
+`injectionStatus` in the capability API will flip from `'pending'` → `'active'` once this PR is merged and deployed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.24",
+  "version": "0.1.31",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -23,7 +23,7 @@ import { getDb } from './db.js'
 import { getUsageSummary, getUsageByAgent, getUsageByModel, listCaps, checkCaps, getRoutingSuggestions, getCostForTaskId } from './usage-tracking.js'
 import { listReflections } from './reflections.js'
 import { listInsights } from './insights.js'
-import { readFileSync, existsSync, watch, type FSWatcher } from 'fs'
+import { readFileSync, writeFileSync, existsSync, watch, type FSWatcher } from 'fs'
 import { join } from 'path'
 import { REFLECTT_HOME } from './config.js'
 import { getRequestMetrics } from './request-tracker.js'
@@ -418,9 +418,14 @@ export async function startCloudIntegration(): Promise<void> {
   // Immediate first heartbeat
   sendHeartbeat().catch(() => {})
 
+  // Fetch capability context at startup and refresh periodically.
+  // Writes systemPromptHint to capability-context.md for agent injection.
+  syncCapabilityContext().catch(() => {})
+
   state.heartbeatTimer = setInterval(() => {
     sendHeartbeat().catch(() => {})
     pollAndProcessCommands().catch(() => {}) // Piggyback on heartbeat tick
+    syncCapabilityContext().catch(() => {})  // Refresh capability context (rate-limited internally)
   }, config.heartbeatIntervalMs)
 
   state.taskSyncTimer = setInterval(() => {
@@ -1977,6 +1982,48 @@ interface PendingCommand {
   type: string
   payload: Record<string, unknown>
   status: string
+}
+
+// ─── Capability context injection ─────────────────────────────────────────────
+
+/**
+ * Fetch capability context from cloud and write systemPromptHint to
+ * $REFLECTT_HOME/capability-context.md so load_agent can append it to
+ * every agent system prompt.
+ *
+ * Called at startup and refreshed every CAPABILITY_CONTEXT_REFRESH_MS.
+ * Fails silently — missing capability context degrades gracefully.
+ */
+const CAPABILITY_CONTEXT_REFRESH_MS = Number(process.env.REFLECTT_CAPABILITY_CONTEXT_REFRESH_MS) || 5 * 60_000
+const CAPABILITY_CONTEXT_FILE = join(REFLECTT_HOME, 'capability-context.md')
+let lastCapabilityContextFetchAt = 0
+
+async function syncCapabilityContext(): Promise<void> {
+  if (!state.hostId || !config || !state.running) return
+
+  const now = Date.now()
+  if (now - lastCapabilityContextFetchAt < CAPABILITY_CONTEXT_REFRESH_MS) return
+  lastCapabilityContextFetchAt = now
+
+  try {
+    const result = await cloudGet<{ systemPromptHint: string }>(`/api/hosts/${state.hostId}/capabilities/context`)
+    if (!result.success || !result.data?.systemPromptHint) return
+
+    const hint = result.data.systemPromptHint.trim()
+    if (!hint || hint === 'No capabilities are currently enabled for this team.') {
+      // No capabilities yet — remove stale file so agents don't get outdated context
+      if (existsSync(CAPABILITY_CONTEXT_FILE)) {
+        writeFileSync(CAPABILITY_CONTEXT_FILE, '')
+      }
+      return
+    }
+
+    writeFileSync(CAPABILITY_CONTEXT_FILE, `## Team capabilities\n\n${hint}\n`)
+    console.log(`[cloud] capability context updated (${hint.length} chars)`)
+  } catch (err: any) {
+    // Non-fatal: agents run without capability context if the fetch fails
+    console.warn(`[cloud] capability context fetch failed: ${err?.message || 'unknown error'}`)
+  }
 }
 
 async function pollAndProcessCommands(): Promise<void> {

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1998,6 +1998,22 @@ const CAPABILITY_CONTEXT_REFRESH_MS = Number(process.env.REFLECTT_CAPABILITY_CON
 const CAPABILITY_CONTEXT_FILE = join(REFLECTT_HOME, 'capability-context.md')
 let lastCapabilityContextFetchAt = 0
 
+/**
+ * Read the current capability context written by syncCapabilityContext().
+ * Returns the content (including the ## Team capabilities header) or null.
+ * Exported so server.ts can include it in the heartbeat response — the
+ * practical injection point for Claude Code agents in the packaged runtime.
+ */
+export function readCapabilityContext(): string | null {
+  try {
+    if (!existsSync(CAPABILITY_CONTEXT_FILE)) return null
+    const content = readFileSync(CAPABILITY_CONTEXT_FILE, 'utf-8').trim()
+    return content || null
+  } catch {
+    return null
+  }
+}
+
 async function syncCapabilityContext(): Promise<void> {
   if (!state.hostId || !config || !state.running) return
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -178,7 +178,7 @@ import { createRun, getRun, subscribeRun, approveRun, rejectRun, executeGithubIs
 import { validateIntent as macOSValidateIntent, isKillSwitchEngaged, engageKillSwitch, resetKillSwitch } from './macos-accessibility.js'
 import { calendarManager, type BlockType, type CreateBlockInput, type UpdateBlockInput } from './calendar.js'
 import { calendarEvents, type CreateEventInput, type UpdateEventInput, type AttendeeStatus } from './calendar-events.js'
-import { requestImmediateCanvasSync, queueCanvasPushEvent } from './cloud.js'
+import { requestImmediateCanvasSync, queueCanvasPushEvent, readCapabilityContext } from './cloud.js'
 import { startReminderEngine, stopReminderEngine, getReminderEngineStats } from './calendar-reminder-engine.js'
 import { startDeployMonitor, stopDeployMonitor } from './deploy-monitor.js'
 import { exportICS, exportEventICS, importICS, parseICS } from './calendar-ical.js'
@@ -13921,6 +13921,10 @@ export async function createServer(): Promise<FastifyInstance> {
       }
     } catch { /* agent-runs not available */ }
 
+    // Capability context — written by syncCapabilityContext() in cloud.ts.
+    // Included in heartbeat so Claude Code agents receive it on every check-in.
+    const capabilityContext = readCapabilityContext()
+
     return {
       agent, ts: Date.now(),
       active: slim(activeTask), next: pauseStatus.paused ? null : slim(nextTask),
@@ -13932,6 +13936,7 @@ export async function createServer(): Promise<FastifyInstance> {
       ...(pauseStatus.paused ? { paused: true, pauseMessage: pauseStatus.message, resumesAt: pauseStatus.entry?.pausedUntil ?? null } : {}),
       ...(bootMemories.length > 0 ? { memories: bootMemories } : {}),
       ...(activeRun ? { run: activeRun } : {}),
+      ...(capabilityContext ? { capabilityContext } : {}),
       ...(() => {
         const p = presenceManager.getAllPresence().find(p => p.agent === agent)
         return p?.waiting ? { waiting: p.waiting } : {}

--- a/tools/agent/load_agent/implementation.ts
+++ b/tools/agent/load_agent/implementation.ts
@@ -1,4 +1,24 @@
 import { type ToolContext } from '@/lib/tools/helpers';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Read the capability context file written by syncCapabilityContext() in cloud.ts.
+ * Returns the content (including the ## Team capabilities header) or null if not present.
+ * This file is refreshed every 5 minutes and contains the enriched systemPromptHint
+ * with skill pack instructions for any ready provider (Supabase, GitHub, etc.).
+ */
+function readCapabilityContext(): string | null {
+  try {
+    const reflecttHome = process.env.REFLECTT_HOME || join(process.env.HOME || '~', '.reflectt');
+    const filePath = join(reflecttHome, 'capability-context.md');
+    if (!existsSync(filePath)) return null;
+    const content = readFileSync(filePath, 'utf-8').trim();
+    return content || null;
+  } catch {
+    return null;
+  }
+}
 
 interface LoadAgentInput {
   agent_name: string;
@@ -77,6 +97,14 @@ async function searchAgentInSpace(
             if (systemPrompt) {
               agent.system_prompt = systemPrompt;
             }
+
+            // Append capability context (written by cloud.ts syncCapabilityContext).
+            // Contains systemPromptHint with skill pack instructions for ready providers.
+            const capabilityContext = readCapabilityContext();
+            if (capabilityContext) {
+              agent.system_prompt = (agent.system_prompt || '').trimEnd() + '\n\n' + capabilityContext;
+            }
+
             return agent;
           }
         } catch {


### PR DESCRIPTION
## Changes

- **feat(cloud): inject capability context into heartbeat response** (#1203)
  - Exports `readCapabilityContext()` from `src/cloud.ts`
  - Adds `capabilityContext` field to `/heartbeat/:agent` response
  - Proof confirmed: `GET /heartbeat/link` returns Email/SMS/Stripe block
- **chore: bump version to 0.1.31**

## Proof

Raw heartbeat proof posted by @link in #general:
```
$ curl -s http://localhost:4445/heartbeat/link | jq '.capabilityContext'
"## Team capabilities\n\nThis team has the following capabilities enabled:\n  - Email: ...\n  - SMS: ...\n  - Stripe: ..."
```

Full capability → knowledge → runtime injection loop confirmed end-to-end. Unblocks #2204 in reflectt-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)