### PR TITLE
feat(server): GET /agents/:name/heartbeat — runtime heartbeat surface

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -821,6 +821,7 @@ Node-owned runtime truth for the cloud detail-pane join. Loopback-gated (`127.0.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/agents/:name/runtime` | Thin runtime truth: `{ status, currentTaskId, lastEvent: {type,at}\|null, lastObservedAt, idleForMs, identityClaimedAt }`. `lastObservedAt` reflects real activity only — heartbeat ticks do NOT advance it. `identityClaimedAt` is persisted by `POST /agents/:name/identity/claim`. |
+| GET | `/agents/:name/heartbeat` | Runtime heartbeat truth for the agent detail panel. Returns `{ success, agent, lastBeatAt, sinceLastBeatMs, intervalMs, idleThresholdMs, offlineThresholdMs, status, beatsToday }`. `intervalMs` mirrors the cloud-sync cadence (`REFLECTT_HEARTBEAT_MS`, default 30000) so the client can render "missed N beats" without baking the interval. Loopback / Fly 6PN only (`fdaa::/16`). NOTE: returns runtime presence only — file content (`HEARTBEAT.md`) is served by the OpenClaw plugin via `/api/channels/reflectt/agents/:name/files`. |
 
 ## Other
 

--- a/src/presence.ts
+++ b/src/presence.ts
@@ -45,6 +45,10 @@ export interface AgentPresence {
   // Distinct from `lastUpdate` (which advances on heartbeat tick). Cloud reads this for the
   // detail-pane "connected" axis to show real activity, not periodic check-in cadence.
   lastObservedAt?: number
+  // Last `/heartbeat/:agent` poll. Distinct from `lastUpdate` (which also advances on
+  // messages/task_completed). The detail pane reads this for the "is the agent
+  // actively heartbeating" axis without confusing it with chat or task activity.
+  lastHeartbeatAt?: number
   focus?: FocusState
   waiting?: WaitingState  // populated when status === 'waiting'
   thought?: string        // agent's current thought — expires after 8s TTL on canvas
@@ -60,8 +64,8 @@ export interface AgentActivity {
   first_seen_today?: number
 }
 
-const IDLE_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes — active agents decay to idle
-const OFFLINE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — idle agents decay to offline
+export const IDLE_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes — active agents decay to idle
+export const OFFLINE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — idle agents decay to offline
 
 interface DailyActivity {
   date: string // YYYY-MM-DD
@@ -571,6 +575,7 @@ export class PresenceManager {
       presence.last_active = now
       presence.lastUpdate = now
       if (type !== 'heartbeat') presence.lastObservedAt = now
+      if (type === 'heartbeat') presence.lastHeartbeatAt = now
       this.presence.set(agent, presence)
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,7 +60,7 @@ import { memoryManager } from './memory.js'
 import { buildContextInjection, getContextBudgets, getContextMemo, upsertContextMemo, type ContextLayer } from './context-budget.js'
 import { deriveScopeId } from './scope-routing.js'
 import { eventBus, VALID_EVENT_TYPES } from './events.js'
-import { presenceManager } from './presence.js'
+import { presenceManager, IDLE_THRESHOLD_MS, OFFLINE_THRESHOLD_MS } from './presence.js'
 import type { NotificationType, NotificationPriorityLevel, AckDecision, NotificationStatus } from './agent-notifications.js'
 import { startSweeper, getSweeperStatus, sweepValidatingQueue, flagPrDrift, generateDriftReport } from './executionSweeper.js'
 import { runRestartDriftGuard } from './restart-drift-guard.js'
@@ -6399,6 +6399,11 @@ export async function createServer(): Promise<FastifyInstance> {
 
   const AGENT_NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/
 
+  // Cloud-sync heartbeat cadence — must match `cloud.ts` (REFLECTT_HEARTBEAT_MS
+  // override, default 30s). Surfaced so the detail pane can compute a
+  // "missed N beats" axis without baking the interval into the client.
+  const HEARTBEAT_EXPECTED_INTERVAL_MS = Number(process.env.REFLECTT_HEARTBEAT_MS) || 30_000
+
   // Accepts loopback (local dev / SSH-into-node curl) AND Fly 6PN (`fdaa::/16`),
   // which is the address the cloud-API box uses when it calls
   // `http://rn-XXX.internal:4445`. Keys off `request.ip` (direct socket); we
@@ -6456,6 +6461,34 @@ export async function createServer(): Promise<FastifyInstance> {
       lastObservedAt,
       idleForMs,
       identityClaimedAt: readIdentityClaimedAt(name),
+    }
+  })
+
+  // GET /agents/:name/heartbeat — runtime heartbeat truth for the detail pane.
+  // Per kai's lane lock 2026-04-23 (msg-1776931994885): node owns runtime/control,
+  // OpenClaw plugin owns workspace files. This endpoint surfaces ONLY the runtime
+  // heartbeat state — never the HEARTBEAT.md file content (that goes via the plugin's
+  // /api/channels/reflectt/agents/:name/files route).
+  app.get<{ Params: { name: string } }>('/agents/:name/heartbeat', async (request, reply) => {
+    if (!privateNetworkOnly(request, reply)) return
+    const { name } = request.params
+    if (!AGENT_NAME_RE.test(name)) {
+      reply.code(400)
+      return { success: false, error: 'Invalid agent name' }
+    }
+    const presence = presenceManager.getPresence(name)
+    const lastBeatAt = presence?.lastHeartbeatAt ?? null
+    const sinceLastBeatMs = lastBeatAt ? Date.now() - lastBeatAt : null
+    return {
+      success: true,
+      agent: name,
+      lastBeatAt,
+      sinceLastBeatMs,
+      intervalMs: HEARTBEAT_EXPECTED_INTERVAL_MS,
+      idleThresholdMs: IDLE_THRESHOLD_MS,
+      offlineThresholdMs: OFFLINE_THRESHOLD_MS,
+      status: presence?.status ?? 'offline',
+      beatsToday: presenceManager.getAgentActivity(name)?.heartbeats_today ?? 0,
     }
   })
 

--- a/tests/agent-heartbeat-truth.test.ts
+++ b/tests/agent-heartbeat-truth.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createServer } from '../src/server.js'
+import { presenceManager, IDLE_THRESHOLD_MS, OFFLINE_THRESHOLD_MS } from '../src/presence.js'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { FastifyInstance } from 'fastify'
+
+let app: FastifyInstance
+let sandbox: string
+let savedHome: string | undefined
+
+beforeAll(async () => {
+  sandbox = mkdtempSync(join(tmpdir(), 'agent-heartbeat-truth-'))
+  savedHome = process.env.OPENCLAW_HOME
+  process.env.OPENCLAW_HOME = sandbox
+
+  app = await createServer()
+  await app.ready()
+})
+
+afterAll(async () => {
+  await app.close()
+  if (savedHome === undefined) delete process.env.OPENCLAW_HOME
+  else process.env.OPENCLAW_HOME = savedHome
+  rmSync(sandbox, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  presenceManager.clearAll()
+})
+
+async function req(method: string, url: string, opts?: { remoteAddress?: string }) {
+  const res = await app.inject({
+    method: method as any,
+    url,
+    remoteAddress: opts?.remoteAddress,
+  })
+  let body: any = res.body
+  try { body = JSON.parse(res.body) } catch {}
+  return { status: res.statusCode, body }
+}
+
+describe('GET /agents/:name/heartbeat', () => {
+  it('returns offline defaults with thresholds when no presence', async () => {
+    const { status, body } = await req('GET', '/agents/ghost-agent/heartbeat')
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.agent).toBe('ghost-agent')
+    expect(body.status).toBe('offline')
+    expect(body.lastBeatAt).toBeNull()
+    expect(body.sinceLastBeatMs).toBeNull()
+    expect(body.beatsToday).toBe(0)
+    expect(body.intervalMs).toBeGreaterThan(0)
+    expect(body.idleThresholdMs).toBe(IDLE_THRESHOLD_MS)
+    expect(body.offlineThresholdMs).toBe(OFFLINE_THRESHOLD_MS)
+  })
+
+  it('reports lastBeatAt and sinceLastBeatMs after a heartbeat tick', async () => {
+    presenceManager.updatePresence('claude', 'working', 'task-7')
+    presenceManager.recordActivity('claude', 'heartbeat')
+
+    const { status, body } = await req('GET', '/agents/claude/heartbeat')
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(typeof body.lastBeatAt).toBe('number')
+    expect(typeof body.sinceLastBeatMs).toBe('number')
+    expect(body.sinceLastBeatMs).toBeGreaterThanOrEqual(0)
+    expect(body.status).toBe('working')
+  })
+
+  it('rejects bad agent name with 400', async () => {
+    const { status } = await req('GET', '/agents/Bad..Name/heartbeat')
+    expect(status).toBe(400)
+  })
+
+  it('returns 403 to public-internet caller', async () => {
+    const { status } = await req('GET', '/agents/claude/heartbeat', {
+      remoteAddress: '203.0.113.7',
+    })
+    expect(status).toBe(403)
+  })
+
+  it('accepts Fly 6PN caller (fdaa::/16) for cloud→node proxy', async () => {
+    const { status, body } = await req('GET', '/agents/claude/heartbeat', {
+      remoteAddress: 'fdaa:0:1234:a7b:1c2:3d4:5e6:7',
+    })
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `GET /agents/:name/heartbeat` returning `{ lastBeatAt, sinceLastBeatMs, intervalMs, idleThresholdMs, offlineThresholdMs, status, beatsToday }` for the agent-detail Phase 1 panel.
- Splits heartbeat ticks from real activity: new `presence.lastHeartbeatAt` (heartbeat-only) preserves `lastObservedAt` semantics for actual messages/tasks.
- Exports `IDLE_THRESHOLD_MS` / `OFFLINE_THRESHOLD_MS` and adds `HEARTBEAT_EXPECTED_INTERVAL_MS` (mirrors cloud.ts) so the panel can compute "missed N beats" without baking the interval into the client.

## Why
Phase 1 panel needs a runtime heartbeat axis distinct from chat/task activity. Per kai's lane lock 2026-04-23 (msg-1776931994885 / task-1776909288586-rj1oi36ws): node stays runtime-only — `HEARTBEAT.md` file content rides the OpenClaw plugin path.

## Cross-repo dependencies
- `reflectt-channel-openclaw` — companion PR for `/files` and `/memory` plugin reads
- `reflectt-cloud` — companion PR (target `develop`) for the cloud proxy routes that surface this through `api.reflectt.ai`

## Test plan
- [x] vitest: 5/5 in `tests/agent-heartbeat-truth.test.ts` (defaults, populated shape, agent-name validation, loopback gate, Fly 6PN cloud-proxy access)
- [x] `tsc --noEmit` clean
- [ ] Staging proof against host `e4e35463-02d7-420d-a00d-65e765ade5a2` / agent `main` once cloud + plugin sides ship