### PR TITLE
fix: preserve claimed founding agent across PUT /config/team-roles (task-1776796380591-wroo87jmu)

### DIFF
--- a/src/agent-config.ts
+++ b/src/agent-config.ts
@@ -119,6 +119,29 @@ export function setAgentConfig(agentId: string, updates: {
 }
 
 /**
+ * Return the set of agent IDs that have claimed identity — i.e. have an
+ * agent_config row with at least one of `settings.avatar`, `settings.voice`,
+ * or `settings.identityColor` set. Used to preserve renamed founding agents
+ * across `PUT /config/team-roles` overwrites.
+ */
+export function getClaimedAgentIds(): Set<string> {
+  const ids = new Set<string>()
+  try {
+    const db = getDb()
+    const rows = db.prepare('SELECT agent_id, settings FROM agent_config').all() as Array<{ agent_id: string; settings: string }>
+    for (const row of rows) {
+      const settings = JSON.parse(row.settings || '{}') as Record<string, unknown>
+      if (settings.avatar || settings.voice || settings.identityColor) {
+        ids.add(String(row.agent_id).toLowerCase())
+      }
+    }
+  } catch {
+    // Empty set on any read/parse failure — caller treats as "no preservation needed"
+  }
+  return ids
+}
+
+/**
  * Read the agent's claimed identity color from agent_config.settings.identityColor.
  * Returns a neutral fallback when the agent hasn't claimed a color.
  * This is the single source of truth for identity color — no roster maps.

--- a/src/assignment.ts
+++ b/src/assignment.ts
@@ -73,7 +73,7 @@ let lastMtime: number = 0
 let watchActive = false
 
 
-function parseRolesYaml(content: string): AgentRole[] {
+export function parseRolesYaml(content: string): AgentRole[] {
   const data = parseYaml(content)
   if (!data?.agents || !Array.isArray(data.agents)) {
     throw new Error('TEAM-ROLES.yaml: missing or invalid "agents" array')

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ import { getFocus, setFocus, clearFocus, getFocusSummary } from './focus.js'
 import { generatePulse, generateCompactPulse } from './pulse.js'
 import { scanScopeOverlap, scanAndNotify } from './scopeOverlap.js'
 import { getDb } from './db.js'
-import { getIdentityColor } from './agent-config.js'
+import { getIdentityColor, getClaimedAgentIds } from './agent-config.js'
 import type { AgentMessage, Task } from './types.js'
 import { isTestHarnessTask } from './test-task-filter.js'
 import { handleMCPRequest, handleSSERequest, handleMessagesRequest, getActiveSamplingProviders } from './mcp.js'
@@ -98,7 +98,7 @@ import { researchManager } from './research.js'
 import { wsHeartbeat } from './ws-heartbeat.js'
 import { getBuildInfo } from './buildInfo.js'
 import { appendStoredLog, readStoredLogs, getStoredLogPath } from './logStore.js'
-import { getAgentRoles, getAgentRolesSource, loadAgentRoles, startConfigWatch, suggestAssignee, suggestReviewer, checkWipCap, saveAgentRoles, scoreAssignment, getAgentRole, getAgentAliases, setAgentDisplayName, resolveAgentMention } from './assignment.js'
+import { getAgentRoles, getAgentRolesSource, loadAgentRoles, startConfigWatch, suggestAssignee, suggestReviewer, checkWipCap, saveAgentRoles, scoreAssignment, getAgentRole, getAgentAliases, setAgentDisplayName, resolveAgentMention, parseRolesYaml } from './assignment.js'
 import { initTelemetry, trackRequest as trackTelemetryRequest, trackError as trackTelemetryError, trackTaskEvent, getSnapshot as getTelemetrySnapshot, getTelemetryConfig, isTelemetryEnabled, stopTelemetry } from './telemetry.js'
 import { recordUsage as recordUsageTracking, recordUsageBatch, getUsageSummary, getUsageByAgent, getUsageByModel, getUsageByTask, getDailySpendByModel, getAvgCostByLane, getAvgCostByAgent, setCap, listCaps, deleteCap, checkCaps, getRoutingSuggestions, estimateCost, ensureUsageTables, type UsageEvent, type SpendCap } from './usage-tracking.js'
 import { getTeamConfigHealth } from './team-config.js'
@@ -11057,11 +11057,45 @@ export async function createServer(): Promise<FastifyInstance> {
       const { writeFileSync } = await import('node:fs')
       const { join } = await import('node:path')
       const filePath = join(REFLECTT_HOME, 'TEAM-ROLES.yaml')
-      writeFileSync(filePath, yaml, 'utf-8')
+
+      // Preserve claimed founding agents that the new yaml drops.
+      // When `main` calls /agents/main/identity/claim it renames itself in TEAM-ROLES.yaml
+      // (e.g. main → beacon) and persists avatar/voice/color into agent_config.settings.
+      // A subsequent PUT /config/team-roles that lists only the new team agents would
+      // wipe the renamed founder from yaml, orphaning it: agent_config still has its
+      // identity, but role resolution / @mention fallback / heartbeat all break.
+      // Detect this: any prev role whose name is in agent_config (with claimed identity)
+      // and missing from the incoming yaml gets re-merged before we save.
+      const prevRoles = getAgentRoles()
+      const prevAgentNames = new Set(prevRoles.map(r => r.name))
+      let preservedNames: string[] = []
+      let yamlToWrite = yaml
+      try {
+        const incomingRoles = parseRolesYaml(yaml)
+        const incomingNames = new Set(incomingRoles.map(r => r.name.toLowerCase()))
+        const claimedIds = getClaimedAgentIds()
+        const preserved = prevRoles.filter(r =>
+          claimedIds.has(r.name.toLowerCase()) && !incomingNames.has(r.name.toLowerCase())
+        )
+        if (preserved.length > 0) {
+          // Use saveAgentRoles to write the merged structured roster (preserves
+          // aliases/avatar/voice fields verbatim). The raw yaml string is discarded
+          // for this path; downstream load reads the merged file.
+          saveAgentRoles([...incomingRoles, ...preserved])
+          preservedNames = preserved.map(r => r.name)
+          console.log(`[config/team-roles] Preserved ${preserved.length} claimed agent(s) dropped by incoming yaml: ${preservedNames.join(', ')}`)
+        } else {
+          writeFileSync(filePath, yamlToWrite, 'utf-8')
+        }
+      } catch (parseErr) {
+        // If we can't parse the incoming yaml, fall back to the original write —
+        // the loadAgentRoles() below will surface the parse failure.
+        writeFileSync(filePath, yamlToWrite, 'utf-8')
+        console.warn(`[config/team-roles] Could not parse yaml for preservation check: ${(parseErr as Error).message}`)
+      }
 
       // Hot-reload the team config
       const { loadAgentRoles } = await import('./assignment.js')
-      const prevAgentNames = new Set(getAgentRoles().map(r => r.name))
       const reloaded = loadAgentRoles()
 
       // Broadcast new agents to canvas so they appear immediately (with idle orb)


### PR DESCRIPTION
## Summary

**Seam 1** of the agent-owned identity verification (task-1776796380591-wroo87jmu).

When `main` calls `POST /agents/main/identity/claim` it renames itself in TEAM-ROLES.yaml (e.g. `main` → `beacon`) and persists avatar/voice/identityColor into `agent_config.settings`. The bootstrap flow then immediately overwrites TEAM-ROLES.yaml via `PUT /config/team-roles` with only the newly-designed team agents — wiping the renamed founder from yaml. Result: `agent_config` still has its identity, but role resolution / @mention fallback / heartbeat all break, because the founder no longer appears in the roster.

## Fix

On the PUT path, detect any prev role whose name is in `agent_config` with at least one of `avatar` / `voice` / `identityColor` set, and missing from the incoming yaml. Re-merge those roles into the saved roster via `saveAgentRoles` — that serializer preserves aliases/avatar/voice verbatim.

## Changes

- **agent-config.ts**: new `getClaimedAgentIds()` returns the set of agent IDs that have claimed any identity field
- **assignment.ts**: export `parseRolesYaml` so the server handler can compute the diff against the prev roster
- **server.ts** (`PUT /config/team-roles`): preservation merge before write; falls back to the original raw write on yaml parse failure

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] @link to rerun verification proof on host `rn-4c33cd05-8gvlup` once merged + deployed
- [ ] After confirmed: roster contains `beacon` (or whatever main renamed to) with avatar/voice and `main` as alias

After Seam 1 lands, Seams 2/3 next per @kai's order (OpenClaw Q&A leak, then @main routing fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)