### PR TITLE
feat: add first-boot reset manage endpoint

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -220,6 +220,7 @@ If your deployment needs quiet-hours behavior today, enforce it in scheduler/gat
 | POST | `/manage/restart` | Remote management: graceful restart (Docker/systemd/CLI). Auth required. |
 | GET | `/manage/restart-context` | Read last restart context snapshot written on graceful restart. Auth required. Returns 404 if no snapshot exists. |
 | GET | `/manage/disk` | Remote management: data directory sizes. Auth required. |
+| POST | `/manage/reset-bootstrap` | Destructive bootstrap reset for managed-host reproof. Clears first-boot state, moves agents aside, deletes tasks, optionally restarts. Auth: manage token or host credential. Body: `{ confirm: "RESET_BOOTSTRAP", restart?: boolean }`. |
 | GET | `/browser/config` | Browser capability configuration (max sessions, rate limits, viewport). |
 | POST | `/browser/sessions` | Create a new isolated browser session. Body: `{ agent, url?, headless?, viewport? }`. Returns session object. |
 | GET | `/browser/sessions` | List all browser sessions (active and recent). |
@@ -1145,6 +1146,7 @@ Auth-gated endpoints for managing a reflectt-node instance remotely. Provide `RE
 | GET | `/manage/logs` | Bounded log tail. Query: `level` (error/warn/info), `since` (epoch ms), `limit` (max 200), `format=text` for plain text |
 | POST | `/manage/restart` | Graceful restart. Works with Docker, systemd, and reflectt CLI (PID file). Returns 501 if unsupported. |
 | GET | `/manage/disk` | Data directory sizes for capacity monitoring |
+| POST | `/manage/reset-bootstrap` | Destructive bootstrap reset. Clears `.first-boot-done`, moves agents aside, deletes tasks, optionally restarts. Body: `{ confirm: "RESET_BOOTSTRAP", restart?: boolean }`. Auth: manage token or host credential. |
 
 ### Agent Runs & Events
 

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -55,15 +55,15 @@ function checkManageAuth(request: FastifyRequest, reply: FastifyReply, opts?: { 
   reply.send({
     error: 'Forbidden: invalid manage token',
     hint: opts?.allowHostCredential
-      ? 'Provide x-manage-token or Authorization: Bearer <token> matching REFLECTT_MANAGE_TOKEN (or the managed host credential for reset-first-boot).'
+      ? 'Provide x-manage-token or Authorization: Bearer <token> matching REFLECTT_MANAGE_TOKEN (or the managed host credential for reset-bootstrap).'
       : 'Provide x-manage-token header or Authorization: Bearer <token> matching REFLECTT_MANAGE_TOKEN.',
   })
   return false
 }
 
-export const FIRST_BOOT_RESET_CONFIRM = 'RESET_FIRST_BOOT'
+export const BOOTSTRAP_RESET_CONFIRM = 'RESET_BOOTSTRAP'
 
-export interface FirstBootResetSummary {
+export interface BootstrapResetSummary {
   backupDir: string
   removedMarker: boolean
   movedAgentEntries: string[]
@@ -72,17 +72,17 @@ export interface FirstBootResetSummary {
   removedBackupDir: boolean
 }
 
-export async function resetFirstBootState(opts?: {
+export async function resetBootstrapState(opts?: {
   reflecttHome?: string
   dataDir?: string
   actor?: string
   now?: () => number
   listTasks?: () => Array<{ id: string }>
   deleteTask?: (taskId: string, actor: string) => Promise<boolean>
-}): Promise<FirstBootResetSummary> {
+}): Promise<BootstrapResetSummary> {
   const reflecttHome = opts?.reflecttHome || REFLECTT_HOME
   const dataDir = opts?.dataDir || DATA_DIR
-  const actor = opts?.actor || 'system-first-boot-reset'
+  const actor = opts?.actor || 'system-bootstrap-reset'
   const now = opts?.now || (() => Date.now())
 
   let importedTaskManager: Awaited<typeof import('./tasks.js')>['taskManager'] | null = null
@@ -352,21 +352,21 @@ export function registerManageRoutes(app: FastifyInstance, deps: {
     }, 500)
   })
 
-  // POST /manage/reset-first-boot — destructive bootstrap reset for managed-host reproof
-  app.post('/manage/reset-first-boot', async (request, reply) => {
+  // POST /manage/reset-bootstrap — destructive bootstrap reset for managed-host reproof
+  app.post('/manage/reset-bootstrap', async (request, reply) => {
     if (!checkManageAuth(request, reply, { allowHostCredential: true })) return
 
     const body = (request.body && typeof request.body === 'object') ? request.body as Record<string, unknown> : {}
-    if (body.confirm !== FIRST_BOOT_RESET_CONFIRM) {
+    if (body.confirm !== BOOTSTRAP_RESET_CONFIRM) {
       reply.code(400)
       return {
-        error: `confirm must equal ${FIRST_BOOT_RESET_CONFIRM}`,
-        hint: 'This endpoint is destructive. It clears first-boot markers, moves agent state aside, deletes live tasks, and optionally restarts the host.',
+        error: `confirm must equal ${BOOTSTRAP_RESET_CONFIRM}`,
+        hint: 'This endpoint is destructive. It clears bootstrap state, deletes stale bootstrap tasks if present, and optionally restarts the host.',
       }
     }
 
     const restart = body.restart !== false
-    const reset = await resetFirstBootState()
+    const reset = await resetBootstrapState()
     const method = restart ? detectRestartMethod() : null
 
     if (restart && !method) {

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -6,8 +6,8 @@
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { serverConfig, openclawConfig, isDev, REFLECTT_HOME, DATA_DIR } from './config.js'
-import { readFileSync, existsSync, statSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { readFileSync, existsSync, statSync, writeFileSync, mkdirSync, readdirSync, renameSync, rmSync } from 'fs'
+import { join, dirname } from 'path'
 
 // ── Auth helper ──────────────────────────────────────────────────────
 // Uses REFLECTT_MANAGE_TOKEN or falls back to REFLECTT_INSIGHT_MUTATION_TOKEN.
@@ -29,9 +29,15 @@ function isLoopback(request: FastifyRequest): boolean {
   return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1'
 }
 
-function checkManageAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+function checkManageAuth(request: FastifyRequest, reply: FastifyReply, opts?: { allowHostCredential?: boolean }): boolean {
   const requiredToken = process.env.REFLECTT_MANAGE_TOKEN || process.env.REFLECTT_INSIGHT_MUTATION_TOKEN
-  if (!requiredToken) {
+  const hostCredential = opts?.allowHostCredential ? process.env.REFLECTT_HOST_CREDENTIAL : undefined
+  const provided = extractToken(request)
+
+  if (requiredToken && provided === requiredToken) return true
+  if (hostCredential && provided === hostCredential) return true
+
+  if (!requiredToken && !hostCredential) {
     // No token configured — allow loopback only
     if (isLoopback(request)) return true
     reply.code(403)
@@ -42,18 +48,102 @@ function checkManageAuth(request: FastifyRequest, reply: FastifyReply): boolean 
     return false
   }
 
-  const provided = extractToken(request)
-  if (provided === requiredToken) return true
-
   // Allow loopback even with token configured (convenient for local dev)
   if (isLoopback(request)) return true
 
   reply.code(403)
   reply.send({
     error: 'Forbidden: invalid manage token',
-    hint: 'Provide x-manage-token header or Authorization: Bearer <token> matching REFLECTT_MANAGE_TOKEN.',
+    hint: opts?.allowHostCredential
+      ? 'Provide x-manage-token or Authorization: Bearer <token> matching REFLECTT_MANAGE_TOKEN (or the managed host credential for reset-first-boot).'
+      : 'Provide x-manage-token header or Authorization: Bearer <token> matching REFLECTT_MANAGE_TOKEN.',
   })
   return false
+}
+
+export const FIRST_BOOT_RESET_CONFIRM = 'RESET_FIRST_BOOT'
+
+export interface FirstBootResetSummary {
+  backupDir: string
+  removedMarker: boolean
+  movedAgentEntries: string[]
+  removedTeamRoles: boolean
+  deletedTaskIds: string[]
+  removedBackupDir: boolean
+}
+
+export async function resetFirstBootState(opts?: {
+  reflecttHome?: string
+  dataDir?: string
+  actor?: string
+  now?: () => number
+  listTasks?: () => Array<{ id: string }>
+  deleteTask?: (taskId: string, actor: string) => Promise<boolean>
+}): Promise<FirstBootResetSummary> {
+  const reflecttHome = opts?.reflecttHome || REFLECTT_HOME
+  const dataDir = opts?.dataDir || DATA_DIR
+  const actor = opts?.actor || 'system-first-boot-reset'
+  const now = opts?.now || (() => Date.now())
+
+  let importedTaskManager: Awaited<typeof import('./tasks.js')>['taskManager'] | null = null
+  const getTaskManager = async () => {
+    if (importedTaskManager) return importedTaskManager
+    const mod = await import('./tasks.js')
+    importedTaskManager = mod.taskManager
+    return importedTaskManager
+  }
+  const deleteTask = opts?.deleteTask || (async (taskId: string, deleteActor: string) => {
+    const taskManager = await getTaskManager()
+    return taskManager.deleteTask(taskId, deleteActor)
+  })
+
+  const backupDir = join(dataDir, '_bootstrap_resets', `reset-${now()}`)
+  mkdirSync(backupDir, { recursive: true })
+
+  const moveIntoBackup = (src: string, relativeDest: string): boolean => {
+    if (!existsSync(src)) return false
+    const dest = join(backupDir, relativeDest)
+    mkdirSync(dirname(dest), { recursive: true })
+    renameSync(src, dest)
+    return true
+  }
+
+  const removedMarker = moveIntoBackup(join(dataDir, '.first-boot-done'), 'data.first-boot-done.bak')
+
+  const movedAgentEntries: string[] = []
+  const agentsDir = join(dataDir, 'agents')
+  if (existsSync(agentsDir)) {
+    for (const entry of readdirSync(agentsDir)) {
+      if (!entry || entry.startsWith('.')) continue
+      if (moveIntoBackup(join(agentsDir, entry), join('agents', entry))) {
+        movedAgentEntries.push(entry)
+      }
+    }
+  }
+
+  const removedTeamRoles = moveIntoBackup(join(reflecttHome, 'TEAM-ROLES.yaml'), 'TEAM-ROLES.yaml.bak')
+
+  const liveTasks = opts?.listTasks ? opts.listTasks() : (await getTaskManager()).listTasks({ includeTest: true })
+  const deletedTaskIds: string[] = []
+  for (const task of liveTasks) {
+    if (!task?.id) continue
+    const deleted = await deleteTask(task.id, actor)
+    if (deleted) deletedTaskIds.push(task.id)
+  }
+
+  const removedBackupDir = !removedMarker && !removedTeamRoles && movedAgentEntries.length === 0 && deletedTaskIds.length === 0
+  if (removedBackupDir) {
+    rmSync(backupDir, { recursive: true, force: true })
+  }
+
+  return {
+    backupDir,
+    removedMarker,
+    movedAgentEntries,
+    removedTeamRoles,
+    deletedTaskIds,
+    removedBackupDir,
+  }
 }
 
 // ── Redact sensitive values ──────────────────────────────────────────
@@ -255,6 +345,57 @@ export function registerManageRoutes(app: FastifyInstance, deps: {
     setTimeout(() => {
       if (method === 'exit') {
         // Docker/systemd will auto-restart on exit code 0
+        process.exit(0)
+      } else if (method === 'sigterm') {
+        process.kill(process.pid, 'SIGTERM')
+      }
+    }, 500)
+  })
+
+  // POST /manage/reset-first-boot — destructive bootstrap reset for managed-host reproof
+  app.post('/manage/reset-first-boot', async (request, reply) => {
+    if (!checkManageAuth(request, reply, { allowHostCredential: true })) return
+
+    const body = (request.body && typeof request.body === 'object') ? request.body as Record<string, unknown> : {}
+    if (body.confirm !== FIRST_BOOT_RESET_CONFIRM) {
+      reply.code(400)
+      return {
+        error: `confirm must equal ${FIRST_BOOT_RESET_CONFIRM}`,
+        hint: 'This endpoint is destructive. It clears first-boot markers, moves agent state aside, deletes live tasks, and optionally restarts the host.',
+      }
+    }
+
+    const restart = body.restart !== false
+    const reset = await resetFirstBootState()
+    const method = restart ? detectRestartMethod() : null
+
+    if (restart && !method) {
+      reply.code(501)
+      return {
+        success: false,
+        error: 'Restart not supported in this environment',
+        hint: 'Reset succeeded, but restart is not supported here. Reboot the process manually or call this endpoint with { restart: false }.',
+        reset,
+      }
+    }
+
+    reply.send({
+      success: true,
+      reset,
+      restart: restart
+        ? {
+            scheduled: true,
+            method,
+            pid: process.pid,
+            message: `First-boot reset applied. Server will restart via ${method}.`,
+          }
+        : { scheduled: false },
+    })
+
+    if (!restart || !method) return
+
+    setTimeout(() => {
+      if (method === 'exit') {
         process.exit(0)
       } else if (method === 'sigterm') {
         process.kill(process.pid, 'SIGTERM')

--- a/src/server.ts
+++ b/src/server.ts
@@ -14732,7 +14732,7 @@ If your heartbeat shows **no active task** and **no next task**:
           { method: 'GET', path: '/manage/config', hint: 'Config introspection (secrets redacted). Auth required.' },
           { method: 'GET', path: '/manage/logs', hint: 'Bounded log tail. Query: level, since, limit, format=text. Auth required.' },
           { method: 'POST', path: '/manage/restart', hint: 'Graceful restart (Docker/systemd/CLI). Auth required.' },
-          { method: 'POST', path: '/manage/reset-first-boot', hint: 'Destructive reproof reset for managed hosts. Clears first-boot markers, moves agent state aside, deletes live tasks, and optionally restarts. Auth: manage token or managed host credential. Body must include { confirm: "RESET_FIRST_BOOT" }.' },
+          { method: 'POST', path: '/manage/reset-bootstrap', hint: 'Destructive reproof reset for managed hosts. Clears bootstrap state, deletes stale bootstrap tasks if present, and optionally restarts. Auth: manage token or managed host credential. Body must include { confirm: "RESET_BOOTSTRAP" }.' },
           { method: 'GET', path: '/manage/disk', hint: 'Data directory sizes. Auth required.' },
         ],
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -14732,6 +14732,7 @@ If your heartbeat shows **no active task** and **no next task**:
           { method: 'GET', path: '/manage/config', hint: 'Config introspection (secrets redacted). Auth required.' },
           { method: 'GET', path: '/manage/logs', hint: 'Bounded log tail. Query: level, since, limit, format=text. Auth required.' },
           { method: 'POST', path: '/manage/restart', hint: 'Graceful restart (Docker/systemd/CLI). Auth required.' },
+          { method: 'POST', path: '/manage/reset-first-boot', hint: 'Destructive reproof reset for managed hosts. Clears first-boot markers, moves agent state aside, deletes live tasks, and optionally restarts. Auth: manage token or managed host credential. Body must include { confirm: "RESET_FIRST_BOOT" }.' },
           { method: 'GET', path: '/manage/disk', hint: 'Data directory sizes. Auth required.' },
         ],
       },

--- a/tests/manage.test.ts
+++ b/tests/manage.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { resetFirstBootState } from '../src/manage.js'
+
+describe('resetFirstBootState', () => {
+  it('moves first-boot artifacts into backup and deletes live tasks', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'reflectt-reset-first-boot-'))
+    const reflecttHome = join(root, '.reflectt')
+    const dataDir = join(reflecttHome, 'data')
+    const agentsDir = join(dataDir, 'agents')
+    mkdirSync(agentsDir, { recursive: true })
+
+    writeFileSync(join(dataDir, '.first-boot-done'), 'done\n', 'utf-8')
+    writeFileSync(join(dataDir, 'TEAM_INTENT.md'), '# Team Intent\n', 'utf-8')
+    mkdirSync(join(agentsDir, 'main'), { recursive: true })
+    mkdirSync(join(agentsDir, 'kai'), { recursive: true })
+    writeFileSync(join(reflecttHome, 'TEAM-ROLES.yaml'), 'agents: []\n', 'utf-8')
+
+    const deleted: string[] = []
+    const summary = await resetFirstBootState({
+      reflecttHome,
+      dataDir,
+      now: () => 12345,
+      listTasks: () => [{ id: 'task-1' }, { id: 'task-2' }],
+      deleteTask: async (taskId) => {
+        deleted.push(taskId)
+        return true
+      },
+    })
+
+    expect(summary.removedMarker).toBe(true)
+    expect(summary.removedTeamRoles).toBe(true)
+    expect(summary.movedAgentEntries.sort()).toEqual(['kai', 'main'])
+    expect(summary.deletedTaskIds).toEqual(['task-1', 'task-2'])
+    expect(summary.removedBackupDir).toBe(false)
+    expect(summary.backupDir).toBe(join(dataDir, '_bootstrap_resets', 'reset-12345'))
+
+    expect(existsSync(join(dataDir, '.first-boot-done'))).toBe(false)
+    expect(existsSync(join(reflecttHome, 'TEAM-ROLES.yaml'))).toBe(false)
+    expect(existsSync(join(dataDir, 'TEAM_INTENT.md'))).toBe(true)
+    expect(readdirSync(agentsDir)).toEqual([])
+    expect(existsSync(join(summary.backupDir, 'data.first-boot-done.bak'))).toBe(true)
+    expect(existsSync(join(summary.backupDir, 'TEAM-ROLES.yaml.bak'))).toBe(true)
+    expect(existsSync(join(summary.backupDir, 'agents', 'main'))).toBe(true)
+    expect(existsSync(join(summary.backupDir, 'agents', 'kai'))).toBe(true)
+
+    expect(deleted).toEqual(['task-1', 'task-2'])
+
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('removes the empty backup directory when nothing needed resetting', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'reflectt-reset-first-boot-'))
+    const reflecttHome = join(root, '.reflectt')
+    const dataDir = join(reflecttHome, 'data')
+    mkdirSync(dataDir, { recursive: true })
+
+    const summary = await resetFirstBootState({
+      reflecttHome,
+      dataDir,
+      now: () => 999,
+      listTasks: () => [],
+      deleteTask: async () => true,
+    })
+
+    expect(summary.removedMarker).toBe(false)
+    expect(summary.removedTeamRoles).toBe(false)
+    expect(summary.movedAgentEntries).toEqual([])
+    expect(summary.deletedTaskIds).toEqual([])
+    expect(summary.removedBackupDir).toBe(true)
+    expect(existsSync(summary.backupDir)).toBe(false)
+
+    rmSync(root, { recursive: true, force: true })
+  })
+})

--- a/tests/manage.test.ts
+++ b/tests/manage.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { resetFirstBootState } from '../src/manage.js'
+import { resetBootstrapState } from '../src/manage.js'
 
-describe('resetFirstBootState', () => {
+describe('resetBootstrapState', () => {
   it('moves first-boot artifacts into backup and deletes live tasks', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'reflectt-reset-first-boot-'))
+    const root = mkdtempSync(join(tmpdir(), 'reflectt-reset-bootstrap-'))
     const reflecttHome = join(root, '.reflectt')
     const dataDir = join(reflecttHome, 'data')
     const agentsDir = join(dataDir, 'agents')
@@ -19,7 +19,7 @@ describe('resetFirstBootState', () => {
     writeFileSync(join(reflecttHome, 'TEAM-ROLES.yaml'), 'agents: []\n', 'utf-8')
 
     const deleted: string[] = []
-    const summary = await resetFirstBootState({
+    const summary = await resetBootstrapState({
       reflecttHome,
       dataDir,
       now: () => 12345,
@@ -52,12 +52,12 @@ describe('resetFirstBootState', () => {
   })
 
   it('removes the empty backup directory when nothing needed resetting', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'reflectt-reset-first-boot-'))
+    const root = mkdtempSync(join(tmpdir(), 'reflectt-reset-bootstrap-'))
     const reflecttHome = join(root, '.reflectt')
     const dataDir = join(reflecttHome, 'data')
     mkdirSync(dataDir, { recursive: true })
 
-    const summary = await resetFirstBootState({
+    const summary = await resetBootstrapState({
       reflecttHome,
       dataDir,
       now: () => 999,


### PR DESCRIPTION
## Summary
- add `POST /manage/reset-first-boot` as a supported destructive reproof path
- allow auth via manage token or managed host credential
- clear first-boot markers, move agent bootstrap state aside, delete live tasks, and optionally restart
- add targeted test coverage for the reset helper

## Why
Managed-host first-boot proof should use admin APIs, not SSH archaeology. This gives cloud a supported node-side reset path.

## Validation
- `npm test -- tests/manage.test.ts` passed in the existing workspace
- module smoke import passed in the existing workspace
- repo-wide type-check remains blocked by pre-existing unrelated sentry typing issues