### PR TITLE
fix(readiness): browser ready via managed relay when cloud-connected

### DIFF
--- a/src/capability-readiness.ts
+++ b/src/capability-readiness.ts
@@ -29,12 +29,43 @@ export interface ReadinessReport {
 
 // ── Browser ──────────────────────────────────────────────────────────────────
 
-function checkBrowserReadiness(): CapabilityReadiness {
+function checkBrowserReadiness(cloudConnected: boolean): CapabilityReadiness {
   const deps: DependencyCheck[] = []
+
+  if (cloudConnected) {
+    // Managed hosts use the cloud browser relay (/browser/managed/sessions →
+    // /api/hosts/:hostId/relay/browser/sessions). The cloud holds the LLM keys;
+    // the node just proxies. No local Stagehand or API key required.
+    deps.push({
+      name: 'managed_relay',
+      status: 'ok',
+      detail: 'Cloud browser relay available via /browser/managed/sessions',
+    })
+
+    // Local Stagehand runtime (optional — useful for debugging/fallback).
+    const stagehandPath = new URL('../node_modules/@browserbasehq/stagehand/package.json', import.meta.url)
+    const stagehandInstalled = (() => { try { return existsSync(stagehandPath) } catch { return false } })()
+    deps.push({
+      name: 'local_stagehand',
+      status: stagehandInstalled ? 'ok' : 'missing',
+      detail: stagehandInstalled
+        ? 'Local Stagehand runtime available (direct sessions via /browser/sessions)'
+        : 'Optional — local Stagehand not installed; use /browser/managed/sessions instead',
+    })
+
+    return {
+      capability: 'browser',
+      status: 'ready',
+      last_success_at: null,
+      last_error: null,
+      dependencies: deps,
+      hint: null,
+    }
+  }
+
+  // Standalone (not cloud-connected) — must use local Stagehand with a local LLM key.
   const errors: string[] = []
 
-  // Check if Stagehand package is available.
-  // Use existsSync on the package directory — require.resolve is not available in ESM.
   const stagehandPath = new URL('../node_modules/@browserbasehq/stagehand/package.json', import.meta.url)
   const stagehandInstalled = (() => { try { return existsSync(stagehandPath) } catch { return false } })()
   if (stagehandInstalled) {
@@ -44,23 +75,14 @@ function checkBrowserReadiness(): CapabilityReadiness {
     errors.push('Stagehand package not installed')
   }
 
-  // Check for ANTHROPIC_API_KEY or OPENAI_API_KEY (required by Stagehand)
   const hasAnthropicKey = !!(process.env.ANTHROPIC_API_KEY)
   const hasOpenAIKey = !!(process.env.OPENAI_API_KEY)
   if (hasAnthropicKey || hasOpenAIKey) {
     deps.push({ name: 'llm_api_key', status: 'ok', detail: hasAnthropicKey ? 'ANTHROPIC_API_KEY set' : 'OPENAI_API_KEY set' })
   } else {
-    deps.push({ name: 'llm_api_key', status: 'missing', detail: 'ANTHROPIC_API_KEY or OPENAI_API_KEY required for Stagehand' })
+    deps.push({ name: 'llm_api_key', status: 'missing', detail: 'ANTHROPIC_API_KEY or OPENAI_API_KEY required for local Stagehand AI operations' })
     errors.push('LLM API key missing (ANTHROPIC_API_KEY or OPENAI_API_KEY)')
   }
-
-  // Check BROWSERBASE_API_KEY (optional — cloud browser)
-  const hasBrowserbaseKey = !!(process.env.BROWSERBASE_API_KEY)
-  deps.push({
-    name: 'browserbase_api_key',
-    status: hasBrowserbaseKey ? 'ok' : 'missing',
-    detail: hasBrowserbaseKey ? 'BROWSERBASE_API_KEY set' : 'Optional — uses local browser if absent',
-  })
 
   const status: ReadinessStatus = errors.length === 0 ? 'ready'
     : errors.some(e => e.includes('package')) ? 'not_ready'
@@ -73,7 +95,9 @@ function checkBrowserReadiness(): CapabilityReadiness {
     last_error: errors.length > 0 ? errors[0] : null,
     dependencies: deps,
     hint: status !== 'ready'
-      ? 'Install @browserbasehq/stagehand and set ANTHROPIC_API_KEY to enable browser automation.'
+      ? errors.some(e => e.includes('package'))
+        ? 'Install @browserbasehq/stagehand and set ANTHROPIC_API_KEY, or enroll this host with Reflectt Cloud to use the managed browser relay.'
+        : 'Set ANTHROPIC_API_KEY or OPENAI_API_KEY for local AI extraction, or enroll this host with Reflectt Cloud to use the managed browser relay.'
       : null,
   }
 }
@@ -281,7 +305,7 @@ export function getCapabilityReadiness(opts: {
   samplingProviders?: string[]
 }): ReadinessReport {
   const capabilities = [
-    checkBrowserReadiness(),
+    checkBrowserReadiness(opts.cloudConnected),
     checkSearchReadiness(),
     checkEmailReadiness(opts.cloudConnected, opts.cloudUrl, opts.webhooks),
     checkSmsReadiness(opts.cloudConnected, opts.cloudUrl, opts.webhooks),

--- a/tests/capability-readiness.test.ts
+++ b/tests/capability-readiness.test.ts
@@ -70,6 +70,23 @@ describe('capability readiness contract', () => {
     expect(cal.status).toBe('ready')
   })
 
+  it('browser is ready when cloud connected (managed relay path)', () => {
+    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://app.reflectt.ai' })
+    const browser = report.capabilities.find(c => c.capability === 'browser')!
+    expect(browser.status).toBe('ready')
+    expect(browser.last_error).toBeNull()
+    expect(browser.hint).toBeNull()
+    const relayDep = browser.dependencies.find(d => d.name === 'managed_relay')
+    expect(relayDep?.status).toBe('ok')
+  })
+
+  it('browser is not_ready or degraded when not cloud connected and no local Stagehand', () => {
+    const report = getCapabilityReadiness(baseOpts)
+    const browser = report.capabilities.find(c => c.capability === 'browser')!
+    // standalone without stagehand installed → not_ready; without LLM key only → degraded
+    expect(['not_ready', 'degraded']).toContain(browser.status)
+  })
+
   it('each capability has non-empty dependencies array with valid statuses', () => {
     const report = getCapabilityReadiness(baseOpts)
     for (const cap of report.capabilities) {

--- a/tests/capability-readiness.test.ts
+++ b/tests/capability-readiness.test.ts
@@ -37,14 +37,14 @@ describe('capability readiness contract', () => {
   })
 
   it('email is degraded when cloud connected but no inbound webhook', () => {
-    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://app.reflectt.ai' })
+    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://api.reflectt.ai' })
     const email = report.capabilities.find(c => c.capability === 'email')!
     expect(email.status).toBe('degraded')
   })
 
   it('email is ready when cloud connected + resend webhook active', () => {
     const webhooks = [{ provider: 'resend', active: true }]
-    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://app.reflectt.ai', webhooks })
+    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://api.reflectt.ai', webhooks })
     const email = report.capabilities.find(c => c.capability === 'email')!
     expect(email.status).toBe('ready')
     expect(email.last_error).toBeNull()
@@ -59,7 +59,7 @@ describe('capability readiness contract', () => {
 
   it('sms is ready when cloud connected + twilio webhook active', () => {
     const webhooks = [{ provider: 'twilio', active: true }]
-    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://app.reflectt.ai', webhooks })
+    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://api.reflectt.ai', webhooks })
     const sms = report.capabilities.find(c => c.capability === 'sms')!
     expect(sms.status).toBe('ready')
   })
@@ -71,7 +71,7 @@ describe('capability readiness contract', () => {
   })
 
   it('browser is ready when cloud connected (managed relay path)', () => {
-    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://app.reflectt.ai' })
+    const report = getCapabilityReadiness({ ...baseOpts, cloudConnected: true, cloudUrl: 'https://api.reflectt.ai' })
     const browser = report.capabilities.find(c => c.capability === 'browser')!
     expect(browser.status).toBe('ready')
     expect(browser.last_error).toBeNull()
@@ -110,7 +110,7 @@ describe('capability readiness contract', () => {
 
     const after = getCapabilityReadiness({
       cloudConnected: true,
-      cloudUrl: 'https://app.reflectt.ai',
+      cloudUrl: 'https://api.reflectt.ai',
       webhooks: [{ provider: 'resend', active: true }],
     })
     const emailAfter = after.capabilities.find(c => c.capability === 'email')!
@@ -122,7 +122,7 @@ describe('capability readiness contract', () => {
       { provider: 'resend', active: true },
       { provider: 'twilio', active: true },
     ]
-    const report = getCapabilityReadiness({ cloudConnected: true, cloudUrl: 'https://app.reflectt.ai', webhooks, samplingProviders: ['claude'] })
+    const report = getCapabilityReadiness({ cloudConnected: true, cloudUrl: 'https://api.reflectt.ai', webhooks, samplingProviders: ['claude'] })
     // browser and search are node-managed — their readiness depends on local env vars not set in tests
     const nonNodeManaged = report.capabilities.filter(c => c.capability !== 'browser' && c.capability !== 'search')
     for (const cap of nonNodeManaged) {


### PR DESCRIPTION
## Summary
- Managed hosts use `/browser/managed/sessions` which proxies to the cloud relay — the cloud holds LLM keys, not the customer
- `checkBrowserReadiness` now accepts `cloudConnected` and returns `ready` with a `managed_relay: ok` dep when true
- Standalone (non-cloud) mode still checks local Stagehand + LLM key as before
- Fixes Nicole's node showing `browser: degraded` when it should be `ready`

## Test plan
- [ ] 14 capability readiness tests pass (all green)
- [ ] `browser: ready` on a managed (cloud-connected) host without any local LLM key set
- [ ] `browser: degraded` on a standalone host with Stagehand but no LLM key

🤖 Generated with [Claude Code](https://claude.com/claude-code)