### PR TITLE
feat: preview approval merge gate

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -850,6 +850,8 @@ Autonomous work-continuity system. Monitors agent queue floors and auto-replenis
 | GET | `/execution-health` | Execution sweeper status: validating queue violations, SLA breaches, escalation tracking. |
 | POST | `/pr-event` | PR state webhook. Body: `{ taskId, prState: "merged"|"closed", prUrl? }`. Auto-updates task artifacts on merge, auto-blocks on close. |
 | GET | `/pr-automerge/status` | PR auto-merge attempt log: recent merge/close attempts with summary counts (attempted, success, failed, skipped, auto-close, close-gate-fail). |
+| GET | `/merge-gate/check/:owner/:repo/:prNumber` | Check if a PR has preview approval. Returns `{ approved: boolean, repo, prNumber }`. Checks both exact repo match and wildcard approvals. |
+| GET | `/merge-gate/approvals` | List all recorded preview approvals (diagnostics). Returns `{ approvals: [{ key, approvedAt, approver }] }`. |
 | GET | `/drift-report` | Task/PR drift report: tasks with merged PRs still in validating, orphan PRs, state mismatches. |
 | POST | `/activation/event` | Record activation funnel event. Body: `{ type, userId, metadata? }`. Events: signup_completed, host_preflight_passed, host_preflight_failed, workspace_ready, first_task_started, first_task_completed, first_team_message_sent, day2_return_action. |
 | GET | `/activation/doctor-gate` | Check whether the BYOH onboarding doctor-gate has been passed for a user. Query: `?userId=...`. Returns `{ passed: boolean, events: ActivationEvent[] }`. Used by cloud onboarding to gate progression to workspace-ready step. |

