### PR TITLE
fix: add --disable-dev-shm-usage to browser launch args

### DIFF
--- a/src/capabilities/browser.ts
+++ b/src/capabilities/browser.ts
@@ -169,9 +169,10 @@ export async function createSession(opts: CreateSessionOpts): Promise<BrowserSes
       executablePath: resolveChromiumPath(),
       headless: opts.headless ?? config.headless,
       viewport: opts.viewport ?? config.viewport,
-      // Required in containerised environments (Docker/Fly) where the kernel
-      // sandbox is unavailable. Safe because the container itself is isolated.
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      // Required in containerised environments (Docker/Fly):
+      // --no-sandbox / --disable-setuid-sandbox: kernel sandbox unavailable in containers
+      // --disable-dev-shm-usage: use /tmp instead of /dev/shm to avoid Chrome crashes
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
     },
   })
 


### PR DESCRIPTION
## Summary
Add --disable-dev-shm-usage to Chromium launch args to prevent renderer crashes on Fly containers with restricted IPC namespaces.

## Root cause
Without this flag, Chromium uses /dev/shm for renderer shared memory. In some container environments (particularly Fly machines), this can cause crashes even when /dev/shm has sufficient space, due to IPC namespace restrictions.

## Verified
POST /browser/sessions, navigate to example.com, and screenshot all pass against a local Docker container running the current image.

task-1776102116400-298w8wl8k

Generated with Claude Code