### PR TITLE
fix(channel): route no-mention messages to main agent instead of dropping

### DIFF
--- a/plugins/reflectt-channel/index.ts
+++ b/plugins/reflectt-channel/index.ts
@@ -612,7 +612,14 @@ function handleInbound(data: string, url: string, account: ReflecttAccount, ctx:
     const regex = /@(\w+)/g;
     let match: RegExpExecArray | null;
     while ((match = regex.exec(content)) !== null) mentions.push(match[1].toLowerCase());
-    if (mentions.length === 0) return;
+    // Track whether this message was explicitly @mentioned (vs. default-routed to main)
+    const hasExplicitMention = mentions.length > 0;
+
+    // Default to main agent if no mentions — unmentioned customer messages still need routing
+    if (mentions.length === 0) {
+      mentions.push("main");
+      ctx.log?.debug(`[reflectt] No @mentions — defaulting to @main for: ${content.slice(0, 60)}...`);
+    }
 
     // Build agent ID map
     const cfg = pluginRuntime?.config?.loadConfig?.() ?? {};
@@ -705,7 +712,7 @@ function handleInbound(data: string, url: string, account: ReflecttAccount, ctx:
         Surface: "reflectt",
         OriginatingChannel: "reflectt" as const,
         OriginatingTo: channel,
-        WasMentioned: true,
+        WasMentioned: hasExplicitMention,
         CommandAuthorized: false,
       };
 


### PR DESCRIPTION
Previously, messages without @mentions were silently dropped at the channel plugin level. Customer messages without @mentions should route to the main agent, not be discarded.

**Root cause:** `handleInbound` returned early when no @mentions were found:
```typescript
if (mentions.length === 0) return;  // message dropped
```

**Fix:**
- When no @mentions found, default to `main` agent and continue routing (self-loop guard still applies)
- `WasMentioned` flag set to `false` for default-routed messages (was hardcoded to `true`)
- Explicit @mentions still route normally with `WasMentioned: true`

**Changes (10 lines):**
- `plugins/reflectt-channel/index.ts`: replace `if (mentions.length === 0) return;` with default-to-main logic
- `WasMentioned` now conditional based on whether message had explicit @mention

**Testing:** Requires staging proof with a customer message sent without @mention, verifying it routes to main and does not get dropped.

**Ref:** `task-1776352596747-4ngszu7rx`