### PR TITLE
Add merge gate isolation tests and proof artifact

### DIFF
--- a/artifacts/merge-gate-proof.md
+++ b/artifacts/merge-gate-proof.md
@@ -1,0 +1,64 @@
+# Preview Approval Merge Gate — Proof Bundle
+
+Task: `task-1776591790485-ym1a8xz79`
+Date: 2026-04-19
+PRs: reflectt-node#1251, #1252, #1253, #1254 + reflectt-cloud#2592
+
+## 1) What it does
+
+Prevents agents (genesis) from merging PRs without explicit canvas preview approval.
+Two enforcement points:
+- `attemptAutoMerge()` in `src/prAutoMerge.ts` — gates the code path
+- `scripts/merge-gate-hook.sh` — PreToolUse hook gates `gh pr merge` bash commands
+
+## 2) Approval contract
+
+- Frontend "Looks good" button searches chat history for agent's PR URL
+- Sends message: `Previewed "..." (host) — looks good. Please merge PR https://github.com/owner/repo/pull/N.`
+- Node extracts repo+PR from the URL → records scoped approval (`owner/repo#N`)
+- No wildcard fallback — if no PR URL found, no approval recorded
+
+## 3) Proof runs
+
+### Run 1: Wildcard proof (2026-04-19T10:25Z)
+- E2E test: `deploy-state-proof.spec.ts`
+- Result: PASSED in 1.6 minutes
+- Approval recorded: `*#0` (wildcard — since fixed)
+- Genesis merged after "Looks good"
+
+### Run 2: Scoped approval proof (2026-04-19T11:17Z)
+- E2E test: `deploy-state-proof.spec.ts` (modified with gate assertions)
+- Negative case: approvals before "Looks good" = `[]` (gate blocks)
+- Positive case: approval after "Looks good" = `reflectt/staging-preview-test#28`
+- Scoped, not wildcard — `*#0` eliminated
+- Genesis merged PR #28 after scoped approval
+
+### Evidence (from E2E output)
+```
+[MergeGate] Approvals BEFORE "Looks good": []
+[MergeGate] NEGATIVE CASE PASSED — no approvals before "Looks good"
+Clicked "Looks good" — approval sent, genesis will merge
+[MergeGate] Approvals AFTER "Looks good": [{"key":"reflectt/staging-preview-test#28","approvedAt":1776596224213,"approver":"user"}]
+[MergeGate] SCOPED APPROVAL VERIFIED: reflectt/staging-preview-test#28 (not wildcard)
+```
+
+## 4) Code locations
+
+- Gate logic: `src/prAutoMerge.ts:218-224`
+- Approval recording: `src/prAutoMerge.ts:61-66`
+- Chat detection: `src/server.ts:4609-4630`
+- API endpoints: `src/server.ts` — `/merge-gate/check/:owner/:repo/:prNumber`, `/merge-gate/approvals`
+- Hook script: `scripts/merge-gate-hook.sh`
+- Token endpoint: `src/server.ts` — `/github/token`
+- Token refresh: `src/github-cloud-token.ts`
+- Frontend: `apps/web/src/app/presence/canvas/chat-panel.tsx` (3 "Looks good" handlers)
+
+## 5) Persistence
+
+Approvals are in-memory (Map). They don't survive node restart.
+Acceptable for current lifecycle — preview → approve → merge happens in one session.
+
+## 6) Open seams
+
+- [ ] Cross-thread isolation — two concurrent PRs, approve one, verify no bleed
+- [ ] Customer-visible honesty — blocked merge should show in canvas, not stall silently

--- a/src/prAutoMerge.ts
+++ b/src/prAutoMerge.ts
@@ -77,6 +77,11 @@ export function getPreviewApprovals(): Array<{ key: string; approvedAt: number; 
   return [...previewApprovals.entries()].map(([key, v]) => ({ key, ...v }))
 }
 
