### PR TITLE
fix: rip remaining hardcoded color maps from live path

### DIFF
--- a/src/canvas-push.ts
+++ b/src/canvas-push.ts
@@ -8,6 +8,7 @@ import { taskManager } from './tasks.js'
 import { emitActivationEvent } from './activationEvents.js'
 import type { CanvasStateEntry } from './canvas-routes.js'
 import { getAgentRoles } from './assignment.js'
+import { getIdentityColor } from './agent-config.js'
 
 interface CanvasPushDeps {
   eventBus: typeof eventBusInstance
@@ -48,10 +49,6 @@ export async function canvasPushRoutes(
       const raw = typeof body.text === 'string' ? body.text.trim() : ''
       const text = raw.slice(0, 200)
       const ttl = typeof body.ttl === 'number' && body.ttl > 0 ? Math.min(body.ttl, 30_000) : 8_000
-      const THOUGHT_COLORS: Record<string, string> = {
-        link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa', sage: '#34d399',
-        scout: '#fbbf24', echo: '#f472b6', rhythm: '#6ee7b7', spark: '#f97316',
-      }
       eventBus.emit({
         id: `cmsg-thought-${now}-${Math.random().toString(36).slice(2, 8)}`,
         type: 'canvas_message' as const,
@@ -60,7 +57,7 @@ export async function canvasPushRoutes(
           type: 'expression',
           expression: 'thought',
           agentId,
-          agentColor: THOUGHT_COLORS[agentId] ?? '#60a5fa',
+          agentColor: getIdentityColor(agentId, '#60a5fa'),
           text,
           ttl,
         },
@@ -109,10 +106,6 @@ export async function canvasPushRoutes(
 
       payload = { ...payload, content: richContent, position, layer, ttl, size }
 
-      const RICH_COLORS: Record<string, string> = {
-        link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa', sage: '#34d399',
-        scout: '#fbbf24', echo: '#f472b6', rhythm: '#6ee7b7', spark: '#f97316',
-      }
       eventBus.emit({
         id: `cmsg-rich-${now}-${Math.random().toString(36).slice(2, 8)}`,
         type: 'canvas_message' as const,
@@ -120,7 +113,7 @@ export async function canvasPushRoutes(
         data: {
           type: 'rich',
           agentId,
-          agentColor: RICH_COLORS[agentId] ?? '#60a5fa',
+          agentColor: getIdentityColor(agentId, '#60a5fa'),
           content: richContent,
           layer,
         },
@@ -134,11 +127,7 @@ export async function canvasPushRoutes(
       const query = typeof body.query === 'string' ? body.query.slice(0, 200) : undefined
       payload = { ...payload, card, query }
 
-      const RESP_COLORS: Record<string, string> = {
-        link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa', sage: '#34d399',
-        scout: '#f472b6', echo: '#fbbf24', rhythm: '#6ee7b7', spark: '#f97316',
-      }
-      const agentColor = RESP_COLORS[agentId] ?? '#60a5fa'
+      const agentColor = getIdentityColor(agentId, '#60a5fa')
       eventBus.emit({
         id: `cmsg-${now}-${Math.random().toString(36).slice(2, 8)}`,
         type: 'canvas_message' as const,
@@ -168,12 +157,7 @@ export async function canvasPushRoutes(
     const taskId = typeof body.taskId === 'string' ? body.taskId : undefined
     const now = Date.now()
 
-    const AGENT_COLORS: Record<string, string> = {
-      link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa',
-      sage: '#34d399', scout: '#fbbf24', echo: '#f472b6',
-      rhythm: '#a3e635', swift: '#38bdf8', kotlin: '#f97316',
-    }
-    const agentColor = AGENT_COLORS[agentId] ?? '#94a3b8'
+    const agentColor = getIdentityColor(agentId, '#94a3b8')
 
     const payload = { type, agentId, agentColor, title, url, taskId, timestamp: now }
     eventBus.emit({

--- a/src/canvas-types.ts
+++ b/src/canvas-types.ts
@@ -101,16 +101,6 @@ export interface SlotEvent {
 
 // ── Agent identity (from Pixel's spec) ───────────────────────────────
 
-export const AGENT_COLORS: Record<string, string> = {
-  pixel: '#a78bfa',   // violet
-  link: '#60a5fa',    // blue
-  kai: '#f59e0b',     // amber
-  harmony: '#34d399', // green
-  sage: '#9eb3ca',    // slate
-  echo: '#f87171',    // red
-  scout: '#fb923c',   // orange
-}
-
 export const AGENT_DEFAULT_EXPRESSION: Record<string, ContentType> = {
   pixel: 'text.brief',       // component / annotation
   link: 'code.diff.summary', // code diff / stream

--- a/src/server.ts
+++ b/src/server.ts
@@ -2519,11 +2519,6 @@ export async function createServer(): Promise<FastifyInstance> {
   // Approval card restore — re-emit canvas_push for undecided validating tasks on startup.
   // Ensures approval cards survive node restarts without re-emitting already-decided cards.
   const APPROVAL_CARD_TTL_MS = 24 * 60 * 60 * 1000 // 24h
-  const CANVAS_AGENT_COLORS_RESTART: Record<string, string> = {
-    link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa',
-    sage: '#34d399', scout: '#fbbf24', echo: '#f472b6',
-    rhythm: '#a3e635', swift: '#38bdf8', kotlin: '#f97316',
-  }
   try {
     const validatingTasks = taskManager.listTasks({ status: 'validating' })
     const cutoff = Date.now() - APPROVAL_CARD_TTL_MS
@@ -2546,7 +2541,7 @@ export async function createServer(): Promise<FastifyInstance> {
       const restoreData = {
         type: 'approval_requested',
         agentId: assigneeId,
-        agentColor: CANVAS_AGENT_COLORS_RESTART[assigneeId] ?? '#94a3b8',
+        agentColor: getIdentityColor(assigneeId, '#94a3b8'),
         data: {
           taskId: task.id,
           taskTitle: task.title,
@@ -7454,11 +7449,7 @@ export async function createServer(): Promise<FastifyInstance> {
       const intensity = Math.min(Math.max(ageScore * 0.7 + doingScore + 0.15, 0.15), 1.0)
 
       const assigneeId = updated.assignee ?? task.assignee ?? getAgentRoles()[0]?.name ?? 'system'
-      const MILESTONE_COLORS: Record<string, string> = {
-        link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa',
-        sage: '#34d399', scout: '#fbbf24', echo: '#f472b6',
-      }
-      const milestoneColor = MILESTONE_COLORS[assigneeId] ?? '#60a5fa'
+      const milestoneColor = getIdentityColor(assigneeId, '#60a5fa')
 
       setImmediate(() => {
         eventBus.emit({
@@ -10187,17 +10178,12 @@ export async function createServer(): Promise<FastifyInstance> {
           ?? (taskMetaForCard?.review_handoff as Record<string, unknown> | undefined)?.pr_url as string | undefined
           ?? (taskMetaForCard?.qa_bundle as Record<string, unknown> | undefined)?.pr_url as string | undefined
         const qaSummary = (taskMetaForCard?.qa_bundle as Record<string, unknown> | undefined)?.summary as string | undefined
-        const CANVAS_AGENT_COLORS: Record<string, string> = {
-          link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa',
-          sage: '#34d399', scout: '#fbbf24', echo: '#f472b6',
-          rhythm: '#a3e635', swift: '#38bdf8', kotlin: '#f97316',
-        }
         const assigneeIdForCard = (task.assignee ?? '').toLowerCase()
         const approvalNow = Date.now()
         const approvalPushData = {
           type: 'approval_requested',
           agentId: assigneeIdForCard,
-          agentColor: CANVAS_AGENT_COLORS[assigneeIdForCard] ?? '#94a3b8',
+          agentColor: getIdentityColor(assigneeIdForCard, '#94a3b8'),
           data: {
             taskId: task.id,
             taskTitle: task.title,
@@ -11696,10 +11682,6 @@ export async function createServer(): Promise<FastifyInstance> {
     // Fires immediately so SSE subscribers receive it before the next pulse tick.
     // Client renders _ghost=true events with low opacity (0.06-0.14), no TTS.
     if (prevState !== state) {
-      const GHOST_COLORS: Record<string, string> = {
-        link: '#60a5fa', kai: '#fb923c', pixel: '#a78bfa',
-        sage: '#34d399', scout: '#fbbf24', echo: '#f472b6',
-      }
       const ghostIntensity =
         state === 'urgent'   ? 0.9 :
         state === 'decision' ? 0.75 :
@@ -11715,7 +11697,7 @@ export async function createServer(): Promise<FastifyInstance> {
           agentId,
           channels: {
             visual: {
-              flash: GHOST_COLORS[agentId] ?? '#60a5fa',
+              flash: getIdentityColor(agentId, '#60a5fa'),
               particles: ghostParticles,
             },
             narrative: `${agentId} → ${state}`,


### PR DESCRIPTION
## Summary
Link's second sweep after #1266 found 8 more hardcoded agent→color maps still masking DB-backed identity on the live path. This PR removes all of them.

### Removed
- `src/canvas-push.ts`: `THOUGHT_COLORS`, `RICH_COLORS`, `RESP_COLORS`, `AGENT_COLORS`
- `src/server.ts`: `CANVAS_AGENT_COLORS_RESTART` (approval-restore), `CANVAS_AGENT_COLORS` (approval card emit), `MILESTONE_COLORS`, `GHOST_COLORS`

All call sites now use `getIdentityColor(agentId, fallback)` (DB-backed, reads `agent_config.settings.identityColor`, fallback for missing rows).

### Bar after merge
No remaining hardcoded agent roster/color maps on the live path. `grep 'Record<string, string>.*\{[^}]*link:.*#'` returns nothing in `src/`.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] CI: tests + guards green
- [ ] After `:latest` publish: @link reruns fresh managed-agent proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)