### PR TITLE
feat: GET /host/status — single-call operator diagnostic endpoint

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -108,6 +108,7 @@ Remote hosts (multi-host installs) phone-home via a lightweight heartbeat so the
 | GET | `/health/chat` | Chat subsystem health: message counts, drop counters per agent (total + rolling 1h + reasons). Returns `{ totalMessages, rooms, subscribers, drops }`. |
 | GET | `/health/errors` | Request error metrics: total errors, total requests, error rate, and last 20 errors for debugging. Returns `{ total_errors, total_requests, error_rate, recent[], timestamp }`. |
 | GET | `/health/version` | Version summary for ops tooling + cloud dashboard. Returns `{ version, commit, uptime_ms, host_id, node_env }`. |
+| GET | `/host/status` | Single-call operator diagnostic endpoint. Returns bootstrap status + stalled reason, agent roster with online/offline, task queue depth, channel health, error rate, and actionable `diagnosis.code` + `diagnosis.next_action`. Use this instead of SSH for managed host triage. Response: `{ healthy, host, bootstrap, agents, tasks, channel, errors, diagnosis }`. |
 | GET | `/health/keepalive` | Self-keepalive status for CF/serverless: warm boot detection, ping state, cold start count, environment info. |
 | GET | `/health/ping` | Ultra-lightweight keepalive — no DB access. Returns `{ status, uptime_seconds, ts }`. Use for cron triggers, load balancers, uptime monitors. |
 | GET | `/health/watchdog` | Richer keepalive with cold_start flag, task/chat stats, boot_info, and remediation hints. For monitoring dashboards. See `docs/KEEPALIVE.md`. |

