### PR TITLE
chore: bump version to 0.1.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflectt-node",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Coordinate your AI agent team. Shared tasks, memory, reflections, and presence. Self-host for free.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to 0.1.33 to publish fixes from main:

- fix(node): agents pick up todo tasks when idle (cherry-picked from develop #1206)
- docs: browser/managed session routes documented (route-docs contract fix)

## Test plan
- [ ] CI green
- [ ] After merge, publish to npm and staging restarts pick up the new version
- [ ] Re-run team-wakeup E2E to verify teammate task pickup works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)