### PR TITLE
fix: remove hardcoded voice/color maps — agent-owned identity only

### DIFF
--- a/src/canvas-interactive.ts
+++ b/src/canvas-interactive.ts
@@ -4,6 +4,7 @@
 
 import type { FastifyInstance } from 'fastify'
 import type { eventBus as eventBusInstance } from './events.js'
+import { getDb } from './db.js'
 
 // ── Types ──
 
@@ -559,22 +560,26 @@ export async function canvasInteractiveRoutes(
 
   const ELEVEN_BASE = 'https://api.elevenlabs.io/v1'
   const ELEVEN_API_KEY = process.env.ELEVEN_LABS_API_KEY || process.env.ELEVENLABS_API_KEY
-  const ELEVEN_VOICE_MAP: Record<string, string> = {
-    link: 'pNInz6obpgDQGcFmaJgB', kai: 'ErXwobaYiN019PkySvjV',
-    pixel: 'MF3mGyEYCl7XYWbV9V6O', echo: 'jBpfuIE2acCO8z3wKNLl',
-    harmony: 'jBpfuIE2acCO8z3wKNLl', rhythm: 'onwK4e9ZLuTAKqWW03F9',
-    swift: 'yoZ06aMxZJJ28mfd3POQ', kotlin: 'SOYHLrjzK2X1ezoPC6cr',
-    sage: 'ThT5KcBeYPX3keUQqHPh', bookkeeper: 'GBv7mTt0atIp3Br8iCZE',
-  }
-  const KOKORO_VOICE_MAP: Record<string, string> = {
-    link: 'af_sarah', swift: 'af_sarah',
-    kai: 'af_nicole', kotlin: 'af_nicole', pixel: 'af_nicole', echo: 'af_nicole', harmony: 'af_nicole',
-    rhythm: 'af_james', bookkeeper: 'bf_emma', sage: 'bf_emma',
+  // No hardcoded voice maps — agents own their identity via agent_config.
+  // Generic fallbacks for agents that haven't claimed a voice.
+  const KOKORO_DEFAULT_VOICE = process.env.KOKORO_DEFAULT_VOICE_ID || 'af_sarah'
+  const ELEVENLABS_DEFAULT_VOICE = process.env.ELEVENLABS_DEFAULT_VOICE_ID || 'pNInz6obpgDQGcFmaJgB'
+
+  function getClaimedVoice(agentId: string): { kokoro: string; eleven: string } {
+    try {
+      const row = getDb().prepare('SELECT settings FROM agent_config WHERE agent_id = ?').get(agentId) as { settings: string } | undefined
+      if (row) {
+        const settings = JSON.parse(row.settings)
+        if (settings?.voice) return { kokoro: settings.voice, eleven: settings.voice }
+      }
+    } catch { /* fall through to defaults */ }
+    return { kokoro: KOKORO_DEFAULT_VOICE, eleven: ELEVENLABS_DEFAULT_VOICE }
   }
 
   async function makeTts(text: string, agentId: string): Promise<{ url: string; ms: number } | null> {
-    const kokoroVoice = KOKORO_VOICE_MAP[agentId] || 'af_sarah'
-    const elevenVoice = ELEVEN_VOICE_MAP[agentId] || 'pNInz6obpgDQGcFmaJgB'
+    const claimed = getClaimedVoice(agentId)
+    const kokoroVoice = claimed.kokoro
+    const elevenVoice = claimed.eleven
     const key = await hashTts(text, kokoroVoice)
     const cached = ttsCache.get(key)
     if (cached && Date.now() - cached.ts < TTS_TTL) return { url: '/audio/' + key, ms: Math.round(text.length * 50) }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8647,15 +8647,9 @@ export async function createServer(): Promise<FastifyInstance> {
       return `Received: "${text.slice(0, 80)}${text.length > 80 ? '...' : ''}"`
     }
 
-    // Agent voice IDs (ElevenLabs) — per-agent identity, same mapping as cloud
-    const NODE_AGENT_VOICE_IDS: Record<string, string> = {
-      link: 'pNInz6obpgDQGcFmaJgB',    // Adam
-      kai: 'onwK4e9ZLuTAKqWW03F9',     // Daniel
-      pixel: 'EXAVITQu4vr4xnSDxMaL',   // Sarah
-      sage: 'yoZ06aMxZJJ28mfd3POQ',    // Rachel
-      scout: '3XbDmaS0mwj3WIVTUxWa',   // Charlie
-      echo: 'MF3mGyEYCl7XYWbV9V6O',    // Elli
-    }
+    // Generic fallback voice for agents that haven't claimed their own.
+    // Agent-claimed voices (via identity/claim → agent_config) take priority.
+    const ELEVENLABS_DEFAULT_VOICE = process.env.ELEVENLABS_DEFAULT_VOICE_ID || 'pNInz6obpgDQGcFmaJgB'
 
     // ── Voice mutex — only one agent speaks at a time ──────────────────
     // P0 fix: multiple agents were triggering TTS simultaneously, causing
@@ -8691,10 +8685,9 @@ export async function createServer(): Promise<FastifyInstance> {
 
       // Fire canvas_expression alongside TTS — the room responds when an agent speaks.
       // Non-blocking: emit first, synthesize in parallel.
-      const IDENTITY_COLORS: Record<string, string> = {
-        link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa',
-        sage: '#34d399', scout: '#fbbf24', echo: '#f472b6',
-      }
+      // Resolve agent's claimed identity color from agent_config, fall back to neutral blue
+      const colorRow = getDb().prepare('SELECT settings FROM agent_config WHERE agent_id = ?').get(forAgentId) as { settings: string } | undefined
+      const claimedColor: string = colorRow ? (() => { try { return JSON.parse(colorRow.settings)?.identityColor ?? '#60a5fa' } catch { return '#60a5fa' } })() : '#60a5fa'
       eventBus.emit({
         id: `voice-expr-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
         type: 'canvas_expression' as const,
@@ -8703,7 +8696,7 @@ export async function createServer(): Promise<FastifyInstance> {
           agentId: forAgentId,
           channels: {
             voice: text.slice(0, 300),
-            visual: { flash: IDENTITY_COLORS[forAgentId] ?? '#60a5fa', particles: 'surge' },
+            visual: { flash: claimedColor, particles: 'surge' },
             narrative: `${forAgentId} responds`,
           },
         },
@@ -8713,7 +8706,7 @@ export async function createServer(): Promise<FastifyInstance> {
       // Prefer voice stored in agent_config (set during identity claim) over hardcoded map
       const agentConfigRow = getDb().prepare('SELECT settings FROM agent_config WHERE agent_id = ?').get(forAgentId) as { settings: string } | undefined
       const agentConfigVoice: string | undefined = agentConfigRow ? (() => { try { return JSON.parse(agentConfigRow.settings)?.voice } catch { return undefined } })() : undefined
-      const voiceId = agentConfigVoice ?? NODE_AGENT_VOICE_IDS[forAgentId] ?? NODE_AGENT_VOICE_IDS['link']
+      const voiceId = agentConfigVoice ?? ELEVENLABS_DEFAULT_VOICE
       try {
         const res = await fetch(
           `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,


### PR DESCRIPTION
## Summary
- Removed `NODE_AGENT_VOICE_IDS` (ElevenLabs) and `IDENTITY_COLORS` from `server.ts`
- Removed `ELEVEN_VOICE_MAP` and `KOKORO_VOICE_MAP` from `canvas-interactive.ts`
- All voice/color resolution now reads from `agent_config.settings` (set during `identity/claim`)
- Unclaimed agents get generic fallback (`af_sarah` for Kokoro, `pNInz6obpgDQGcFmaJgB` for ElevenLabs, `#60a5fa` for color)
- No team-roster mappings anywhere on the runtime path

## Why
Hardcoded maps were fake identity — they mapped our internal team roster to static voices/colors instead of letting agents own their identity through the claim path. Per Ryan: "agents pick their own name, avatar, color, voice."

## Companion PR
- Cloud: reflectt/reflectt-cloud#2700 (merged) — removed cloud-side `KOKORO_VOICE_MAP` and `AGENT_VOICE_MAP`

## Test plan
- [ ] Fresh managed agent claims voice via `POST /agents/:name/identity/claim { voice }`
- [ ] Claimed voice flows through TTS (both server.ts ElevenLabs path and canvas-interactive Kokoro path)
- [ ] Unclaimed agent gets generic fallback, not a fake persona
- [ ] Canvas expression flash color reads from agent_config, not hardcoded map

🤖 Generated with [Claude Code](https://claude.com/claude-code)