### PR TITLE
fix(channel): subscribe agent_identity_changed SSE event to flush attribution cache

### DIFF
--- a/plugins/reflectt-channel/index.ts
+++ b/plugins/reflectt-channel/index.ts
@@ -435,8 +435,27 @@ function connectSSE(url: string, account: ReflecttAccount, ctx: any) {
             ctx.log?.error(`[reflectt] batch parse error: ${e}`);
           }
         }
+      } else if (eventType === "agent_identity_changed" && eventData) {
+        try {
+          const payload = JSON.parse(eventData);
+          const newName = payload?.newName;
+          const previousName = payload?.previousName;
+          ctx.log?.info(`[reflectt] identity changed: ${previousName} → ${newName}`);
+          // Invalidate any stale session index entries so chat attribution uses
+          // the current identity rather than a stale cache entry.
+          if (newName) {
+            for (const agentId of WATCHED_AGENTS) {
+              // Purge the canonical session key for this agent so the next dispatch
+              // rebuilds the session index from current identity, not a stale name.
+              purgeSessionIndexEntry(agentId, `agent:${agentId}:reflectt:main`, ctx);
+            }
+          }
+        } catch (e) {
+          ctx.log?.error(`[reflectt] agent_identity_changed parse error: ${e}`);
+        }
       }
     });
+
 
     res.on("end", () => {
       ctx.log?.warn("[reflectt] SSE stream ended by server");


### PR DESCRIPTION
When an agent claims a new identity (name/avatar/voice), the gateway emits `agent_identity_changed`. The channel plugin now subscribes this event and purges the session index entry for each watched agent so the next dispatch rebuilds from the current identity rather than a stale name.

**Changes:**
- SSE handler in `plugins/reflectt-channel/index.ts` now handles `agent_identity_changed` event type
- On identity change, purges session index entries so attribution uses the updated agent identity

**Refs:**
- `task-1776352608806-t881mdrvg` (speaker attribution P1)
- `task-1776352596747-4ngszu7rx` (no-mention routing)

**Tested:** Staging E2E proof confirmed `agent_identity_changed` fires with full payload on identity claim (`POST /agents/main/identity/claim`). Staged at `rn-cb2eeb02-ek57z4`.