### PR TITLE
fix: add --no-sandbox for Chromium in Docker/Fly containers

### DIFF
--- a/src/capabilities/browser.ts
+++ b/src/capabilities/browser.ts
@@ -169,6 +169,9 @@ export async function createSession(opts: CreateSessionOpts): Promise<BrowserSes
       executablePath: resolveChromiumPath(),
       headless: opts.headless ?? config.headless,
       viewport: opts.viewport ?? config.viewport,
+      // Required in containerised environments (Docker/Fly) where the kernel
+      // sandbox is unavailable. Safe because the container itself is isolated.
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
     },
   })
 


### PR DESCRIPTION
## Summary
Add --no-sandbox and --disable-setuid-sandbox to Chromium launch args.

## Root cause
Chromium crashes with ECONNREFUSED on its own CDP port when launched inside a container without --no-sandbox. The kernel sandbox is not available in Docker/Fly VMs. This is the standard fix for browser automation in containers.

Confirmed by smoke testing on the staging node after PR 1221 (Playwright install in Dockerfile): POST /browser/sessions returned 500 with ECONNREFUSED.

## Test plan
- POST /browser/sessions creates a session and returns session ID
- Session can navigate and extract from example.com

task-1776102116400-298w8wl8k

Generated with Claude Code