### PR TITLE
fix(node): expose teamId on Host type and rowToHost

### DIFF
--- a/src/host-registry.ts
+++ b/src/host-registry.ts
@@ -28,6 +28,7 @@ export interface Host {
   status: 'online' | 'offline' | 'stale'
   last_seen_at: number
   registered_at: number
+  teamId: string | null
 }
 
 // ── Constants ──
@@ -149,5 +150,6 @@ function rowToHost(row: Record<string, unknown>): Host {
     status,
     last_seen_at: lastSeen,
     registered_at: Number(row.registered_at) || 0,
+    teamId: (row.team_id as string) || null,
   }
 }


### PR DESCRIPTION
The hosts table has a `team_id` column (present in Supabase staging DB) but the Host interface and `rowToHost()` omitted it from the API surface. This prevents the web UI from filtering hosts by team.

**Changes:**
- `src/host-registry.ts`: added `teamId: string | null` to Host interface and `rowToHost()` return

**Why this matters:** `GET /api/hosts` now returns `teamId` per host, enabling the `header.tsx` team filter (PR #2390) to work correctly. Without this, `header.tsx` receives hosts with no `teamId` field and the filter silently passes all hosts.

**Verification:** Staging DB query confirmed `team_id` column exists and hosts have values:
```
mac-daddy.local → team_id: 4d5ce790-497b-4675-a391-f46a85da44f8
```

**Stack:** pairs with `reflectt-cloud#2390` (header.tsx client-side team filter)

**Refs:** `task-1776350961362-w07szb6km`