### PR TITLE
feat(cloud): inject REFLECTT_NODE_URL into capability-context.md on Fly hosts

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -2041,8 +2041,16 @@ async function syncCapabilityContext(): Promise<void> {
       return
     }
 
-    writeFileSync(CAPABILITY_CONTEXT_FILE, `## Team capabilities\n\n${hint}\n`)
-    console.log(`[cloud] capability context updated (${hint.length} chars)`)
+    // Append internal node URL so agents can reach node APIs (browser, search, etc.)
+    // from exec without public URL coaching. Only set on Fly.io managed hosts.
+    const flyAppName = process.env.FLY_APP_NAME
+    const nodePort = process.env.PORT || '4445'
+    const nodeUrlSection = flyAppName
+      ? `\n## Node API\n\nREFLECTT_NODE_URL=http://${flyAppName}.internal:${nodePort}\n\nUse this URL for direct node API calls from exec (e.g. browser sessions, search).\n`
+      : ''
+
+    writeFileSync(CAPABILITY_CONTEXT_FILE, `## Team capabilities\n\n${hint}\n${nodeUrlSection}`)
+    console.log(`[cloud] capability context updated (${hint.length} chars${flyAppName ? ', node URL included' : ''})`)
   } catch (err: any) {
     // Non-fatal: agents run without capability context if the fetch fails
     console.warn(`[cloud] capability context fetch failed: ${err?.message || 'unknown error'}`)

--- a/src/context-budget.ts
+++ b/src/context-budget.ts
@@ -17,6 +17,7 @@ import { homedir } from 'os'
 import { getDb, safeJsonParse, safeJsonStringify } from './db.js'
 import type { AgentMessage } from './types.js'
 import { memoryManager } from './memory.js'
+import { REFLECTT_HOME } from './config.js'
 
 export type ContextLayer = 'session_local' | 'agent_persistent' | 'team_shared'
 
@@ -259,6 +260,7 @@ async function buildAgentPersistentItems(agent: string): Promise<ContextItem[]> 
     { id: 'USER.md', title: 'USER.md', path: join(root, 'USER.md'), maxChars: 16_000 },
     { id: 'AGENTS.md', title: 'AGENTS.md', path: join(root, 'AGENTS.md'), maxChars: 16_000 },
     { id: 'HEARTBEAT.md', title: 'HEARTBEAT.md', path: join(root, 'HEARTBEAT.md'), maxChars: 16_000 },
+    { id: 'capability-context.md', title: 'capability-context.md', path: join(REFLECTT_HOME, 'capability-context.md'), maxChars: 4_000 },
   ]
 
   const memoryItems: ContextItem[] = []


### PR DESCRIPTION
## Summary

- When `FLY_APP_NAME` is set (Fly.io managed host), appends a `## Node API` section to `capability-context.md` containing `REFLECTT_NODE_URL=http://{app}.internal:{port}`
- No-op on local/Mac Daddy where `FLY_APP_NAME` is not set
- Agents read this from context (wired in #1229) and can use the internal URL for browser/search API calls from exec — no public URL coaching needed

## Why

Diagnostic confirmed: gateway (`rg-*`) can reach node (`rn-*`) at `.internal:4445`, but the URL wasn't exposed to agent exec environments. This closes the final gap cleanly via the managed capability-context path.

## Test plan

- [ ] Deploy to staging node
- [ ] Verify `capability-context.md` contains `REFLECTT_NODE_URL=http://rn-*.internal:4445`
- [ ] Verify staged agent can use the URL from exec to hit `/health` without coaching
- [ ] Verify Mac Daddy / local: no `## Node API` section in capability-context.md

🤖 Generated with [Claude Code](https://claude.ai/claude-code)