### PR TITLE
fix(relay): fall back to REFLECTT_HOST_CREDENTIAL in cloudRelay

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19006,7 +19006,7 @@ If your heartbeat shows **no active task** and **no next task**:
     method: 'GET' | 'POST' = 'POST',
   ): Promise<unknown> {
     const cloudUrl = process.env.REFLECTT_CLOUD_URL
-    const hostToken = process.env.REFLECTT_HOST_TOKEN
+    const hostToken = process.env.REFLECTT_HOST_TOKEN || process.env.REFLECTT_HOST_CREDENTIAL
     if (!cloudUrl || !hostToken) {
       reply.code(503)
       return { error: 'Not connected to cloud. Configure REFLECTT_CLOUD_URL and REFLECTT_HOST_TOKEN.' }


### PR DESCRIPTION
## Summary
- Managed nodes are provisioned with `REFLECTT_HOST_CREDENTIAL` (not `REFLECTT_HOST_TOKEN`) by the fly provisioner
- `cloudRelay()` in server.ts was only checking `REFLECTT_HOST_TOKEN`, so managed nodes always got a 503 "Not connected to cloud" on browser/email/SMS relay calls — despite the cloud connection being active
- Fix: `const hostToken = process.env.REFLECTT_HOST_TOKEN || process.env.REFLECTT_HOST_CREDENTIAL`

## Root cause
`fly-provisioner.ts` sets `REFLECTT_HOST_CREDENTIAL` + `REFLECTT_HOST_ID` on machine env (line 637). `REFLECTT_HOST_TOKEN` is only set by `cli.ts` at startup (for non-Docker installs) or dynamically by `server.ts:16349` after cloud registration completes. Docker containers running `node dist/index.js` directly never get `REFLECTT_HOST_TOKEN` set as an env var — only `REFLECTT_HOST_CREDENTIAL`.

## Test plan
- [ ] Deploy to Nicole's node (rn-6091646d-d5yt5o) and verify `POST /browser/managed/sessions` returns 200/201 instead of 503
- [ ] Run `npm --workspace apps/web run test:e2e:staging -- e2e/browser-managed-sessions.spec.ts` to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)