### PR TITLE
feat(node): GET /openclaw/models — surface gateway models.list over existing WS

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -836,6 +836,7 @@ Node-owned runtime truth for the cloud detail-pane join. Loopback-gated (`127.0.
 | GET | `/shared/read` | Read file from shared workspace. Query: `path` (required), `include=preview` (truncated), `maxChars` (default 2000). Security: same as `/shared/list` + size cap (400KB). |
 | GET | `/shared/view` | HTML viewer for shared workspace artifacts. Query: `path` (required). Dark-themed in-browser view. |
 | GET | `/openclaw/status` | OpenClaw connection status |
+| GET | `/openclaw/models` | Gateway model catalog. Calls `OpenClawClient.request('models.list')` over the existing node↔gateway WS and returns `{ success, models: [{id, name, provider, contextWindow, reasoning, input}] }`. Cloud reads from here for the agent-details models capability axis. Private network only (loopback or Fly 6PN). |
 | GET | `/secrets` | List all secrets (metadata only — no plaintext values) |
 | POST | `/secrets` | Create/update a secret (encrypts locally, stores ciphertext) |
 | GET | `/secrets/export` | Export all secrets as encrypted bundle for portability |

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -268,6 +268,12 @@ export class OpenClawClient {
     })
   }
 
+  // Native gateway protocol method: returns `{ models }` from
+  // loadGatewayModelCatalog() (openclaw/dist/gateway/server-methods/models.js).
+  async models(): Promise<unknown> {
+    return this.request('models.list', {})
+  }
+
   isConnected(): boolean {
     return this.connected
   }
@@ -293,4 +299,5 @@ export const openclawClient = {
   isConnected() { return _client?.isConnected() ?? false },
   reidentify(identity: AgentIdentity) { _client?.reidentify(identity) },
   getIdentity(): AgentIdentity { return _client?.getIdentity() ?? { name: openclawConfig.agentId } },
+  models(): Promise<unknown> { return this.instance.models() },
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -17904,6 +17904,24 @@ If your heartbeat shows **no active task** and **no next task**:
     }
   })
 
+  // GET /openclaw/models — surface the gateway's native `models.list` over the
+  // existing node↔gateway WS. Cloud reads from here for the agent-details
+  // models capability axis; no plugin HTTP route is involved.
+  app.get('/openclaw/models', async (request, reply) => {
+    if (!privateNetworkOnly(request, reply)) return
+    if (!openclawClient.isConnected()) {
+      reply.code(503)
+      return { success: false, error: 'OpenClaw gateway WS not connected', gateway: openclawConfig.gatewayUrl }
+    }
+    try {
+      const payload = await openclawClient.models()
+      return { success: true, ...(payload as Record<string, unknown>) }
+    } catch (err) {
+      reply.code(502)
+      return { success: false, error: String((err as Error).message ?? err) }
+    }
+  })
+
   // ============ MCP ENDPOINTS ============
 
   // MCP HTTP endpoint (new protocol)


### PR DESCRIPTION
## Summary

- Adds `OpenClawClient.models()` calling the gateway's native `models.list` protocol method (`/usr/local/lib/node_modules/openclaw/dist/gateway/server-methods/models.js`) over the **existing** node↔gateway WebSocket — no new transport, no plugin HTTP route, no shelling.
- Exposes it as a `privateNetworkOnly` Fastify route at `GET /openclaw/models`, paralleling the existing `/openclaw/status` endpoint shape.
- Cloud's `fetchModelsForHost` will repoint at this in the follow-up PR (`reflectt-cloud` task #122) so the agent-details models capability axis flows through node, not through a gateway plugin HTTP route.

## Final architecture (per kai's `final_architecture_2026_04_23_1722` lock)

```
cloud REST → node /openclaw/models → OpenClawClient.request('models.list') → gateway native models.list → loadGatewayModelCatalog()
```

Supersedes the cloud → gateway-plugin direct HTTP path (PRs #19/#20 in `reflectt-channel-openclaw`), which were the wrong product seam.

## Test plan
- [ ] `npm run build` clean (verified locally)
- [ ] After merge + deploy on staging `rn-34faba44-wlgkeq`: curl from inside the host `curl -sS http://127.0.0.1:4445/openclaw/models | jq` and confirm `{success: true, models: {...}}` with the expected catalog shape
- [ ] kai re-runs `e4e35463` smoke for #119 once cloud repoint lands