### PR TITLE
fix(sweeper): pass task.metadata to suggestReviewer on reviewer auto-reassign

### DIFF
--- a/src/executionSweeper.ts
+++ b/src/executionSweeper.ts
@@ -483,6 +483,7 @@ export async function sweepValidatingQueue(): Promise<SweepResult> {
             assignee: task.assignee,
             tags: meta.tags as string[] | undefined,
             done_criteria: task.done_criteria,
+            metadata: task.metadata as Record<string, unknown> | undefined,
           },
           tasksForScoring,
         )


### PR DESCRIPTION
## Summary

- `executionSweeper.ts`: pass `metadata: task.metadata` to `suggestReviewer()` during reviewer auto-reassign
- Root cause: when a task triggered the `VALIDATING_REASSIGN_MS` auto-reassign path, `suggestReviewer()` was called with no `metadata`, silently dropping the task's `lane` field
- `agentEligibleForTask()` reads `metadata.lane` to enforce opt-in lane boundaries — without it, agents from wrong lanes (e.g. QA reviewing ops tasks) could be picked
- Fix is a single field addition; no logic change, no new behavior

## Test plan

- [x] `tests/execution-sweeper.test.ts` — 26/26 pass
- [x] `tests/reviewer-assignment.test.ts` — pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)