### PR TITLE
fix(docker): add ca-certificates for gh CLI install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpango-1.0-0 \
     libcairo2 \
     libasound2 \
-    curl git \
+    ca-certificates curl git \
   && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) — agents use it to create PRs, manage issues


### PR DESCRIPTION
## Summary
- Adds `ca-certificates` to the apt-get install in the runtime stage
- Fixes Docker build failure: `curl: (77) error setting certificate file` when fetching GitHub CLI keyring
- `node:22-slim` doesn't include ca-certificates by default

Follow-up fix for reflectt/reflectt-node#1249.

## Test plan
- [ ] Docker publish GitHub Action succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)