### PR TITLE
fix: correct stagehand ESM package detection path

### DIFF
--- a/src/capability-readiness.ts
+++ b/src/capability-readiness.ts
@@ -35,7 +35,7 @@ function checkBrowserReadiness(): CapabilityReadiness {
 
   // Check if Stagehand package is available.
   // Use existsSync on the package directory — require.resolve is not available in ESM.
-  const stagehandPath = new URL('../../node_modules/@browserbasehq/stagehand/package.json', import.meta.url)
+  const stagehandPath = new URL('../node_modules/@browserbasehq/stagehand/package.json', import.meta.url)
   const stagehandInstalled = (() => { try { return existsSync(stagehandPath) } catch { return false } })()
   if (stagehandInstalled) {
     deps.push({ name: 'stagehand_package', status: 'ok' })


### PR DESCRIPTION
## Summary
One-line fix: `../../` from `dist/capability-readiness.js` resolves to `/` not `/app/`. Changed to `../` which correctly resolves to `/app/node_modules/`.

Stacks on #1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)