### PR TITLE
Seam 3: alias-aware mention-ack so @main routes to renamed founder

### DIFF
--- a/src/mention-ack.ts
+++ b/src/mention-ack.ts
@@ -12,6 +12,8 @@
  * Exposes ack-latency metrics for health/compliance reporting.
  */
 
+import { resolveAgentMention } from './assignment.js'
+
 export interface MentionAckEntry {
   id: string
   mentionedAgent: string
@@ -239,7 +241,15 @@ class MentionAckTracker {
 
   private extractMentions(content: string): string[] {
     const matches = [...content.matchAll(MENTION_REGEX)]
-    return [...new Set(matches.map(m => m[1].toLowerCase()))]
+    // Resolve each literal capture through the alias-aware resolver so that
+    // `@main` after a `main → apex` rename is recorded as `apex` (canonical),
+    // not as the literal that no agent will ever ack. Fall back to the literal
+    // when the resolver returns nothing so unknown @whoever stays debuggable.
+    const resolved = matches.map(m => {
+      const literal = m[1].toLowerCase()
+      return resolveAgentMention(literal)?.toLowerCase() ?? literal
+    })
+    return [...new Set(resolved)]
   }
 }
 

--- a/tests/mention-ack-alias.test.ts
+++ b/tests/mention-ack-alias.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+//
+// Locks Seam 3: when a fresh managed agent renames itself (e.g. main → apex)
+// and persists `main` as an alias, live `@main` mentions must record the
+// pending ack against the canonical agent (`apex`), NOT the literal `main`
+// that no agent will ever ack.
+//
+// Bug captured by link's fresh-host proof on rn-d62950b0-5agkbn:
+//   - team/roles: apex with aliases ["main", "apex"] ✓
+//   - posted "@main ping seam3 …"
+//   - /health/mention-ack/main → count: 1 (literal stuck)
+//   - /health/mention-ack/apex → count: 0 (canonical missed)
+// task-1776819531813-j7xstmkuh
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mentionAckTracker } from '../src/mention-ack.js'
+import { setTestRoles } from '../src/assignment.js'
+
+describe('mention-ack alias resolution', () => {
+  beforeEach(() => {
+    setTestRoles([
+      {
+        name: 'apex',
+        role: 'lead',
+        aliases: ['main', 'apex'],
+        affinityTags: [],
+        wipCap: 1,
+      },
+    ])
+  })
+
+  afterEach(() => {
+    setTestRoles(null)
+  })
+
+  it('resolves @main → apex when apex carries main as an alias', () => {
+    const mentioned = mentionAckTracker.recordMessage({
+      id: 'msg-test-seam3-1',
+      from: 'claude',
+      content: '@main ping seam3',
+      channel: 'general',
+    })
+
+    expect(mentioned).toContain('apex')
+    expect(mentioned).not.toContain('main')
+
+    expect(mentionAckTracker.getPending('apex').length).toBeGreaterThan(0)
+    expect(mentionAckTracker.getPending('main').length).toBe(0)
+  })
+
+  it('apex posting in same channel acks the @main pending entry', () => {
+    // Channel-scoped pending is keyed by (agent, channel); use a unique
+    // channel per test to dodge tracker singleton state from sibling tests.
+    const channel = 'seam3-ack-channel'
+
+    mentionAckTracker.recordMessage({
+      id: 'msg-test-seam3-2',
+      from: 'claude',
+      content: '@main please ack',
+      channel,
+    })
+
+    expect(
+      mentionAckTracker.getPending('apex').filter(e => e.channel === channel).length
+    ).toBe(1)
+
+    mentionAckTracker.recordMessage({
+      id: 'msg-test-seam3-3',
+      from: 'apex',
+      content: 'on it',
+      channel,
+    })
+
+    expect(
+      mentionAckTracker.getPending('apex').filter(e => e.channel === channel).length
+    ).toBe(0)
+  })
+
+  it('falls back to the literal mention when no agent role resolves', () => {
+    const channel = 'seam3-ghost-channel'
+    const mentioned = mentionAckTracker.recordMessage({
+      id: 'msg-test-seam3-4',
+      from: 'claude',
+      content: '@ghost who are you',
+      channel,
+    })
+
+    expect(mentioned).toContain('ghost')
+    expect(
+      mentionAckTracker.getPending('ghost').filter(e => e.channel === channel).length
+    ).toBe(1)
+  })
+
+  it('@apex (canonical) still resolves to apex (not double-resolved)', () => {
+    const mentioned = mentionAckTracker.recordMessage({
+      id: 'msg-test-seam3-5',
+      from: 'claude',
+      content: '@apex direct ping',
+      channel: 'general',
+    })
+
+    expect(mentioned).toEqual(['apex'])
+  })
+})


### PR DESCRIPTION
## Summary

After a fresh managed agent renames itself (e.g. `main → apex`), `TEAM-ROLES.yaml` correctly persists `main` as an alias on `apex` (Seam 1). But the live mention-ack tracker in `src/mention-ack.ts` was extracting `@main` literally and creating a pending entry under `"main"` — `apex` never saw or acked it.

This routes every captured mention through `resolveAgentMention()` (which already walks name → displayName → aliases) before the pending state is recorded, so:

- pending entry is keyed by the canonical agent name (`apex`)
- when `apex` posts in the same channel, the entry resolves as expected
- `/health/mention-ack/apex` shows the count, not `/health/mention-ack/main`
- unknown `@whoever` falls back to the literal capture so debuggability is preserved

Narrow scope per kai's instruction: no identity work, no bootstrap work, no yaml changes.

Closes verification gap reported by @link on `rn-d62950b0-5agkbn.fly.dev`:
- `/health/mention-ack/main` → count: 1 (literal stuck)
- `/health/mention-ack/apex` → count: 0 (canonical missed)

task-1776819531813-j7xstmkuh

## Test plan

- [x] `tests/mention-ack-alias.test.ts` (new) — locks the four cases: alias resolves to canonical, apex post acks the @main pending, unknown mention falls back to literal, canonical mention isn't double-resolved
- [x] Full vitest suite (2525 tests) passes — no regressions
- [x] `tsc --noEmit` clean
- [ ] @link reruns the fresh-host proof on a managed host built from this image: post `@main ping seam3 <ts>`, expect `/health/mention-ack/apex` count = 1 and apex acks

🤖 Generated with [Claude Code](https://claude.com/claude-code)