--- a/scripts/merge-gate-hook.sh
+++ b/scripts/merge-gate-hook.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# merge-gate-hook.sh — Claude Code PreToolUse hook for Bash
+#
+# Intercepts `gh pr merge` commands and checks the node's merge-gate API
+# to ensure preview approval exists before allowing the merge.
+#
+# Install as a Claude Code PreToolUse hook (matcher: Bash) in the agent's
+# settings.json or .claude/settings.json:
+#
+#   "hooks": {
+#     "PreToolUse": [{
+#       "matcher": "Bash",
+#       "hooks": [{
+#         "type": "command",
+#         "command": "/path/to/merge-gate-hook.sh"
+#       }]
+#     }]
+#   }
+#
+# Reads JSON on stdin: { "tool_name": "Bash", "tool_input": { "command": "..." } }
+# Outputs JSON to block: { "decision": "block", "reason": "..." }
+
+set -euo pipefail
+
+# Read stdin (Claude Code hook input)
+INPUT=$(cat)
+
+# Extract the bash command
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only gate `gh pr merge` commands
+if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+merge\b'; then
+  exit 0
+fi
+
+# Extract PR number and repo from the command
+PR_NUMBER=$(echo "$COMMAND" | grep -oE '\bgh\s+pr\s+merge\s+(\S+)' | awk '{print $NF}')
+REPO=$(echo "$COMMAND" | grep -oE '--repo\s+(\S+)' | awk '{print $2}')
+
+if [ -z "$PR_NUMBER" ]; then
+  exit 0  # Can't parse — let it through, will fail naturally
+fi
+
+# Use NODE_API_BASE if set, otherwise default to localhost
+NODE_API=${NODE_API_BASE:-http://localhost:3000}
+
+# Check the merge gate API (route: /merge-gate/check/:owner/:repo/:prNumber)
+if [ -n "$REPO" ]; then
+  GATE_URL="${NODE_API}/merge-gate/check/${REPO}/${PR_NUMBER}"
+else
+  GATE_URL="${NODE_API}/merge-gate/check/*/*/${PR_NUMBER}"
+fi
+
+RESPONSE=$(curl -sf "$GATE_URL" 2>/dev/null || echo '{"approved":false}')
+APPROVED=$(echo "$RESPONSE" | jq -r '.approved // false')
+
+if [ "$APPROVED" = "true" ]; then
+  exit 0
+fi
+
+# Block the merge
+cat <<EOF
+{"decision":"block","reason":"[MergeGate] PR #${PR_NUMBER} has no preview approval. A 'Looks good' message in the canvas preview thread is required before merging. Ask the team to review the preview first."}
+EOF

--- a/src/prAutoMerge.ts
+++ b/src/prAutoMerge.ts
@@ -54,6 +54,29 @@ export interface MergeAttemptLog {
   detail: string
 }
 
+// ── Preview Approval Gate ──────────────────────────────────────────────────
+// Tracks preview approvals from canvas "Looks good" messages.
+// Merge is blocked unless the PR has a recorded approval.
+
+const previewApprovals = new Map<string, { approvedAt: number; approver: string }>()
+
+/** Record a preview approval for a PR (called when "Looks good" message arrives) */
+export function recordPreviewApproval(repo: string, prNumber: number, approver: string): void {
+  const key = `${repo}#${prNumber}`
+  previewApprovals.set(key, { approvedAt: Date.now(), approver })
+  console.log(`[MergeGate] Preview approved: ${key} by ${approver}`)
+}
+
+/** Check if a PR has been preview-approved */
+export function hasPreviewApproval(repo: string, prNumber: number): boolean {
+  return previewApprovals.has(`${repo}#${prNumber}`)
+}
+
+/** Get all preview approvals (for diagnostics) */
+export function getPreviewApprovals(): Array<{ key: string; approvedAt: number; approver: string }> {
+  return [...previewApprovals.entries()].map(([key, v]) => ({ key, ...v }))
+}
+
 // ── State ──────────────────────────────────────────────────────────────────
 
 const mergeAttemptLog: MergeAttemptLog[] = []
@@ -186,10 +209,17 @@ export function checkPrMergeability(prUrl: string): PrMergeability {
 
 // ── Attempt Auto-Merge ─────────────────────────────────────────────────────
 
-export function attemptAutoMerge(prUrl: string): MergeAttemptResult {
+export function attemptAutoMerge(prUrl: string, { skipPreviewGate = false } = {}): MergeAttemptResult {
   const parsed = parsePrUrl(prUrl)
   if (!parsed) {
     return { success: false, error: 'Invalid PR URL format', mergeCommitSha: null }
+  }
+
+  // Preview approval gate — block merge unless approved via canvas thread
+  if (!skipPreviewGate && !hasPreviewApproval(parsed.repo, parsed.prNumber) && !hasPreviewApproval('*', parsed.prNumber)) {
+    const msg = `[MergeGate] Blocked: PR ${parsed.repo}#${parsed.prNumber} has no preview approval. A "Looks good" message in the canvas thread is required before merging.`
+    console.log(msg)
+    return { success: false, error: msg, mergeCommitSha: null }
   }
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,7 +63,7 @@ import { presenceManager } from './presence.js'
 import type { NotificationType, NotificationPriorityLevel, AckDecision, NotificationStatus } from './agent-notifications.js'
 import { startSweeper, getSweeperStatus, sweepValidatingQueue, flagPrDrift, generateDriftReport } from './executionSweeper.js'
 import { runRestartDriftGuard } from './restart-drift-guard.js'
-import { autoPopulateCloseGate, tryAutoCloseTask, getMergeAttemptLog } from './prAutoMerge.js'
+import { autoPopulateCloseGate, tryAutoCloseTask, getMergeAttemptLog, hasPreviewApproval, getPreviewApprovals } from './prAutoMerge.js'
 import { getDuplicateClosureCanonicalRefError } from './duplicateClosureGuard.js'
 import { recordReviewMutation, diffReviewFields, getAuditEntries, loadAuditLedger } from './auditLedger.js'
 import { listSharedFiles, readSharedFile, resolveTaskArtifact, validatePath, ALLOWED_EXTENSIONS } from './shared-workspace-api.js'
@@ -4602,6 +4602,24 @@ export async function createServer(): Promise<FastifyInstance> {
           }
         } catch (err) {
           app.log.warn({ err, signal: detection.signal }, '[ChatApproval] Failed to apply approval')
+        }
+      }
+    }
+
+    // Preview approval gate: detect "Previewed ... looks good. Please merge" messages
+    // and record the approval so the merge gate allows the PR to be merged.
+    if (data.content) {
+      const previewApprovalMatch = data.content.match(/looks good\.?\s+Please merge.*?(?:PR|pull request)\b/i)
+      const prRefMatch = data.content.match(/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/)
+        || data.content.match(/PR\s*#?(\d+)/i)
+      if (previewApprovalMatch && prRefMatch) {
+        const { recordPreviewApproval } = await import('./prAutoMerge.js')
+        if (prRefMatch[2]) {
+          // Full github URL match: owner/repo and PR number
+          recordPreviewApproval(prRefMatch[1], parseInt(prRefMatch[2], 10), data.from)
+        } else if (prRefMatch[1]) {
+          // PR #N match without repo — record with wildcard repo
+          recordPreviewApproval('*', parseInt(prRefMatch[1], 10), data.from)
         }
       }
     }
@@ -17741,6 +17759,22 @@ If your heartbeat shows **no active task** and **no next task**:
         closeGateFail: log.filter(l => l.action === 'close_gate_fail').length,
       },
     }
