### PR TITLE
Persist merge gate approvals to disk

### DIFF
--- a/src/prAutoMerge.ts
+++ b/src/prAutoMerge.ts
@@ -57,14 +57,51 @@ export interface MergeAttemptLog {
 // ── Preview Approval Gate ──────────────────────────────────────────────────
 // Tracks preview approvals from canvas "Looks good" messages.
 // Merge is blocked unless the PR has a recorded approval.
+// Approvals are persisted to disk so they survive node restarts.
 
+import { join } from 'node:path'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { DATA_DIR } from './config.js'
+
+const APPROVALS_FILE = join(DATA_DIR, 'merge-gate-approvals.json')
 const previewApprovals = new Map<string, { approvedAt: number; approver: string }>()
+
+/** Load persisted approvals from disk on startup */
+function loadApprovals(): void {
+  try {
+    const raw = readFileSync(APPROVALS_FILE, 'utf-8')
+    const entries = JSON.parse(raw) as Array<{ key: string; approvedAt: number; approver: string }>
+    for (const entry of entries) {
+      previewApprovals.set(entry.key, { approvedAt: entry.approvedAt, approver: entry.approver })
+    }
+    if (entries.length > 0) {
+      console.log(`[MergeGate] Loaded ${entries.length} persisted approval(s) from disk`)
+    }
+  } catch {
+    // File doesn't exist or is invalid — start fresh
+  }
+}
+
+/** Persist current approvals to disk */
+function persistApprovals(): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true })
+    const entries = [...previewApprovals.entries()].map(([key, v]) => ({ key, ...v }))
+    writeFileSync(APPROVALS_FILE, JSON.stringify(entries, null, 2))
+  } catch (err) {
+    console.warn('[MergeGate] Failed to persist approvals:', err)
+  }
+}
+
+// Load on module init
+loadApprovals()
 
 /** Record a preview approval for a PR (called when "Looks good" message arrives) */
 export function recordPreviewApproval(repo: string, prNumber: number, approver: string): void {
   const key = `${repo}#${prNumber}`
   previewApprovals.set(key, { approvedAt: Date.now(), approver })
   console.log(`[MergeGate] Preview approved: ${key} by ${approver}`)
+  persistApprovals()
 }
 
 /** Check if a PR has been preview-approved */


### PR DESCRIPTION
## Summary
- Preview approvals now persist to DATA_DIR/merge-gate-approvals.json
- On startup, approvals are loaded from disk
- On each new approval, the file is written synchronously
- Approvals survive node restarts on Fly.io persistent volumes

task-1776591790485-ym1a8xz79

## Test plan
- All 35 existing tests pass
- Deploy to staging, record an approval, restart node, verify approval survives
- Verify merge gate still correctly blocks unapproved PRs after restart