### PR TITLE
feat(context): include capability-context.md in agent context budget

### DIFF
--- a/src/context-budget.ts
+++ b/src/context-budget.ts
@@ -17,6 +17,7 @@ import { homedir } from 'os'
 import { getDb, safeJsonParse, safeJsonStringify } from './db.js'
 import type { AgentMessage } from './types.js'
 import { memoryManager } from './memory.js'
+import { REFLECTT_HOME } from './config.js'
 
 export type ContextLayer = 'session_local' | 'agent_persistent' | 'team_shared'
 
@@ -259,6 +260,7 @@ async function buildAgentPersistentItems(agent: string): Promise<ContextItem[]> 
     { id: 'USER.md', title: 'USER.md', path: join(root, 'USER.md'), maxChars: 16_000 },
     { id: 'AGENTS.md', title: 'AGENTS.md', path: join(root, 'AGENTS.md'), maxChars: 16_000 },
     { id: 'HEARTBEAT.md', title: 'HEARTBEAT.md', path: join(root, 'HEARTBEAT.md'), maxChars: 16_000 },
+    { id: 'capability-context.md', title: 'capability-context.md', path: join(REFLECTT_HOME, 'capability-context.md'), maxChars: 4_000 },
   ]
 
   const memoryItems: ContextItem[] = []


### PR DESCRIPTION
## Summary

- Imports `REFLECTT_HOME` from `config.ts` in `context-budget.ts`
- Adds `capability-context.md` (max 4k chars) to the `agent_persistent` context candidates list
- This file is written by `syncCapabilityContext()` on each cloud heartbeat and contains the `systemPromptHint` from the cloud capability API

## Why

Agents had zero awareness of which capabilities (browser, email, SMS, calendar) were ready for them to use. The file `$REFLECTT_HOME/capability-context.md` was already being written on heartbeat sync but was never injected into agent context — a silent product gap.

## Test plan

- [ ] Deploy to staging node
- [ ] Verify `capability-context.md` appears in agent context budget attribution output
- [ ] Confirm agents reference capability status in responses when relevant

🤖 Generated with [Claude Code](https://claude.ai/claude-code)