### PR TITLE
feat: browser CHROME_PATH fix + web search capability

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -1262,6 +1262,12 @@ Persistent key-value store with tags, namespaces, and expiration. Survives node 
 
 Events are **append-only** — no updates, no deletes.
 
+### Web Search
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/search` | Search the web. Body: `{ query (required), limit? (default 10, max 20) }`. Returns `{ results: [{title, url, snippet, date?}], provider, query }`. Uses first configured key: `SERPER_API_KEY`, `BRAVE_SEARCH_API_KEY`, or `TAVILY_API_KEY`. 503 if no key configured. |
+
 ### Browser Capability
 
 | Method | Path | Description |

--- a/src/capabilities/browser.ts
+++ b/src/capabilities/browser.ts
@@ -8,6 +8,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -103,6 +104,29 @@ export function getBrowserConfig(): BrowserConfig {
   return { ...config }
 }
 
+/**
+ * Resolve a Chrome/Chromium executable path for Stagehand's LOCAL env.
+ * Priority: CHROME_PATH env → playwright-core bundled chromium.
+ * Returns undefined if nothing is found (Stagehand will throw a clear error).
+ */
+function resolveChromiumPath(): string | undefined {
+  if (process.env.CHROME_PATH && existsSync(process.env.CHROME_PATH)) {
+    return process.env.CHROME_PATH
+  }
+  try {
+    // playwright-core ships a bundled Chromium on all platforms.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { chromium } = require('playwright-core') as {
+      chromium: { executablePath(): string }
+    }
+    const p = chromium.executablePath()
+    if (p && existsSync(p)) return p
+  } catch {
+    // playwright-core not installed — fall through
+  }
+  return undefined
+}
+
 function touchSession(session: BrowserSession): void {
   session.lastActivityAt = Date.now()
   if (session._idleTimer) clearTimeout(session._idleTimer)
@@ -140,6 +164,7 @@ export async function createSession(opts: CreateSessionOpts): Promise<BrowserSes
     disablePino: true,
     disableAPI: true,
     localBrowserLaunchOptions: {
+      executablePath: resolveChromiumPath(),
       headless: opts.headless ?? config.headless,
       viewport: opts.viewport ?? config.viewport,
     },

--- a/src/capabilities/search.ts
+++ b/src/capabilities/search.ts
@@ -1,0 +1,142 @@
+/**
+ * Search capability — web search via Serper, Brave, or Tavily.
+ *
+ * The node calls the search provider directly using an API key from the
+ * local environment. Provider priority: Serper → Brave → Tavily.
+ *
+ * @module capabilities/search
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SearchResult {
+  title: string
+  url: string
+  snippet: string
+  /** ISO date string when available */
+  date?: string
+}
+
+export interface SearchResponse {
+  results: SearchResult[]
+  /** Which provider was used */
+  provider: 'serper' | 'brave' | 'tavily'
+  query: string
+}
+
+// ---------------------------------------------------------------------------
+// Provider detection
+// ---------------------------------------------------------------------------
+
+export type SearchProvider = 'serper' | 'brave' | 'tavily' | null
+
+/** Return the first configured search provider, or null if none available. */
+export function getSearchProvider(): SearchProvider {
+  if (process.env.SERPER_API_KEY) return 'serper'
+  if (process.env.BRAVE_SEARCH_API_KEY) return 'brave'
+  if (process.env.TAVILY_API_KEY) return 'tavily'
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Search implementation
+// ---------------------------------------------------------------------------
+
+async function searchSerper(query: string, limit: number): Promise<SearchResult[]> {
+  const res = await fetch('https://google.serper.dev/search', {
+    method: 'POST',
+    headers: {
+      'X-API-KEY': process.env.SERPER_API_KEY!,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ q: query, num: limit }),
+  })
+  if (!res.ok) throw new Error(`Serper error ${res.status}: ${await res.text()}`)
+  const data = await res.json() as {
+    organic?: Array<{ title: string; link: string; snippet: string; date?: string }>
+  }
+  return (data.organic ?? []).slice(0, limit).map((r) => ({
+    title: r.title,
+    url: r.link,
+    snippet: r.snippet,
+    date: r.date,
+  }))
+}
+
+async function searchBrave(query: string, limit: number): Promise<SearchResult[]> {
+  const url = new URL('https://api.search.brave.com/res/v1/web/search')
+  url.searchParams.set('q', query)
+  url.searchParams.set('count', String(Math.min(limit, 20)))
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json',
+      'Accept-Encoding': 'gzip',
+      'X-Subscription-Token': process.env.BRAVE_SEARCH_API_KEY!,
+    },
+  })
+  if (!res.ok) throw new Error(`Brave error ${res.status}: ${await res.text()}`)
+  const data = await res.json() as {
+    web?: { results?: Array<{ title: string; url: string; description: string; page_age?: string }> }
+  }
+  return (data.web?.results ?? []).slice(0, limit).map((r) => ({
+    title: r.title,
+    url: r.url,
+    snippet: r.description,
+    date: r.page_age,
+  }))
+}
+
+async function searchTavily(query: string, limit: number): Promise<SearchResult[]> {
+  const res = await fetch('https://api.tavily.com/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: process.env.TAVILY_API_KEY,
+      query,
+      max_results: limit,
+      search_depth: 'basic',
+    }),
+  })
+  if (!res.ok) throw new Error(`Tavily error ${res.status}: ${await res.text()}`)
+  const data = await res.json() as {
+    results?: Array<{ title: string; url: string; content: string; published_date?: string }>
+  }
+  return (data.results ?? []).slice(0, limit).map((r) => ({
+    title: r.title,
+    url: r.url,
+    snippet: r.content,
+    date: r.published_date,
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a web search using the first available configured provider.
+ * Throws if no provider is configured.
+ */
+export async function search(query: string, limit = 10): Promise<SearchResponse> {
+  const provider = getSearchProvider()
+  if (!provider) {
+    throw new Error(
+      'No search API key configured. Set SERPER_API_KEY, BRAVE_SEARCH_API_KEY, or TAVILY_API_KEY.',
+    )
+  }
+
+  const clampedLimit = Math.min(Math.max(1, limit), 20)
+
+  let results: SearchResult[]
+  if (provider === 'serper') {
+    results = await searchSerper(query, clampedLimit)
+  } else if (provider === 'brave') {
+    results = await searchBrave(query, clampedLimit)
+  } else {
+    results = await searchTavily(query, clampedLimit)
+  }
+
+  return { results, provider, query }
+}

--- a/src/capability-readiness.ts
+++ b/src/capability-readiness.ts
@@ -239,6 +239,35 @@ export function checkModelsReadiness(opts: { samplingProviders?: string[] } = {}
   }
 }
 
+// ── Search ────────────────────────────────────────────────────────────────────
+
+function checkSearchReadiness(): CapabilityReadiness {
+  const deps: DependencyCheck[] = []
+
+  const hasSerper = !!(process.env.SERPER_API_KEY)
+  const hasBrave = !!(process.env.BRAVE_SEARCH_API_KEY)
+  const hasTavily = !!(process.env.TAVILY_API_KEY)
+  const hasAny = hasSerper || hasBrave || hasTavily
+
+  const activeProvider = hasSerper ? 'SERPER_API_KEY' : hasBrave ? 'BRAVE_SEARCH_API_KEY' : hasTavily ? 'TAVILY_API_KEY' : null
+  deps.push({
+    name: 'search_api_key',
+    status: hasAny ? 'ok' : 'missing',
+    detail: hasAny
+      ? `${activeProvider} set`
+      : 'Set SERPER_API_KEY, BRAVE_SEARCH_API_KEY, or TAVILY_API_KEY to enable web search',
+  })
+
+  return {
+    capability: 'search',
+    status: hasAny ? 'ready' : 'not_ready',
+    last_success_at: null,
+    last_error: hasAny ? null : 'No search API key configured',
+    dependencies: deps,
+    hint: hasAny ? null : 'Set SERPER_API_KEY, BRAVE_SEARCH_API_KEY, or TAVILY_API_KEY on this node to enable web search.',
+  }
+}
+
 // ── Main readiness check ──────────────────────────────────────────────────────
 
 export function getCapabilityReadiness(opts: {
@@ -249,6 +278,7 @@ export function getCapabilityReadiness(opts: {
 }): ReadinessReport {
   const capabilities = [
     checkBrowserReadiness(),
+    checkSearchReadiness(),
     checkEmailReadiness(opts.cloudConnected, opts.cloudUrl, opts.webhooks),
     checkSmsReadiness(opts.cloudConnected, opts.cloudUrl, opts.webhooks),
     checkCalendarReadiness(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -19089,6 +19089,29 @@ If your heartbeat shows **no active task** and **no next task**:
     }, reply)
   })
 
+  // ── Web Search (node-managed, direct API call) ─────────────────────────
+  // Agents call POST /search to query the web. The node calls Serper, Brave,
+  // or Tavily directly using a locally-configured API key (whichever is set).
+
+  app.post('/search', async (request, reply) => {
+    const body = request.body as Record<string, unknown>
+    const query = typeof body.query === 'string' ? body.query.trim() : ''
+    if (!query) return reply.code(400).send({ error: 'query is required' })
+    const limit = typeof body.limit === 'number' ? body.limit : 10
+
+    try {
+      const { search: webSearch } = await import('./capabilities/search.js')
+      const result = await webSearch(query, limit)
+      return result
+    } catch (err: any) {
+      const msg: string = err?.message ?? 'search failed'
+      if (msg.includes('No search API key')) {
+        return reply.code(503).send({ error: msg, hint: 'Set SERPER_API_KEY, BRAVE_SEARCH_API_KEY, or TAVILY_API_KEY on this node.' })
+      }
+      return reply.code(502).send({ error: msg })
+    }
+  })
+
   // ── Managed Browser Sessions (cloud relay via host credential) ─────────
   // Proxies to the cloud API's managed browser session stack using host auth.
   // Allows agents to use cloud-stored auth profiles (e.g., @ReflecttAI X session)

--- a/tests/capability-readiness.test.ts
+++ b/tests/capability-readiness.test.ts
@@ -9,15 +9,16 @@ const baseOpts = {
 }
 
 describe('capability readiness contract', () => {
-  it('returns report with all 5 capabilities', () => {
+  it('returns report with all 6 capabilities', () => {
     const report = getCapabilityReadiness(baseOpts)
     const names = report.capabilities.map(c => c.capability)
     expect(names).toContain('browser')
+    expect(names).toContain('search')
     expect(names).toContain('email')
     expect(names).toContain('sms')
     expect(names).toContain('calendar')
     expect(names).toContain('models')
-    expect(report.capabilities).toHaveLength(5)
+    expect(report.capabilities).toHaveLength(6)
   })
 
   it('report has checked_at timestamp', () => {
@@ -105,8 +106,9 @@ describe('capability readiness contract', () => {
       { provider: 'twilio', active: true },
     ]
     const report = getCapabilityReadiness({ cloudConnected: true, cloudUrl: 'https://app.reflectt.ai', webhooks, samplingProviders: ['claude'] })
-    const nonBrowser = report.capabilities.filter(c => c.capability !== 'browser')
-    for (const cap of nonBrowser) {
+    // browser and search are node-managed — their readiness depends on local env vars not set in tests
+    const nonNodeManaged = report.capabilities.filter(c => c.capability !== 'browser' && c.capability !== 'search')
+    for (const cap of nonNodeManaged) {
       expect(cap.status, `${cap.capability} should be ready`).toBe('ready')
     }
   })


### PR DESCRIPTION
## Summary
- **browser.ts**: `resolveChromiumPath()` detects playwright's bundled Chromium so Stagehand 3.x works on managed hosts without `CHROME_PATH` env var
- **search.ts**: new web search capability module — Serper → Brave → Tavily priority, direct node-side API calls
- **capability-readiness.ts**: `checkSearchReadiness()` reports search key status through `/capabilities/readiness`
- **server.ts**: `POST /search { query, limit }` endpoint — returns `{ results, provider, query }`

## Browser fix
Stagehand 3.x requires `executablePath` in `localBrowserLaunchOptions`. Previously this was missing, causing `CHROME_PATH must be set` errors on managed hosts. The fix auto-detects playwright's bundled Chromium (which is always installed on managed nodes).

## Search
Agents can now `POST /search { "query": "...", "limit": 10 }` and get back `{ results: [{title, url, snippet, date}], provider, query }`. No browser session needed for simple searches.

## Test plan
- [ ] `POST /browser/sessions` no longer fails with CHROME_PATH error
- [ ] `POST /search { "query": "test" }` returns results when a search API key is set
- [ ] `GET /capabilities/readiness` returns `search` in capabilities array
- [ ] `POST /search` returns 503 with helpful message when no search API key configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)