### PR TITLE
feat(server): allow Fly 6PN callers on /agents/:name/runtime gate

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6312,19 +6312,25 @@ export async function createServer(): Promise<FastifyInstance> {
     return result
   })
 
-  // ── Agent Runtime Truth (loopback only — proxied by cloud) ─────────────
+  // ── Agent Runtime Truth (private network only — proxied by cloud) ──────
   // Node owns runtime/control truth: presence, last event, claimedAt.
   // Workspace-file truth (SOUL/MEMORY/HEARTBEAT) belongs to OpenClaw/gateway,
   // not node — deliberately omitted from this surface.
 
   const AGENT_NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/
 
-  function loopbackOnly(request: any, reply: any): boolean {
+  // Accepts loopback (local dev / SSH-into-node curl) AND Fly 6PN (`fdaa::/16`),
+  // which is the address the cloud-API box uses when it calls
+  // `http://rn-XXX.internal:4445`. Keys off `request.ip` (direct socket); we
+  // deliberately leave Fastify's `trustProxy:false` so X-Forwarded-For cannot
+  // forge an allowed source.
+  function privateNetworkOnly(request: any, reply: any): boolean {
     const ip = String(request.ip || '')
     const isLoopback = ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1'
-    if (!isLoopback) {
+    const isFly6PN = ip.toLowerCase().startsWith('fdaa:')
+    if (!isLoopback && !isFly6PN) {
       reply.code(403)
-      reply.send({ success: false, error: 'Forbidden: localhost-only endpoint' })
+      reply.send({ success: false, error: 'Forbidden: private-network-only endpoint' })
       return false
     }
     return true
@@ -6351,7 +6357,7 @@ export async function createServer(): Promise<FastifyInstance> {
   // identityClaimedAt (from agent_config.settings — pane's enabledForAgent axis).
   // No derived copy, no panel sugar — the pane composes the display layer.
   app.get<{ Params: { name: string } }>('/agents/:name/runtime', async (request, reply) => {
-    if (!loopbackOnly(request, reply)) return
+    if (!privateNetworkOnly(request, reply)) return
     const { name } = request.params
     if (!AGENT_NAME_RE.test(name)) {
       reply.code(400)

--- a/tests/agent-runtime-truth.test.ts
+++ b/tests/agent-runtime-truth.test.ts
@@ -82,11 +82,19 @@ describe('GET /agents/:name/runtime', () => {
     expect(status).toBe(400)
   })
 
-  it('returns 403 to non-loopback caller', async () => {
+  it('returns 403 to public-internet caller', async () => {
     const { status } = await req('GET', '/agents/claude/runtime', {
       remoteAddress: '203.0.113.7',
     })
     expect(status).toBe(403)
+  })
+
+  it('accepts Fly 6PN caller (fdaa::/16) for cloud→node proxy', async () => {
+    const { status, body } = await req('GET', '/agents/claude/runtime', {
+      remoteAddress: 'fdaa:0:1234:a7b:1c2:3d4:5e6:7',
+    })
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

- Renames `loopbackOnly` → `privateNetworkOnly` and accepts any IP starting `fdaa:` (Fly 6PN, `fdaa::/16`) in addition to `127.0.0.1` / `::1` / `::ffff:127.0.0.1`.
- Cloud-API calls into node land over `http://rn-XXX.internal:4445`, which presents an `fdaa:` source IP on the node socket — previously rejected as 403.
- Keys off `request.ip` (direct socket); Fastify's `trustProxy:false` is intentionally left unchanged so X-Forwarded-For cannot forge an allowed source.

## Why

`/agents/:name/runtime` (slice 1 of the agent detail pane) was gated to localhost-only when introduced. The cloud-side proxy lives on a separate Fly app (`reflectt-browser-api`) and reaches node over Fly 6PN, so every cloud→node call returns 403. This loosens the gate to the minimum viable boundary that matches the deployment topology.

Direction set in team chat (kai + pixel): preserve the boundary (cloud auths, node stays private), accept Fly 6PN by direct-IP check, do not loosen public-edge access.

## Pairs with

reflectt-cloud PR adding the cloud-side proxy + registry entry for `GET /api/hosts/:hostId/agents/:name/runtime`. This node patch must merge first (or together) so cloud's calls succeed.

## Test plan

- [x] Unit test added: `accepts Fly 6PN caller (fdaa::/16) for cloud→node proxy` returns 200
- [x] Existing test retained: 403 to public-internet caller (`203.0.113.7`)
- [x] All 13 tests in `tests/agent-runtime-truth.test.ts` pass locally
- [ ] After merge: deploy to one staging host, exercise the cloud proxy end-to-end against the new `/api/hosts/:hostId/agents/:name/runtime` route