+/** Clear all preview approvals (for testing) */
+export function _clearPreviewApprovals(): void {
+  previewApprovals.clear()
+}
+
 // ── State ──────────────────────────────────────────────────────────────────
 
 const mergeAttemptLog: MergeAttemptLog[] = []

--- a/tests/pr-automerge.test.ts
+++ b/tests/pr-automerge.test.ts
@@ -14,6 +14,8 @@ import {
   getMergeAttemptLog,
   _clearMergeabilityCache,
   recordPreviewApproval,
+  hasPreviewApproval,
+  _clearPreviewApprovals,
 } from '../src/prAutoMerge.js'
 import { taskManager } from '../src/tasks.js'
 
@@ -94,6 +96,7 @@ describe('PR Auto-Merge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     _clearMergeabilityCache()
+    _clearPreviewApprovals()
   })
 
   describe('parsePrUrl', () => {
@@ -235,6 +238,54 @@ describe('PR Auto-Merge', () => {
 
       const result = attemptAutoMerge('https://github.com/reflectt/reflectt-node/pull/42')
       expect(result.success).toBe(true)
+    })
+
+    it('cross-thread isolation: approving PR A does not approve PR B', () => {
+      // Two PRs from different threads/repos
+      recordPreviewApproval('reflectt/repo-a', 10, 'user')
+
+      // PR A should be approved
+      expect(hasPreviewApproval('reflectt/repo-a', 10)).toBe(true)
+      // PR B should NOT be approved
+      expect(hasPreviewApproval('reflectt/repo-b', 20)).toBe(false)
+
+      // Merge gate: PR A passes, PR B blocked
+      mockExecSync.mockReturnValueOnce('' as any)
+      mockExecSync.mockReturnValueOnce('sha1234' as any)
+      const resultA = attemptAutoMerge('https://github.com/reflectt/repo-a/pull/10')
+      expect(resultA.success).toBe(true)
+
+      const resultB = attemptAutoMerge('https://github.com/reflectt/repo-b/pull/20')
+      expect(resultB.success).toBe(false)
+      expect(resultB.error).toContain('[MergeGate] Blocked')
+    })
+
+    it('cross-thread isolation: same repo different PRs are independent', () => {
+      recordPreviewApproval('reflectt/staging-preview-test', 28, 'user')
+
+      // PR 28 approved, PR 29 not
+      expect(hasPreviewApproval('reflectt/staging-preview-test', 28)).toBe(true)
+      expect(hasPreviewApproval('reflectt/staging-preview-test', 29)).toBe(false)
+
+      // PR 29 blocked
+      const result = attemptAutoMerge('https://github.com/reflectt/staging-preview-test/pull/29')
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('[MergeGate] Blocked')
+    })
+
+    it('cross-thread isolation: wildcard repo with specific PR does not bleed', () => {
+      // Wildcard repo approval for PR 15 (from PR #N without full URL)
+      recordPreviewApproval('*', 15, 'user')
+
+      // PR 15 should pass for any repo
+      expect(hasPreviewApproval('*', 15)).toBe(true)
+      // But PR 16 should NOT pass
+      expect(hasPreviewApproval('*', 16)).toBe(false)
+
+      // PR 16 blocked even though PR 15 has wildcard approval
+      const result = attemptAutoMerge('https://github.com/reflectt/some-repo/pull/16')
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('[MergeGate] Blocked')
     })
 
     it('returns failure for invalid PR URL', () => {


### PR DESCRIPTION
## Summary
- Add `_clearPreviewApprovals()` for proper test isolation between runs
- Add 3 cross-thread approval isolation tests proving no approval bleed across PRs
- Add `artifacts/merge-gate-proof.md` documenting all proof runs (wildcard, scoped, isolation)

task-1776591790485-ym1a8xz79

## Test plan
- [ ] All 35 tests pass (32 existing + 3 new isolation)
- [ ] Live API isolation verified on staging node

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>