### PR TITLE
fix: pin PLAYWRIGHT_BROWSERS_PATH so install and runtime paths agree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
 # Install Playwright's Chromium browser (used by @browserbasehq/stagehand for local browser automation).
-# --with-deps installs required system libraries (libnss3, libatk-bridge2.0, etc.).
+# Pin PLAYWRIGHT_BROWSERS_PATH to a fixed location so the install path and runtime executablePath() agree
+# regardless of the HOME env at runtime (Fly sets HOME differently from the Docker build context).
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npx playwright install chromium --with-deps
 
 COPY --from=build /app/dist/ dist/


### PR DESCRIPTION
## Summary
Set PLAYWRIGHT_BROWSERS_PATH=/ms-playwright in Dockerfile so the browser install path and runtime executablePath() resolve identically.

## Root cause
Playwright installs Chromium to HOME/.cache/ms-playwright at build time (HOME=/root in Docker, so /root/.cache/ms-playwright/chromium-1208/). But Fly does not set HOME=/root at runtime, so executablePath() returns /.cache/ms-playwright/chromium-1208/chrome-linux64/chrome -- a path that does not exist. The browser session then fails with ECONNREFUSED because Chromium cannot be found.

Confirmed on smoke test node: /root/.cache/ms-playwright/chromium-1208/ exists, /.cache/ms-playwright/ does not.

## Fix
Pin PLAYWRIGHT_BROWSERS_PATH=/ms-playwright as a Dockerfile ENV before the install step. Both install and runtime use this env var to locate browsers, making the path independent of HOME.

task-1776102116400-298w8wl8k

Generated with Claude Code