+  })
+
+  // GET /merge-gate/check/:owner/:repo/:prNumber — check if PR has preview approval
+  app.get<{ Params: { owner: string; repo: string; prNumber: string } }>('/merge-gate/check/:owner/:repo/:prNumber', async (request) => {
+    const { owner, repo, prNumber } = request.params
+    const fullRepo = `${owner}/${repo}`
+    const prNum = parseInt(prNumber, 10)
+    if (isNaN(prNum)) return { approved: false, error: 'Invalid PR number' }
+    // Check both exact repo match and wildcard
+    const approved = hasPreviewApproval(fullRepo, prNum) || hasPreviewApproval('*', prNum)
+    return { approved, repo: fullRepo, prNumber: prNum }
+  })
+
+  // GET /merge-gate/approvals — list all recorded preview approvals (diagnostics)
+  app.get('/merge-gate/approvals', async () => {
+    return { approvals: getPreviewApprovals() }
   })
 
   // ── Calendar API ──────────────────────────────────────────────────────────

--- a/tests/pr-automerge.test.ts
+++ b/tests/pr-automerge.test.ts
@@ -13,6 +13,7 @@ import {
   generateRemediation,
   getMergeAttemptLog,
   _clearMergeabilityCache,
+  recordPreviewApproval,
 } from '../src/prAutoMerge.js'
 import { taskManager } from '../src/tasks.js'
 
@@ -205,7 +206,7 @@ describe('PR Auto-Merge', () => {
       mockExecSync.mockReturnValueOnce('' as any) // merge
       mockExecSync.mockReturnValueOnce('abc1234def5678' as any) // get SHA
 
-      const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42')
+      const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42', { skipPreviewGate: true })
       expect(result.success).toBe(true)
       expect(result.error).toBeNull()
       expect(result.mergeCommitSha).toBe('abc1234def5678')
@@ -216,9 +217,24 @@ describe('PR Auto-Merge', () => {
       error.stderr = Buffer.from('PR has merge conflicts')
       mockExecSync.mockImplementationOnce(() => { throw error })
 
-      const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42')
+      const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42', { skipPreviewGate: true })
       expect(result.success).toBe(false)
       expect(result.error).toContain('PR has merge conflicts')
+    })
+
+    it('blocks merge without preview approval', () => {
+      const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42')
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('[MergeGate] Blocked')
+    })
+
+    it('allows merge with preview approval', () => {
+      recordPreviewApproval('reflectt/reflectt-node', 42, 'test-user')
+      mockExecSync.mockReturnValueOnce('' as any) // merge
+      mockExecSync.mockReturnValueOnce('abc1234def5678' as any) // get SHA
+
+      const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42')
+      expect(result.success).toBe(true)
     })
 
     it('returns failure for invalid PR URL', () => {
@@ -358,6 +374,8 @@ describe('PR Auto-Merge', () => {
   describe('processAutoMerge (sweep integration)', () => {
     it('attempts merge for green+approved PR', async () => {
       const prUrl = 'https://github.com/reflectt/reflectt-node/pull/99'
+      // Register preview approval so merge gate allows it
+      recordPreviewApproval('reflectt/reflectt-node', 99, 'test-user')
       const taskId = await createValidatingTask('sweep-merge', {
         pr_url: prUrl,
         reviewer_approved: true,


### PR DESCRIPTION
## Summary
- Adds a node-level merge gate that blocks agent PR merges unless the PR has a canvas preview approval
- attemptAutoMerge() now checks hasPreviewApproval() before proceeding
- Chat message handler detects approval patterns and records them with repo and PR number
- New API endpoints for external gate checks and diagnostics
- Includes a PreToolUse hook script to gate agent merge bash commands via the API

## Test plan
- [ ] Deploy to staging node
- [ ] Verify attemptAutoMerge() blocks without approval
- [ ] Send approval message in canvas chat, verify approval recorded
- [ ] Verify merge succeeds after approval
- [ ] Test /merge-gate/approvals returns recorded approvals