--- a/src/server.ts
+++ b/src/server.ts
@@ -2753,6 +2753,150 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
+  // ── Host status — single-call operator diagnostic endpoint ───────────────
+  // Returns everything needed to diagnose a managed host without SSH.
+  // Covers: bootstrap, agents, tasks, channel, errors.
+  app.get('/host/status', async () => {
+    const now = Date.now()
+
+    // Bootstrap markers
+    const firstBootMarker = join(DATA_DIR, '.first-boot-done')
+    const teamRolesPath = join(REFLECTT_HOME, 'TEAM-ROLES.yaml')
+    const hasBootstrapped = existsSync(firstBootMarker)
+    const hasTeamRoles = existsSync(teamRolesPath)
+    const teamIntentPath = join(DATA_DIR, 'TEAM_INTENT.md')
+    const hasTeamIntent = existsSync(teamIntentPath)
+
+    // Bootstrap task status
+    const allTasks = taskManager.listTasks({})
+    const bootstrapTask = allTasks.find(t =>
+      t.priority === 'P0' && t.assignee === 'main' && t.title?.toLowerCase().includes('bootstrap')
+    )
+
+    // Agent presence
+    const presences = presenceManager.getAllPresence()
+    const ONLINE_THRESHOLD_MS = 5 * 60 * 1000 // 5 min
+    const agentSummary = presences.map(p => ({
+      agent: p.agent,
+      status: p.last_active && (now - p.last_active) < ONLINE_THRESHOLD_MS ? 'online' : 'offline',
+      last_active: p.last_active ?? null,
+      last_active_ago_s: p.last_active ? Math.round((now - p.last_active) / 1000) : null,
+    }))
+
+    // Task queue
+    const taskStats = taskManager.getStats()
+
+    // Channel / cloud
+    const channelOk = !!openclawConfig.gatewayToken
+
+    // Error rate
+    const metrics = getRequestMetrics()
+    const errorRate = metrics.total > 0
+      ? Math.round((metrics.errors / metrics.total) * 10000) / 100
+      : 0
+
+    // Derive bootstrap status + stall reason
+    const bootstrapComplete =
+      (hasBootstrapped && hasTeamRoles) ||
+      bootstrapTask?.status === 'done' ||
+      (!bootstrapTask && hasTeamRoles)
+
+    const bootstrapStatus = bootstrapComplete
+      ? 'complete'
+      : bootstrapTask
+      ? bootstrapTask.status  // todo / doing / validating
+      : 'not_started'
+
+    let bootstrapStalledReason: string | null = null
+    if (!bootstrapComplete) {
+      if (!hasTeamIntent && !bootstrapTask) {
+        bootstrapStalledReason = 'no_team_intent_and_no_bootstrap_task'
+      } else if (hasTeamIntent && !bootstrapTask) {
+        bootstrapStalledReason = 'team_intent_present_but_no_bootstrap_task_created'
+      } else if (bootstrapTask && (bootstrapTask.status === 'todo' || bootstrapTask.status === 'doing')) {
+        bootstrapStalledReason = 'bootstrap_task_in_progress'
+      } else if (!hasTeamRoles) {
+        bootstrapStalledReason = 'team_roles_yaml_not_written'
+      }
+    }
+
+    // Diagnosis: derive actionable code + next step
+    const agentsOnline = agentSummary.filter(a => a.status === 'online').length
+    let diagnosisCode: string
+    let diagnosisAction: string
+    if (!channelOk) {
+      diagnosisCode = 'CHANNEL_NOT_CONFIGURED'
+      diagnosisAction = 'Set OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN, then restart the node'
+    } else if (!bootstrapComplete && bootstrapStalledReason === 'team_intent_present_but_no_bootstrap_task_created') {
+      diagnosisCode = 'BOOTSTRAP_STALLED_NO_TASK'
+      diagnosisAction = 'Bootstrap task was never created — restart the node to re-trigger first-boot detection'
+    } else if (!bootstrapComplete && bootstrapTask) {
+      diagnosisCode = 'BOOTSTRAP_IN_PROGRESS'
+      diagnosisAction = 'Bootstrap is running — wait or check if the main agent is stuck'
+    } else if (!bootstrapComplete) {
+      diagnosisCode = 'BOOTSTRAP_NOT_STARTED'
+      diagnosisAction = 'No agents or tasks found — check that TEAM_INTENT is set and restart the node'
+    } else if (agentsOnline === 0) {
+      diagnosisCode = 'NO_AGENTS_ONLINE'
+      diagnosisAction = 'Bootstrap complete but no agents active — check gateway connection and heartbeat config'
+    } else if (errorRate >= 10) {
+      diagnosisCode = 'HIGH_ERROR_RATE'
+      diagnosisAction = `Error rate ${errorRate}% — check /health/errors for recent failures`
+    } else {
+      diagnosisCode = 'HEALTHY'
+      diagnosisAction = 'No action needed'
+    }
+
+    const healthy = diagnosisCode === 'HEALTHY'
+
+    return {
+      healthy,
+      timestamp: now,
+      host: {
+        id: process.env.REFLECTT_HOST_ID ?? process.env.HOSTNAME ?? 'unknown',
+        node_url: process.env.REFLECTT_NODE_URL ?? null,
+        version: BUILD_VERSION,
+        uptime_s: Math.round((now - BUILD_STARTED_AT) / 1000),
+      },
+      bootstrap: {
+        status: bootstrapStatus,
+        complete: bootstrapComplete,
+        first_boot_marker: hasBootstrapped,
+        team_roles_yaml: hasTeamRoles,
+        team_intent_seeded: hasTeamIntent,
+        stalled_reason: bootstrapStalledReason,
+        task: bootstrapTask
+          ? { id: bootstrapTask.id, status: bootstrapTask.status, title: bootstrapTask.title }
+          : null,
+      },
+      agents: {
+        online: agentsOnline,
+        total: agentSummary.length,
+        roster: agentSummary,
+      },
+      tasks: {
+        todo: taskStats.byStatus?.todo ?? 0,
+        doing: taskStats.byStatus?.doing ?? 0,
+        validating: taskStats.byStatus?.validating ?? 0,
+        done: taskStats.byStatus?.done ?? 0,
+        total: taskStats.total ?? 0,
+      },
+      channel: {
+        openclaw_configured: channelOk,
+        gateway_url: openclawConfig.gatewayUrl ?? null,
+      },
+      errors: {
+        rate_pct: errorRate,
+        total_errors: metrics.errors,
+        total_requests: metrics.total,
+      },
+      diagnosis: {
+        code: diagnosisCode,
+        next_action: diagnosisAction,
+      },
+    }
+  })
+
   app.get('/health/reflection-pipeline', async () => {
     const health = computeReflectionPipelineHealth(Date.now())
     return {


### PR DESCRIPTION
## Summary

- Adds `GET /host/status` to reflectt-node — a single endpoint that returns everything needed to diagnose a managed host without SSH
- Aggregates data already available in-process: no new deps, no external calls

## What it returns

```json
{
  "healthy": true/false,
  "bootstrap": {
    "status": "complete | todo | doing | validating | not_started",
    "first_boot_marker": bool,
    "team_roles_yaml": bool,
    "team_intent_seeded": bool,
    "task": { "id", "status", "title" } | null
  },
  "agents": {
    "online": 1,
    "total": 1,
    "roster": [{ "agent", "status", "last_active_ago_s" }]
  },
  "tasks": { "todo", "doing", "validating", "done", "total" },
  "channel": { "openclaw_configured": bool, "gateway_url": "..." },
  "errors": { "rate_pct", "total_errors", "total_requests" },
  "version": "...",
  "uptime_s": 3600
}
```

## Why

Today diagnosing a managed host requires SSH + manual log reading across 2 machines. This endpoint lets operators (and agents) get full host health with a single `GET /host/status` call from anywhere.

Addresses the support gap identified in `docs/operator-audit-2026-04-14.md`.

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit` passes — verified)
- [ ] `GET /host/status` returns 200 with expected shape on a running node
- [ ] `healthy: false` when bootstrap hasn't completed
- [ ] `healthy: true` when bootstrap done, agents online, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)