### PR TITLE
fix: make health.ts mention-detection regex dynamic

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -1628,7 +1628,8 @@ class TeamHealthMonitor {
    */
   private extractMentionedTrioAgents(content: string): Array<typeof this.trioAgents[number]> {
     if (!content) return []
-    const matches = content.match(/@(kai|link|pixel)\b/gi) || []
+    const agentPattern = this.trioAgents.length > 0 ? this.trioAgents.join('|') : 'kai|link|pixel'
+    const matches = content.match(new RegExp(`@(${agentPattern})\\b`, 'gi')) || []
     const uniq = new Set<typeof this.trioAgents[number]>()
     for (const m of matches) {
       const name = m.replace('@', '').toLowerCase() as typeof this.trioAgents[number]
@@ -1764,7 +1765,8 @@ class TeamHealthMonitor {
       const channel = (m.channel || 'general')
       const content = typeof m.content === 'string' ? m.content : ''
       if (channel !== 'general' || from !== 'ryan') return false
-      return /@(kai|link|pixel)\b/i.test(content)
+      const agentPat = this.trioAgents.length > 0 ? this.trioAgents.join('|') : 'kai|link|pixel'
+      return new RegExp(`@(${agentPat})\\b`, 'i').test(content)
     })
 
     const trioSet = new Set(this.trioAgents)


### PR DESCRIPTION
## Summary
- Two regex patterns in `health.ts` still matched hardcoded `/@(kai|link|pixel)/`
- Both now build the pattern dynamically from `this.trioAgents` (which is already a dynamic getter from PR #1215)
- Fallback to `kai|link|pixel` if trioAgents is empty (safe for internal team)

## Changes
- `extractMentionedTrioAgents`: dynamic regex from `this.trioAgents`  
- mention-rescue filter: same dynamic regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)