### PR TITLE
feat: seed avatars when team roles bootstrap

### DIFF
--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -248,33 +248,44 @@ ${shapes}
 </svg>`
 }
 
+function ensureAgentAvatar(agentId: string): boolean {
+  const existing = getAgentConfig(agentId)
+  const currentAvatar = (existing?.settings as Record<string, unknown> | undefined)?.avatar as Record<string, unknown> | undefined
+  if (typeof currentAvatar?.content === 'string' && currentAvatar.content.trim()) return false
+
+  const settings = { ...(existing?.settings || {}) } as Record<string, unknown>
+  settings.avatar = {
+    type: 'svg',
+    content: generateAvatarSvg(agentId),
+    updatedAt: Date.now(),
+    source: 'bootstrap-seed',
+  }
+
+  setAgentConfig(agentId, {
+    teamId: existing?.teamId ?? 'default',
+    model: existing?.model,
+    fallbackModel: existing?.fallbackModel,
+    costCapDaily: existing?.costCapDaily,
+    costCapMonthly: existing?.costCapMonthly,
+    maxTokensPerCall: existing?.maxTokensPerCall,
+    settings,
+  })
+  return true
+}
+
 /**
- * Seed avatars for all agents in TEAM-ROLES.yaml that don't have one yet.
- * Called once at startup after loadAgentRoles().
+ * Seed avatars for agent IDs provided by a TEAM-ROLES materialization event,
+ * or for all currently loaded roles when called without arguments.
  */
-export function seedAgentAvatars(): number {
-  const roles = getAgentRoles()
-  const db = getDb()
+export function seedAgentAvatars(agentIds?: string[]): number {
+  const targets = Array.isArray(agentIds) && agentIds.length > 0
+    ? agentIds
+    : getAgentRoles().map(role => role.name)
+
   let seeded = 0
-
-  for (const role of roles) {
-    const row = db.prepare('SELECT settings FROM agent_config WHERE agent_id = ?').get(role.name) as { settings: string } | undefined
-    const settings = row ? JSON.parse(row.settings || '{}') : {}
-
-    if (settings.avatar?.content) continue // already has an avatar
-
-    const svg = generateAvatarSvg(role.name)
-    settings.avatar = { type: 'svg', content: svg, updatedAt: Date.now() }
-
-    const now = Date.now()
-    if (row) {
-      db.prepare('UPDATE agent_config SET settings = ?, updated_at = ? WHERE agent_id = ?')
-        .run(JSON.stringify(settings), now, role.name)
-    } else {
-      db.prepare('INSERT INTO agent_config (agent_id, team_id, settings, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')
-        .run(role.name, 'default', JSON.stringify(settings), now, now)
-    }
-    seeded++
+  for (const agentId of targets) {
+    if (!agentId) continue
+    if (ensureAgentAvatar(agentId)) seeded++
   }
 
   if (seeded > 0) {

--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -5,6 +5,7 @@ import { readFileSync, writeFileSync, existsSync, watchFile, unwatchFile, statSy
 import { join } from 'path'
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import { REFLECTT_HOME } from './config.js'
+import { seedAgentAvatars } from './agent-config.js'
 
 export interface AgentRole {
   name: string
@@ -72,6 +73,15 @@ let loadedFromPath: string | null = null
 let lastMtime: number = 0
 let watchActive = false
 
+function seedRoleAvatars(roles: AgentRole[], source: string): void {
+  try {
+    const seeded = seedAgentAvatars(roles.map(role => role.name).filter(Boolean))
+    if (seeded > 0) console.log(`[Assignment] Seeded ${seeded} avatar(s) from ${source}`)
+  } catch (err) {
+    console.error('[Assignment] Avatar seeding failed (non-fatal):', (err as Error).message)
+  }
+}
+
 function parseRolesYaml(content: string): AgentRole[] {
   const data = parseYaml(content)
   if (!data?.agents || !Array.isArray(data.agents)) {
@@ -124,6 +134,7 @@ export function loadAgentRoles(): { roles: AgentRole[]; source: string } {
   if (isTest && testRolesOverride) {
     loadedRoles = testRolesOverride
     loadedFromPath = null
+    seedRoleAvatars(testRolesOverride, 'test-override')
     console.log(`[Assignment] Using ${testRolesOverride.length} test-override agent roles`)
     return { roles: testRolesOverride, source: 'test-override' }
   }
@@ -138,6 +149,7 @@ export function loadAgentRoles(): { roles: AgentRole[]; source: string } {
         try {
           lastMtime = statSync(configPath).mtimeMs
         } catch { /* ignore */ }
+        seedRoleAvatars(roles, configPath)
         console.log(`[Assignment] Loaded ${roles.length} agent roles from ${configPath}`)
         return { roles, source: configPath }
       }
@@ -151,6 +163,7 @@ export function loadAgentRoles(): { roles: AgentRole[]; source: string } {
     const bootstrapRoles: AgentRole[] = [{ name: 'main', role: 'bootstrap', description: 'Bootstrap agent — reads TEAM_INTENT and creates the team.', affinityTags: [], wipCap: 1 }]
     loadedRoles = bootstrapRoles
     loadedFromPath = 'TEAM_INTENT-bootstrap'
+    seedRoleAvatars(bootstrapRoles, 'TEAM_INTENT-bootstrap')
     console.log(`[Assignment] TEAM_INTENT detected — skipping default roster. Only bootstrap agent 'main' loaded.`)
     return { roles: bootstrapRoles, source: 'TEAM_INTENT-bootstrap' }
   }
@@ -160,6 +173,7 @@ export function loadAgentRoles(): { roles: AgentRole[]; source: string } {
   const source = testRolesOverride ? 'test-override' : 'builtin'
   loadedRoles = fallbackRoles
   loadedFromPath = null
+  seedRoleAvatars(fallbackRoles, source)
   console.log(`[Assignment] Using ${fallbackRoles.length} ${source} agent roles (no YAML found)`)
   return { roles: fallbackRoles, source }
 }
@@ -270,6 +284,7 @@ export function saveAgentRoles(roles: AgentRole[]): { saved: boolean; path: stri
   loadedRoles = roles
   loadedFromPath = targetPath
   lastMtime = statSync(targetPath).mtimeMs
+  seedRoleAvatars(roles, targetPath)
 
   return { saved: true, path: targetPath, version: Date.now() }
 }

--- a/tests/avatar-bootstrap-seeding.test.ts
+++ b/tests/avatar-bootstrap-seeding.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+describe('avatar bootstrap seeding', () => {
+  const originalEnv = { ...process.env }
+  let tempDir = ''
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'reflectt-avatar-seed-'))
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    vi.resetModules()
+    vi.unmock('../src/agent-config.js')
+    try { rmSync(tempDir, { recursive: true, force: true }) } catch { /* ignore */ }
+  })
+
+  async function importAssignmentWithSeedSpy() {
+    const calls: string[][] = []
+    process.env.REFLECTT_HOME = tempDir
+    process.env.NODE_ENV = 'development'
+    delete process.env.VITEST
+
+    vi.doMock('../src/agent-config.js', () => ({
+      seedAgentAvatars: vi.fn((ids: string[]) => {
+        calls.push([...ids])
+        return ids.length
+      }),
+    }))
+
+    const assignment = await import('../src/assignment.js')
+    return { assignment, calls }
+  }
+
+  it('seeds avatars when TEAM-ROLES loads from bootstrap output', async () => {
+    writeFileSync(join(tempDir, 'TEAM-ROLES.yaml'), `agents:\n  - name: kai\n    role: builder\n    affinityTags: [backend]\n    wipCap: 2\n  - name: link\n    role: ops\n    affinityTags: [infra]\n    wipCap: 2\n`, 'utf-8')
+
+    const { assignment, calls } = await importAssignmentWithSeedSpy()
+    const result = assignment.loadAgentRoles()
+
+    expect(result.roles.map(role => role.name)).toEqual(['kai', 'link'])
+    expect(calls).toEqual([['kai', 'link']])
+  })
+
+  it('seeds avatars when routing policy saves agent roles', async () => {
+    const { assignment, calls } = await importAssignmentWithSeedSpy()
+
+    assignment.saveAgentRoles([
+      { name: 'pixel', role: 'designer', affinityTags: ['ui'], wipCap: 1 },
+      { name: 'claude', role: 'analyst', affinityTags: ['docs'], wipCap: 1 },
+    ])
+
+    expect(calls).toEqual([['pixel', 'claude']])
+  })
+})


### PR DESCRIPTION
## Summary
- seed Reflectt-native avatars when agent roles are loaded or saved
- wire seeding into the managed-host TEAM-ROLES bootstrap/reload path, not just initial startup
- add a focused test that proves TEAM-ROLES load/save both trigger avatar seeding

## Why
`#2651` fixed canvas display fallback, but provisioned teams could still miss real avatars because TEAM-ROLES often lands after the node is already running. This moves seeding onto the Reflectt bootstrap/materialization path so new managed hosts get actual agent avatars without relying on canvas fallback or a restart.

## Verification
- `npm test -- tests/avatar-bootstrap-seeding.test.ts`
- `npm run build` *(currently fails on pre-existing unrelated Sentry typing issues in `src/sentry.ts`: missing `@sentry/node` resolution + implicit-any errors)*
