### PR TITLE
feat(heartbeat): push capabilityReadiness in every heartbeat payload

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -29,6 +29,7 @@ import { REFLECTT_HOME } from './config.js'
 import { getRequestMetrics } from './request-tracker.js'
 import { listApprovalQueue, listAgentEvents, listAgentRuns, type AgentRun } from './agent-runs.js'
 import { getUnpushedTrustEvents, markTrustEventsPushed } from './trust-events.js'
+import { getCapabilityReadiness } from './capability-readiness.js'
 
 /**
  * Docker identity guard: detect when a container has inherited cloud
@@ -885,6 +886,18 @@ async function sendHeartbeat(): Promise<void> {
         errors: m.rolling.errors,
         windowMs,
         errorRatePct: Math.round(errorRatePct * 100) / 100,
+      }
+    })(),
+    capabilityReadiness: (() => {
+      try {
+        const r = getCapabilityReadiness({
+          cloudConnected: true,
+          cloudUrl: config.cloudUrl,
+          webhooks: [],
+        })
+        return r
+      } catch {
+        return undefined
       }
     })(),
     source: {


### PR DESCRIPTION
## Summary

- Adds `capabilityReadiness` field to the 30s heartbeat payload sent to the cloud API
- Contains the full `ReadinessReport` from `getCapabilityReadiness()` — per-capability status, dependencies, last error
- Cloud-side can now cache this and serve capability readiness without fetching a public node URL

**Why:** Companion to reflectt/reflectt-cloud `feat/heartbeat-capability-readiness`. Moves capability readiness from pull (public URL fetch) to push (heartbeat), removing the security risk of exposing a public node URL.

## Companion PR
reflectt/reflectt-cloud — `feat/heartbeat-capability-readiness`

## Test plan
- [ ] After both PRs merged + node redeployed: heartbeat payload includes `capabilityReadiness.capabilities[]` array
- [ ] Cloud `storeHeartbeatReadiness` populates the in-memory cache on each heartbeat
- [ ] `GET /api/teams/:teamId/capabilities` shows `search: { status: "ready" }` for teams with a running node

🤖 Generated with [Claude Code](https://claude.com/claude-code)