### PR TITLE
fix(bridge): stamp task.metadata.lane from assignee's lane at insight task creation

### DIFF
--- a/src/insight-task-bridge.ts
+++ b/src/insight-task-bridge.ts
@@ -15,6 +15,7 @@ import { getInsight, updateInsightStatus, type Insight } from './insights.js'
 import { taskManager } from './tasks.js'
 import { getDb } from './db.js'
 import { suggestAssignee, suggestReviewer, getAgentRoles } from './assignment.js'
+import { getAgentLane } from './lane-config.js'
 
 // ── Types ──
 
@@ -416,6 +417,7 @@ async function autoCreateTask(insight: Insight): Promise<void> {
         source: 'insight-task-bridge',
         reflection_count: insight.reflection_ids.length,
         authors: insight.authors,
+        lane: getAgentLane(decision.assignee)?.name,
         assignment_decision: {
           reason: decision.reason,
           guardrail_applied: decision.guardrailApplied,


### PR DESCRIPTION
## Summary

- `insight-task-bridge.ts`: import `getAgentLane` from `lane-config.ts` and stamp `metadata.lane` on synthetic tasks at creation time
- Root cause: insight-auto-created tasks had no `lane` in metadata — `agentEligibleForTask()` reads `metadata.lane` to enforce opt-in reviewer lane boundaries; without it any agent was eligible regardless of lane
- Source of truth: `getAgentLane(decision.assignee)` — same canonical lookup used by ready-queue engine and `health.ts`. Direct membership check, no heuristics
- Null-safe: if assignee has no lane configured, `getAgentLane()` returns `null`, lane field stays absent — no regression vs current behavior

## Test plan

- [x] `npx vitest run` — 223/223 test files, 2460/2460 tests pass (0 regressions)
- [x] `npm run build` — clean
- [x] Bridge tests (bridge-catchup, bridge-dedup-fix, bridge-dedup-reflection-ids, bridge-dedup-user-tasks) — 31/31 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)