### PR TITLE
Remove wildcard merge approval, require PR-scoped

### DIFF
--- a/src/prAutoMerge.ts
+++ b/src/prAutoMerge.ts
@@ -216,8 +216,8 @@ export function attemptAutoMerge(prUrl: string, { skipPreviewGate = false } = {}
   }
 
   // Preview approval gate — block merge unless approved via canvas thread
-  // Check: exact repo+PR, wildcard repo with exact PR, or wildcard approval (PR 0 = any PR)
-  if (!skipPreviewGate && !hasPreviewApproval(parsed.repo, parsed.prNumber) && !hasPreviewApproval('*', parsed.prNumber) && !hasPreviewApproval('*', 0)) {
+  // Check: exact repo+PR, or wildcard repo with exact PR number
+  if (!skipPreviewGate && !hasPreviewApproval(parsed.repo, parsed.prNumber) && !hasPreviewApproval('*', parsed.prNumber)) {
     const msg = `[MergeGate] Blocked: PR ${parsed.repo}#${parsed.prNumber} has no preview approval. A "Looks good" message in the canvas thread is required before merging.`
     console.log(msg)
     return { success: false, error: msg, mergeCommitSha: null }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4621,10 +4621,8 @@ export async function createServer(): Promise<FastifyInstance> {
           // PR #N match without repo — record with wildcard repo
           recordPreviewApproval('*', parseInt(prRefMatch[1], 10), data.from)
         } else {
-          // No PR number in message (e.g. "looks good. Please merge the associated PR")
-          // Record a wildcard approval — the next merge attempt for any PR will be allowed
-          recordPreviewApproval('*', 0, data.from)
-          console.log(`[MergeGate] Wildcard approval recorded from ${data.from} (no PR number in message)`)
+          // No PR number in message — cannot create scoped approval
+          console.log(`[MergeGate] Skipped approval from ${data.from} — no PR number found in message`)
         }
       }
     }


### PR DESCRIPTION
## Summary
- Remove the `*#0` wildcard approval fallback from `attemptAutoMerge()` — approvals now require a specific PR number
- Node-side approval detection skips recording when no PR number is found in the message (instead of recording a wildcard)
- Companion to reflectt/reflectt-cloud#2590 that includes PR URLs in "Looks good" messages

## Test plan
- [ ] All 32 existing tests pass
- [ ] Merge gate blocks PRs without a scoped approval
- [ ] Merge gate allows PRs with exact repo+PR or wildcard-repo+PR approval
- [ ] E2E proof: normal request → preview → "Looks good" with PR URL → scoped approval → merge succeeds

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>