### PR TITLE
fix(cloud): auto-reclaim credential on "Invalid or expired token"

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -172,7 +172,7 @@ function isIdle(): boolean {
 
 // ── Connection lifecycle tracking ──────────────────────────────────
 interface ConnectionEvent {
-  type: 'connected' | 'disconnected' | 'reconnected' | 'error' | 'heartbeat_failed' | 'heartbeat_recovered'
+  type: 'connected' | 'disconnected' | 'reconnected' | 'error' | 'heartbeat_failed' | 'heartbeat_recovered' | 'credential_reclaim_attempt' | 'credential_reclaim_success' | 'credential_reclaim_failed'
   timestamp: number
   reason?: string
   errorCount?: number
@@ -2236,7 +2236,93 @@ interface CloudApiResponse<T = unknown> {
   error?: string
 }
 
-async function cloudGet<T = unknown>(path: string): Promise<CloudApiResponse<T>> {
+// Match cloud responses that indicate the bearer credential was rejected.
+// Cloud returns `{ error: "Invalid or expired token" }` (or a 401/403 status)
+// when the host's per-host credential is no longer accepted.
+function isExpiredCredentialError(status: number, errorMessage: string | undefined): boolean {
+  if (status === 401 || status === 403) return true
+  if (!errorMessage) return false
+  return /invalid or expired token/i.test(errorMessage)
+}
+
+// Single-flight reclaim: if many requests fail simultaneously, only one
+// re-claim runs; the rest await its result.
+let reclaimInFlight: Promise<boolean> | null = null
+
+/**
+ * Re-run /api/hosts/claim with the configured join token to obtain a fresh
+ * credential after the cloud has rejected the current one. Uses raw fetch to
+ * avoid recursing through cloudPost. Returns true on success.
+ */
+async function attemptCredentialReclaim(): Promise<boolean> {
+  if (!config) return false
+  if (reclaimInFlight) return reclaimInFlight
+
+  reclaimInFlight = (async () => {
+    const previousCredential = state.credential
+    logConnectionEvent({ type: 'credential_reclaim_attempt', timestamp: Date.now(), reason: 'cloud rejected current credential' })
+    console.warn('☁️  Cloud credential rejected — attempting reclaim with join token...')
+
+    if (!config!.token) {
+      logConnectionEvent({ type: 'credential_reclaim_failed', timestamp: Date.now(), reason: 'no join token configured (set REFLECTT_HOST_TOKEN to enable auto-reclaim)' })
+      console.warn('☁️  Reclaim skipped: no REFLECTT_HOST_TOKEN configured. Operator intervention required.')
+      return false
+    }
+
+    try {
+      const url = `${config!.cloudUrl}/api/hosts/claim`
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${config!.token}`,
+        },
+        body: JSON.stringify({
+          joinToken: config!.token,
+          name: config!.hostName,
+          capabilities: config!.capabilities,
+        }),
+      })
+
+      if (!response.ok) {
+        const errBody = await response.json().catch(() => ({})) as Record<string, unknown>
+        const reason = (errBody.error as string) || `HTTP ${response.status}`
+        logConnectionEvent({ type: 'credential_reclaim_failed', timestamp: Date.now(), reason })
+        console.warn(`☁️  Reclaim failed: ${reason}`)
+        // Restore previous credential so the caller's subsequent retry doesn't
+        // accidentally fall through to the join-token path on managed hosts
+        // where the join token IS the rejected credential.
+        state.credential = previousCredential
+        return false
+      }
+
+      const payload = await response.json() as { host?: { id?: string }; credential?: { token?: string } }
+      if (payload.host?.id && payload.credential?.token) {
+        state.hostId = payload.host.id
+        state.credential = payload.credential.token
+        logConnectionEvent({ type: 'credential_reclaim_success', timestamp: Date.now(), reason: `re-claimed (hostId: ${state.hostId})` })
+        console.log(`☁️  Credential reclaimed — heartbeat/sync will resume on next tick (hostId: ${state.hostId})`)
+        return true
+      }
+
+      logConnectionEvent({ type: 'credential_reclaim_failed', timestamp: Date.now(), reason: 'unexpected claim response shape' })
+      state.credential = previousCredential
+      return false
+    } catch (err: any) {
+      logConnectionEvent({ type: 'credential_reclaim_failed', timestamp: Date.now(), reason: err?.message || 'reclaim threw' })
+      state.credential = previousCredential
+      return false
+    }
+  })()
+
+  try {
+    return await reclaimInFlight
+  } finally {
+    reclaimInFlight = null
+  }
+}
+
+async function cloudGet<T = unknown>(path: string, _retried = false): Promise<CloudApiResponse<T>> {
   if (!config) return { success: false, error: 'Not configured' }
 
   try {
@@ -2253,7 +2339,14 @@ async function cloudGet<T = unknown>(path: string): Promise<CloudApiResponse<T>>
 
     if (!response.ok) {
       const errBody = await response.json().catch(() => ({})) as Record<string, unknown>
-      return { success: false, error: (errBody.error as string) || `HTTP ${response.status}` }
+      const errorMessage = (errBody.error as string) || `HTTP ${response.status}`
+
+      if (!_retried && isExpiredCredentialError(response.status, errorMessage)) {
+        const reclaimed = await attemptCredentialReclaim()
+        if (reclaimed) return cloudGet<T>(path, true)
+      }
+
+      return { success: false, error: errorMessage }
     }
 
     const payload = await response.json() as T
@@ -2263,7 +2356,7 @@ async function cloudGet<T = unknown>(path: string): Promise<CloudApiResponse<T>>
   }
 }
 
-async function cloudPost<T = unknown>(path: string, body: unknown): Promise<CloudApiResponse<T>> {
+async function cloudPost<T = unknown>(path: string, body: unknown, _retried = false): Promise<CloudApiResponse<T>> {
   if (!config) return { success: false, error: 'Not configured' }
 
   try {
@@ -2287,7 +2380,18 @@ async function cloudPost<T = unknown>(path: string, body: unknown): Promise<Clou
 
     if (!response.ok) {
       const errBody = await response.json().catch(() => ({})) as Record<string, unknown>
-      return { success: false, error: (errBody.error as string) || `HTTP ${response.status}` }
+      const errorMessage = (errBody.error as string) || `HTTP ${response.status}`
+
+      // Auto-reclaim path: if the cloud rejected our credential and we haven't
+      // already retried this request, re-claim and retry once. Skipping the
+      // claim endpoint itself prevents a recursive loop if cloud also rejects
+      // the join token.
+      if (!_retried && path !== '/api/hosts/claim' && isExpiredCredentialError(response.status, errorMessage)) {
+        const reclaimed = await attemptCredentialReclaim()
+        if (reclaimed) return cloudPost<T>(path, body, true)
+      }
+
+      return { success: false, error: errorMessage }
     }
 
     const payload = await response.json() as T
@@ -2296,4 +2400,45 @@ async function cloudPost<T = unknown>(path: string, body: unknown): Promise<Clou
     // Don't increment errors here — callers handle error counting
     return { success: false, error: err?.message || 'Request failed' }
   }
+}
+
+// ── Test hooks ────────────────────────────────────────────────────────────
+// Exported for tests only — never use in product code.
+export const _testInternals = {
+  reset(): void {
+    config = null
+    state.hostId = null
+    state.credential = null
+    state.errors = 0
+    connectionEvents.length = 0
+    reclaimInFlight = null
+  },
+  configure(cfg: { cloudUrl: string; token: string; hostName: string }): void {
+    config = {
+      cloudUrl: cfg.cloudUrl,
+      token: cfg.token,
+      hostName: cfg.hostName,
+      hostType: 'openclaw',
+      heartbeatIntervalMs: DEFAULT_HEARTBEAT_MS,
+      taskSyncIntervalMs: DEFAULT_TASK_SYNC_MS,
+      capabilities: ['tasks', 'chat'],
+    }
+  },
+  setCredential(credential: string | null): void {
+    state.credential = credential
+  },
+  setHostId(hostId: string | null): void {
+    state.hostId = hostId
+  },
+  getCredential(): string | null {
+    return state.credential
+  },
+  getHostId(): string | null {
+    return state.hostId
+  },
+  getConnectionEvents(): ConnectionEvent[] {
+    return [...connectionEvents]
+  },
+  cloudPost,
+  cloudGet,
 }

--- a/tests/cloud-credential-reclaim.test.ts
+++ b/tests/cloud-credential-reclaim.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+//
+// Regression for the managed-host cloud-delivery seam:
+//   Before this fix, when the cloud started rejecting a host's credential
+//   ("Invalid or expired token"), the node kept sending the same dead bearer
+//   forever. heartbeat/chat sync stopped, every cloudPost piled into the
+//   error counter, and canvas messages sitting in the cloud's outbound queue
+//   never reached the host (delivered=false).
+//
+// task-1776807913205-71z35p70j (managed-host canvas chat delivery)
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { _testInternals } from '../src/cloud.js'
+
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+  _testInternals.reset()
+  _testInternals.configure({
+    cloudUrl: 'https://cloud.test',
+    token: 'join-tok-XXXX',
+    hostName: 'rn-test-host',
+  })
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  vi.restoreAllMocks()
+})
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('cloud credential auto-reclaim', () => {
+  it('on "Invalid or expired token", drops the bad credential, re-claims, and retries the original request', async () => {
+    _testInternals.setHostId('host-old')
+    _testInternals.setCredential('cred-stale')
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const auth = (init?.headers as Record<string, string> | undefined)?.Authorization
+
+      if (url.endsWith('/api/hosts/test/heartbeat') && auth === 'Bearer cred-stale') {
+        return jsonResponse(401, { error: 'Invalid or expired token' })
+      }
+      if (url.endsWith('/api/hosts/claim') && auth === 'Bearer join-tok-XXXX') {
+        return jsonResponse(200, {
+          host: { id: 'host-new' },
+          credential: { token: 'cred-fresh' },
+        })
+      }
+      if (url.endsWith('/api/hosts/test/heartbeat') && auth === 'Bearer cred-fresh') {
+        return jsonResponse(200, { ok: true })
+      }
+      throw new Error(`Unexpected fetch: ${url} (auth=${auth})`)
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const result = await _testInternals.cloudPost<{ ok: boolean }>('/api/hosts/test/heartbeat', { tick: 1 })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({ ok: true })
+    expect(_testInternals.getCredential()).toBe('cred-fresh')
+    expect(_testInternals.getHostId()).toBe('host-new')
+
+    const events = _testInternals.getConnectionEvents().map(e => e.type)
+    expect(events).toContain('credential_reclaim_attempt')
+    expect(events).toContain('credential_reclaim_success')
+
+    // 3 calls: original (rejected) → claim → retry (succeeds)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry indefinitely if reclaim itself is rejected', async () => {
+    _testInternals.setHostId('host-old')
+    _testInternals.setCredential('cred-stale')
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/hosts/claim')) {
+        return jsonResponse(401, { error: 'Invalid or expired token' })
+      }
+      return jsonResponse(401, { error: 'Invalid or expired token' })
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const result = await _testInternals.cloudPost('/api/hosts/test/heartbeat', { tick: 1 })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/invalid or expired token/i)
+    // Original credential preserved so the next operator-driven recovery can see what cloud rejected
+    expect(_testInternals.getCredential()).toBe('cred-stale')
+
+    const failures = _testInternals.getConnectionEvents().filter(e => e.type === 'credential_reclaim_failed')
+    expect(failures.length).toBe(1)
+
+    // 2 calls: original (rejected) → claim (also rejected). No infinite retry.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips reclaim when no join token is configured (managed-only host without REFLECTT_HOST_TOKEN)', async () => {
+    _testInternals.configure({
+      cloudUrl: 'https://cloud.test',
+      token: '', // no join token — operator-only recovery path
+      hostName: 'rn-managed-no-jointoken',
+    })
+    _testInternals.setHostId('host-mgd')
+    _testInternals.setCredential('cred-stale')
+
+    const fetchMock = vi.fn(async () => jsonResponse(401, { error: 'Invalid or expired token' }))
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const result = await _testInternals.cloudPost('/api/hosts/test/heartbeat', {})
+
+    expect(result.success).toBe(false)
+    // Single call — no reclaim attempted because there's no join token to use
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const failures = _testInternals.getConnectionEvents().filter(e => e.type === 'credential_reclaim_failed')
+    expect(failures.length).toBe(1)
+    expect(failures[0].reason).toMatch(/no join token/i)
+  })
+
+  it('coalesces concurrent rejections into a single reclaim (single-flight)', async () => {
+    _testInternals.setHostId('host-old')
+    _testInternals.setCredential('cred-stale')
+
+    let claimCallCount = 0
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const auth = (init?.headers as Record<string, string> | undefined)?.Authorization
+
+      if (url.endsWith('/api/hosts/claim')) {
+        claimCallCount++
+        // Slow response so concurrent callers actually overlap
+        await new Promise(r => setTimeout(r, 20))
+        return jsonResponse(200, {
+          host: { id: 'host-new' },
+          credential: { token: 'cred-fresh' },
+        })
+      }
+      if (auth === 'Bearer cred-stale') {
+        return jsonResponse(401, { error: 'Invalid or expired token' })
+      }
+      if (auth === 'Bearer cred-fresh') {
+        return jsonResponse(200, { ok: true })
+      }
+      throw new Error(`Unexpected: ${url}`)
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const [a, b, c] = await Promise.all([
+      _testInternals.cloudPost('/api/hosts/test/a', {}),
+      _testInternals.cloudPost('/api/hosts/test/b', {}),
+      _testInternals.cloudPost('/api/hosts/test/c', {}),
+    ])
+
+    expect(a.success).toBe(true)
+    expect(b.success).toBe(true)
+    expect(c.success).toBe(true)
+    expect(claimCallCount).toBe(1) // single-flight: one claim covers all three
+  })
+
+  it('does not reclaim for the claim endpoint itself (no recursion)', async () => {
+    _testInternals.setHostId('host-old')
+    _testInternals.setCredential('cred-stale')
+
+    const fetchMock = vi.fn(async () => jsonResponse(401, { error: 'Invalid or expired token' }))
+    globalThis.fetch = fetchMock as typeof fetch
+
+    const result = await _testInternals.cloudPost('/api/hosts/claim', { joinToken: 'join-tok-XXXX' })
+
+    expect(result.success).toBe(false)
+    // Exactly one call — claim endpoint must not trigger reclaim of itself
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- When cloud rejects a host's credential (`401 Invalid or expired token`), the node now drops the dead bearer, re-claims with the configured `joinToken`, and retries the original request once.
- Single-flight guard coalesces concurrent rejections into one `/api/hosts/claim` call.
- Reclaim uses raw `fetch` (not `cloudPost`) to avoid recursion; `/api/hosts/claim` is excluded from reclaim handling so a rejected claim never self-retries.

## Why
Without this, a host whose credential the cloud has expired stays bricked: heartbeat/chat sync stop forever, every `cloudPost` piles into the error counter, and canvas messages waiting in the cloud's outbound queue sit at `delivered=false`. This was the actual seam blocking the managed-host canvas chat delivery (task-1776807913205-71z35p70j) — not a double-write.

## Test plan
- [x] 5 new vitest cases in `tests/cloud-credential-reclaim.test.ts` cover: happy-path reclaim+retry, reclaim itself rejected (no infinite retry), no-join-token (managed-only host), single-flight coalescing, and no self-recursion on the claim endpoint.
- [x] `npm test` — all 5 pass.
- [x] `npm run build` — clean.
- [ ] @link to rerun the same managed-host canvas send after merge to confirm end-to-end delivery, then re-check duplicate-row behavior.

task-1776807913205-71z35p70j

🤖 Generated with [Claude Code](https://claude.com/claude-code)