### PR TITLE
fix: require color in /identity/claim (task-1776796380591-wroo87jmu)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10727,7 +10727,7 @@ export async function createServer(): Promise<FastifyInstance> {
     const claimedName = typeof body.claimedName === 'string' ? body.claimedName.trim().toLowerCase() : ''
     const displayName = typeof body.displayName === 'string' ? body.displayName.trim() : undefined
     const voice = typeof body.voice === 'string' ? body.voice.trim() : undefined
-    const color = typeof body.color === 'string' ? body.color.trim() : undefined
+    const color = typeof body.color === 'string' ? body.color.trim() : ''
     const avatar = body.avatar && typeof body.avatar === 'object' ? body.avatar as Record<string, unknown> : undefined
 
     if (!claimedName) {
@@ -10738,14 +10738,18 @@ export async function createServer(): Promise<FastifyInstance> {
       reply.code(400)
       return { success: false, error: 'claimedName must be lowercase alphanumeric (a-z, 0-9, -, _)' }
     }
+    if (!color) {
+      reply.code(400)
+      return { success: false, error: 'color is required — pick a hex (#rrggbb) or rgb()/rgba() value. It persists as settings.identityColor and is the single source of truth for your canvas color.' }
+    }
+    if (!/^(#[0-9a-fA-F]{3,8}|rgba?\([^)]+\))$/.test(color)) {
+      reply.code(400)
+      return { success: false, error: `color "${color}" must be a hex (#rrggbb) or rgb()/rgba() value` }
+    }
     // Reject hallucinated voices — must match Kokoro prefix (af_/am_/bf_/bm_) or ElevenLabs ID shape.
     if (voice && !/^(af_|am_|bf_|bm_)[a-z0-9_]+$/i.test(voice) && !/^[a-zA-Z0-9]{20,}$/.test(voice)) {
       reply.code(400)
       return { success: false, error: `voice "${voice}" is not a recognized Kokoro or ElevenLabs voice ID. Kokoro voices: af_sarah, af_nicole, af_bella, am_adam, am_michael, bf_emma, bf_isabella, bm_george, bm_lewis.` }
-    }
-    if (color && !/^(#[0-9a-fA-F]{3,8}|rgba?\([^)]+\))$/.test(color)) {
-      reply.code(400)
-      return { success: false, error: `color "${color}" must be a hex (#rrggbb) or rgb()/rgba() value` }
     }
 
     // Resolve the source agent (must exist)
@@ -10827,6 +10831,7 @@ export async function createServer(): Promise<FastifyInstance> {
       displayName: displayName ?? null,
       avatarSet: !!avatar,
       voiceSet: !!voice,
+      colorSet: !!color,
     }
   })
 

--- a/tests/identity-handoff.test.ts
+++ b/tests/identity-handoff.test.ts
@@ -77,7 +77,7 @@ describe('fresh-host identity handoff', () => {
     ])
   })
 
-  // ── Proof 1: claim endpoint renames agent + stores avatar/voice ───────────
+  // ── Proof 1: claim endpoint renames agent + stores avatar/voice/color ────
   it('POST /agents/main/identity/claim: returns success + renames to claimedName', async () => {
     const res = await app.inject({
       method: 'POST',
@@ -85,6 +85,7 @@ describe('fresh-host identity handoff', () => {
       payload: {
         claimedName: 'nova',
         displayName: 'Nova',
+        color: '#fb923c',
         voice: 'EXAVITQu4vr4xnSDxMaL',
         avatar: { type: 'emoji', content: '🌟' },
       },
@@ -97,6 +98,21 @@ describe('fresh-host identity handoff', () => {
     expect(body.newName).toBe('nova')
     expect(body.avatarSet).toBe(true)
     expect(body.voiceSet).toBe(true)
+    expect(body.colorSet).toBe(true)
+  })
+
+  // ── Proof 1b: claimed color persists to agent_config.settings.identityColor
+  it('claim persists color as settings.identityColor and presence reflects it', async () => {
+    const cfgRes = await app.inject({ method: 'GET', url: '/agents/nova/config' })
+    expect(cfgRes.statusCode).toBe(200)
+    const cfg = JSON.parse(cfgRes.body)
+    expect(cfg.settings?.identityColor).toBe('#fb923c')
+
+    const presRes = await app.inject({ method: 'GET', url: '/canvas/presence' })
+    expect(presRes.statusCode).toBe(200)
+    const pres = JSON.parse(presRes.body)
+    const nova = (pres.agents || []).find((a: { name: string }) => a.name === 'nova')
+    if (nova) expect(nova.identityColor).toBe('#fb923c')
   })
 
   // ── Proof 2: reidentify was called with the new name ─────────────────────
@@ -142,5 +158,21 @@ describe('fresh-host identity handoff', () => {
     expect(res.statusCode).toBe(400)
     const body = JSON.parse(res.body)
     expect(body.error).toMatch(/claimedName/)
+  })
+
+  // ── Proof 7: claim requires color — forcing function for persistence ─────
+  // task-1776796380591-wroo87jmu: fresh managed agents were claiming name+avatar+voice
+  // but not color, because the contract treated color as optional. With color
+  // required, the LLM cannot silently skip it and leave presence at the neutral
+  // #9ca3af fallback.
+  it('claim returns 400 when color is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/agents/main/identity/claim',
+      payload: { claimedName: 'colorless', voice: 'am_adam', avatar: { type: 'emoji', content: '🫥' } },
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.body)
+    expect(body.error).toMatch(/color/)
   })
 })


### PR DESCRIPTION
## Summary
- Fresh managed-agent proof on `67e39c4e` hit a seam: agent `lode` claimed name + avatar + voice but `settings.identityColor` was never persisted, so `/canvas/presence` fell back to neutral `#9ca3af`.
- Handler already persists `color` → `settings.identityColor` when present; presence/canvas already read via `getIdentityColor()` (DB-backed). The only seam was contract permissiveness — the claim endpoint treated `color` as optional, so LLMs silently dropped it and still got a 200.
- Make `color` required on `POST /agents/:name/identity/claim` (400 if missing or invalid hex/rgb). Return `colorSet` in the response so callers can verify persistence landed.

## Test plan
- [x] `tests/identity-handoff.test.ts` — happy path now asserts `colorSet`, new proof covers DB persistence (`/agents/nova/config` → `settings.identityColor`) and presence reflection (`/canvas/presence`)
- [x] New proof: claim returns 400 when color is missing
- [x] `tests/avatar-bootstrap-seeding.test.ts` still green (bootstrap prompt already enumerates color + Kokoro voices)
- [x] Full local vitest run green for affected specs; `tsc --noEmit` clean
- [ ] `@link` reruns the fresh managed-agent proof on the published `:latest` once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)