### PR TITLE
feat: expose cloud GitHub token via API for agent-shell auth

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -852,6 +852,7 @@ Autonomous work-continuity system. Monitors agent queue floors and auto-replenis
 | GET | `/pr-automerge/status` | PR auto-merge attempt log: recent merge/close attempts with summary counts (attempted, success, failed, skipped, auto-close, close-gate-fail). |
 | GET | `/merge-gate/check/:owner/:repo/:prNumber` | Check if a PR has preview approval. Returns `{ approved: boolean, repo, prNumber }`. Checks both exact repo match and wildcard approvals. |
 | GET | `/merge-gate/approvals` | List all recorded preview approvals (diagnostics). Returns `{ approvals: [{ key, approvedAt, approver }] }`. |
+| GET | `/github/token` | Get the cloud-refreshed GitHub installation token. Returns `{ available: true, token }` or `{ available: false, error }`. Used by gateway/agent startup to set GH_TOKEN. |
 | GET | `/drift-report` | Task/PR drift report: tasks with merged PRs still in validating, orphan PRs, state mismatches. |
 | POST | `/activation/event` | Record activation funnel event. Body: `{ type, userId, metadata? }`. Events: signup_completed, host_preflight_passed, host_preflight_failed, workspace_ready, first_task_started, first_task_completed, first_team_message_sent, day2_return_action. |
 | GET | `/activation/doctor-gate` | Check whether the BYOH onboarding doctor-gate has been passed for a user. Query: `?userId=...`. Returns `{ passed: boolean, events: ActivationEvent[] }`. Used by cloud onboarding to gate progression to workspace-ready step. |

--- a/src/github-cloud-token.ts
+++ b/src/github-cloud-token.ts
@@ -64,6 +64,11 @@ export async function startGitHubTokenRefresh(): Promise<void> {
   if (refreshTimer.unref) refreshTimer.unref()
 }
 
+/** Get the current cloud-refreshed GitHub token (if any). */
+export function getCloudGitHubToken(): string | null {
+  return process.env.GH_TOKEN || process.env.GITHUB_TOKEN || null
+}
+
 export function stopGitHubTokenRefresh(): void {
   if (refreshTimer) {
     clearInterval(refreshTimer)

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,7 +103,7 @@ import { recordUsage as recordUsageTracking, recordUsageBatch, getUsageSummary, 
 import { getTeamConfigHealth } from './team-config.js'
 import { SecretVault } from './secrets.js'
 import { initGitHubActorAuth, resolveGitHubTokenForActor } from './github-actor-auth.js'
-import { startGitHubTokenRefresh } from './github-cloud-token.js'
+import { startGitHubTokenRefresh, getCloudGitHubToken } from './github-cloud-token.js'
 import { approvePullRequest, githubWhoami } from './github-reviews.js'
 import type { GitHubIdentityProvider } from './github-identity.js'
 import { computeCiFromCheckRuns, computeCiFromCombinedStatus } from './github-ci.js'
@@ -17775,6 +17775,16 @@ If your heartbeat shows **no active task** and **no next task**:
   // GET /merge-gate/approvals — list all recorded preview approvals (diagnostics)
   app.get('/merge-gate/approvals', async () => {
     return { approvals: getPreviewApprovals() }
+  })
+
+  // GET /github/token — expose the cloud-refreshed GitHub installation token
+  // Used by gateway/agent startup to set GH_TOKEN before spawning Claude Code.
+  app.get('/github/token', async () => {
+    const token = getCloudGitHubToken()
+    if (!token) {
+      return { available: false, error: 'No GitHub token available — cloud token refresh may not be configured' }
+    }
+    return { available: true, token }
   })
 
   // ── Calendar API ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds GET /github/token endpoint that returns the cloud-refreshed GitHub installation token
- Gateway/agent startup can fetch this token and set GH_TOKEN before spawning Claude Code
- Bridges the gap where the node process has a valid token via cloud refresh but agent shells don't inherit it

## Context
The cloud token refresh (github-cloud-token.ts) sets process.env.GH_TOKEN inside the node's Node.js process. This works for attemptAutoMerge() which runs via execSync. But agents (like genesis) run as separate Claude Code processes on the gateway with their own environment. This endpoint lets the gateway fetch the token at startup.

## Test plan
- [ ] Deploy to staging node
- [ ] Verify GET /github/token returns a valid token
- [ ] Wire gateway startup to fetch and set GH_TOKEN
- [ ] Verify genesis can run gh pr merge with the fetched token