### PR TITLE
fix(openclaw): eager init + surface handshake error in /openclaw/models 503

### DIFF
--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -51,6 +51,7 @@ export class OpenClawClient {
   }>()
   private eventHandlers = new Map<string, Set<(payload: unknown) => void>>()
   private activeIdentity: AgentIdentity = { name: openclawConfig.agentId }
+  private lastHandshakeError: string | null = null
 
   // Reconnect backoff: 1s, 2s, 4s, 8s, 16s, 30s (cap)
   private static readonly BASE_RECONNECT_MS = 1000
@@ -155,8 +156,10 @@ export class OpenClawClient {
 
       console.log('[OpenClaw] Handshake successful:', response)
       this.connected = true
+      this.lastHandshakeError = null
     } catch (err) {
       console.error('[OpenClaw] Handshake failed:', err)
+      this.lastHandshakeError = String((err as Error).message ?? err)
       this.ws?.close()
     }
   }
@@ -278,6 +281,10 @@ export class OpenClawClient {
     return this.connected
   }
 
+  getLastHandshakeError(): string | null {
+    return this.lastHandshakeError
+  }
+
   close() {
     this.stopPing()
     if (this.reconnectTimer) {
@@ -297,6 +304,7 @@ export const openclawClient = {
   },
   close() { _client?.close() },
   isConnected() { return _client?.isConnected() ?? false },
+  getLastHandshakeError(): string | null { return _client?.getLastHandshakeError() ?? null },
   reidentify(identity: AgentIdentity) { _client?.reidentify(identity) },
   getIdentity(): AgentIdentity { return _client?.getIdentity() ?? { name: openclawConfig.agentId } },
   models(): Promise<unknown> { return this.instance.models() },

--- a/src/server.ts
+++ b/src/server.ts
@@ -17909,9 +17909,20 @@ If your heartbeat shows **no active task** and **no next task**:
   // models capability axis; no plugin HTTP route is involved.
   app.get('/openclaw/models', async (request, reply) => {
     if (!privateNetworkOnly(request, reply)) return
+    // Force eager singleton init — without this, a never-instantiated client
+    // makes isConnected() return false and we surface a generic 503 without
+    // ever attempting the WS handshake.
+    void openclawClient.instance
     if (!openclawClient.isConnected()) {
+      const handshakeError = openclawClient.getLastHandshakeError()
       reply.code(503)
-      return { success: false, error: 'OpenClaw gateway WS not connected', gateway: openclawConfig.gatewayUrl }
+      return {
+        success: false,
+        error: handshakeError
+          ? `OpenClaw gateway handshake failed: ${handshakeError}`
+          : 'OpenClaw gateway WS not connected (still connecting)',
+        gateway: openclawConfig.gatewayUrl,
+      }
     }
     try {
       const payload = await openclawClient.models()


### PR DESCRIPTION
## Summary

Two small, additive changes to make `/openclaw/models` cold-path failures debuggable:

- **`openclaw.ts`** — `OpenClawClient` now tracks `lastHandshakeError`, set in the handshake catch block and cleared on success. New `getLastHandshakeError()` on both the class and the singleton wrapper.
- **`server.ts`** — `/openclaw/models` forces eager singleton init via `void openclawClient.instance` before the readiness check. If still not connected, the 503 body now includes the captured handshake error instead of a generic "not connected" string.

## Why

Before this change: on cold paths, `isConnected()` returned `false` because `_client?.isConnected() ?? false` short-circuited on the never-instantiated singleton. The route returned a generic 503 without ever attempting the WS handshake. And when the handshake did fail (e.g. `INVALID_REQUEST: invalid connect params: at /client/id`), the real error was only logged — never surfaced to the cloud caller.

This blocked diagnosis of the current cloud→node→gateway models.list chain on the canonical staging host.

## Scope

Observability-only. Does not change handshake behavior. Pairs with @link's separate PR fixing the actual handshake (`client.id` enum mismatch in the `connect` request).

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Deploy to staging node `rn-34faba44-wlgkeq`
- [ ] `curl http://rn-34faba44-wlgkeq.internal:4445/openclaw/models` (from cloud machine) — confirm 503 body contains the real `INVALID_REQUEST` error string while link's handshake fix is unmerged
- [ ] After link's handshake fix lands, confirm 200 with `{ success: true, models: [...] }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)