### PR TITLE
fix: install Playwright Chromium in Docker + use createRequire for ESM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
+# Install Playwright's Chromium browser (used by @browserbasehq/stagehand for local browser automation).
+# --with-deps installs required system libraries (libnss3, libatk-bridge2.0, etc.).
+RUN npx playwright install chromium --with-deps
+
 COPY --from=build /app/dist/ dist/
 # Copy pre-baked commit.txt for version reporting (run npm run build locally first)
 COPY commit.txt* ./

--- a/src/capabilities/browser.ts
+++ b/src/capabilities/browser.ts
@@ -9,6 +9,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -114,15 +115,16 @@ function resolveChromiumPath(): string | undefined {
     return process.env.CHROME_PATH
   }
   try {
-    // playwright-core ships a bundled Chromium on all platforms.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { chromium } = require('playwright-core') as {
+    // playwright-core ships a bundled Chromium. Use createRequire so this works
+    // in ESM context (bare require() is not available in ES modules).
+    const req = createRequire(import.meta.url)
+    const { chromium } = req('playwright-core') as {
       chromium: { executablePath(): string }
     }
     const p = chromium.executablePath()
     if (p && existsSync(p)) return p
   } catch {
-    // playwright-core not installed — fall through
+    // playwright-core not installed or browser not downloaded — fall through
   }
   return undefined
 }


### PR DESCRIPTION
## Summary
- **Dockerfile**: add playwright install chromium --with-deps in runtime stage so the Chromium binary is baked into the image
- **browser.ts**: replace bare require('playwright-core') with createRequire(import.meta.url) so ESM context can resolve the package from /app/node_modules

## Root cause
resolveChromiumPath() silently returned undefined for two reasons:
1. Bare require() is not available in ES module scope - it would throw, get caught, and fall through
2. Even with correct resolution, the Playwright Chromium binary was never installed in the Docker image

Together these meant every POST /browser/sessions failed with Stagehand's "CHROME_PATH must be set" error.

## Test plan
- [ ] Docker image builds successfully with Chromium installed
- [ ] GET /capabilities/readiness shows browser: degraded (stagehand + chromium found, no LLM key)
- [ ] POST /browser/sessions with valid API key creates a session and navigates to example.com

task-1776102116400-298w8wl8k

Generated with Claude Code