### PR TITLE
feat: GitHub cloud token refresh for agent GitHub access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpango-1.0-0 \
     libcairo2 \
     libasound2 \
+    curl git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) — agents use it to create PRs, manage issues
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package.json package-lock.json ./

--- a/src/github-cloud-token.ts
+++ b/src/github-cloud-token.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Fetches a GitHub installation access token from the cloud API and keeps it fresh.
+// The token is set as GITHUB_TOKEN / GH_TOKEN so `gh` CLI and existing
+// resolveGitHubTokenForActor() pick it up automatically.
+
+let refreshTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Fetch a GitHub installation token from the cloud API and set it in process.env.
+ * Returns true if a token was obtained, false if GitHub isn't connected.
+ */
+async function fetchAndSet(): Promise<boolean> {
+  const cloudUrl = (process.env.REFLECTT_CLOUD_URL || '').replace(/\/+$/, '')
+  const hostId = process.env.REFLECTT_HOST_ID
+  const credential = process.env.REFLECTT_HOST_CREDENTIAL
+  if (!cloudUrl || !hostId || !credential) return false
+
+  try {
+    const res = await fetch(`${cloudUrl}/api/hosts/${hostId}/github/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${credential}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    if (res.status === 404) return false // GitHub not connected on this team
+    if (!res.ok) {
+      console.warn(`[github-cloud-token] Failed to fetch token: ${res.status} ${await res.text().catch(() => '')}`)
+      return false
+    }
+    const { token, expires_at } = await res.json() as { token: string; expires_at: string }
+    process.env.GITHUB_TOKEN = token
+    process.env.GH_TOKEN = token
+    console.log(`[github-cloud-token] Token set, expires ${expires_at}`)
+    return true
+  } catch (err) {
+    console.warn('[github-cloud-token] Error fetching token:', err)
+    return false
+  }
+}
+
+/**
+ * Start the GitHub token refresh loop.
+ * Fetches immediately, then refreshes every 50 minutes (tokens expire after 1 hour).
+ */
+export async function startGitHubTokenRefresh(): Promise<void> {
+  // Don't override an explicitly provided token
+  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
+    console.log('[github-cloud-token] GITHUB_TOKEN already set, skipping cloud token refresh')
+    return
+  }
+
+  const ok = await fetchAndSet()
+  if (!ok) {
+    console.log('[github-cloud-token] GitHub not connected or cloud not available — agents will work without GitHub access')
+    return
+  }
+
+  // Refresh every 50 minutes
+  refreshTimer = setInterval(() => {
+    fetchAndSet().catch(() => {})
+  }, 50 * 60 * 1000)
+  // Don't keep the process alive just for this timer
+  if (refreshTimer.unref) refreshTimer.unref()
+}
+
+export function stopGitHubTokenRefresh(): void {
+  if (refreshTimer) {
+    clearInterval(refreshTimer)
+    refreshTimer = null
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,6 +103,7 @@ import { recordUsage as recordUsageTracking, recordUsageBatch, getUsageSummary, 
 import { getTeamConfigHealth } from './team-config.js'
 import { SecretVault } from './secrets.js'
 import { initGitHubActorAuth, resolveGitHubTokenForActor } from './github-actor-auth.js'
+import { startGitHubTokenRefresh } from './github-cloud-token.js'
 import { approvePullRequest, githubWhoami } from './github-reviews.js'
 import type { GitHubIdentityProvider } from './github-identity.js'
 import { computeCiFromCheckRuns, computeCiFromCombinedStatus } from './github-ci.js'
@@ -2312,6 +2313,9 @@ export async function createServer(): Promise<FastifyInstance> {
   } catch (err) {
     console.error('[Vault] Failed to initialize:', (err as Error).message)
   }
+
+  // Fetch GitHub installation token from cloud API (if GitHub App connected on team)
+  startGitHubTokenRefresh().catch(err => console.warn('[GitHubCloudToken] Init error:', err))
 
   // Initialize GitHub identity provider (PAT env fallback + optional GitHub App installation token mode)
   // v1: per-node/team configuration via env vars; secrets stored in SecretVault.


### PR DESCRIPTION
## Summary
- Adds `src/github-cloud-token.ts` — fetches a short-lived GitHub installation token from the cloud API on startup and refreshes every 50 min
- Sets `GITHUB_TOKEN`/`GH_TOKEN` in process.env so `gh` CLI and `resolveGitHubTokenForActor()` pick it up automatically
- Adds `gh` CLI, `curl`, and `git` to the Docker runtime image so agents can create PRs, manage issues, etc.

Depends on the cloud API side: `POST /api/hosts/:hostId/github/token` endpoint (separate PR in reflectt-cloud).

## Test plan
- [ ] Type check passes (`tsc --noEmit`)
- [ ] Node starts and logs `[github-cloud-token] Token set, expires ...` when team has GitHub connected
- [ ] Node logs skip message when `GITHUB_TOKEN` already set or GitHub not connected
- [ ] Agent can run `gh pr list` successfully with the auto-fetched token
- [ ] Docker build succeeds with `gh --version` available at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)