### PR TITLE
fix(openclaw): valid gateway-enum client.id + eager init/handshake-error propagation

### DIFF
--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -136,7 +136,11 @@ export class OpenClawClient {
         minProtocol: 3,
         maxProtocol: 3,
         client: {
-          id: this.activeIdentity.name,
+          // Gateway requires id to be one of the enum values in
+          // openclaw/dist/gateway/protocol/client-info.js (GATEWAY_CLIENT_IDS).
+          // We run as a CLI-mode operator; the actual agent identity (e.g. "claude")
+          // travels in displayName so the gateway can log/render it.
+          id: 'cli',
           displayName: this.activeIdentity.displayName || this.activeIdentity.name,
           version: PKG_VERSION,
           platform: 'node',

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -51,6 +51,7 @@ export class OpenClawClient {
   }>()
   private eventHandlers = new Map<string, Set<(payload: unknown) => void>>()
   private activeIdentity: AgentIdentity = { name: openclawConfig.agentId }
+  private lastHandshakeError: string | null = null
 
   // Reconnect backoff: 1s, 2s, 4s, 8s, 16s, 30s (cap)
   private static readonly BASE_RECONNECT_MS = 1000
@@ -155,8 +156,10 @@ export class OpenClawClient {
 
       console.log('[OpenClaw] Handshake successful:', response)
       this.connected = true
+      this.lastHandshakeError = null
     } catch (err) {
       console.error('[OpenClaw] Handshake failed:', err)
+      this.lastHandshakeError = String((err as Error).message ?? err)
       this.ws?.close()
     }
   }
@@ -278,6 +281,10 @@ export class OpenClawClient {
     return this.connected
   }
 
+  getLastHandshakeError(): string | null {
+    return this.lastHandshakeError
+  }
+
   close() {
     this.stopPing()
     if (this.reconnectTimer) {
@@ -297,6 +304,7 @@ export const openclawClient = {
   },
   close() { _client?.close() },
   isConnected() { return _client?.isConnected() ?? false },
+  getLastHandshakeError(): string | null { return _client?.getLastHandshakeError() ?? null },
   reidentify(identity: AgentIdentity) { _client?.reidentify(identity) },
   getIdentity(): AgentIdentity { return _client?.getIdentity() ?? { name: openclawConfig.agentId } },
   models(): Promise<unknown> { return this.instance.models() },

--- a/src/server.ts
+++ b/src/server.ts
@@ -17909,9 +17909,20 @@ If your heartbeat shows **no active task** and **no next task**:
   // models capability axis; no plugin HTTP route is involved.
   app.get('/openclaw/models', async (request, reply) => {
     if (!privateNetworkOnly(request, reply)) return
+    // Force eager singleton init — without this, a never-instantiated client
+    // makes isConnected() return false and we surface a generic 503 without
+    // ever attempting the WS handshake.
+    void openclawClient.instance
     if (!openclawClient.isConnected()) {
+      const handshakeError = openclawClient.getLastHandshakeError()
       reply.code(503)
-      return { success: false, error: 'OpenClaw gateway WS not connected', gateway: openclawConfig.gatewayUrl }
+      return {
+        success: false,
+        error: handshakeError
+          ? `OpenClaw gateway handshake failed: ${handshakeError}`
+          : 'OpenClaw gateway WS not connected (still connecting)',
+        gateway: openclawConfig.gatewayUrl,
+      }
     }
     try {
       const payload = await openclawClient.models()


### PR DESCRIPTION
## Summary

Two-commit fix to unblock the OpenClaw handshake path that's been bouncing every WS connection at the gateway and surfacing as 502s on `/capabilities/detail` model-context hydration + the staging E2E proof.

- **Commit 1 (367d487d)**: eager-init the OpenClaw client + propagate the handshake error from `/openclaw/models` so callers see the real reason instead of a generic 500.
- **Commit 2 (4f95dcec)**: send a valid gateway-enum value (`cli`) as `client.id`. The agent identity (e.g. `"claude"`, `"kai"`) continues to travel in `displayName`.

### Root cause

OpenClaw's gateway validates `connect` frames against `ConnectParamsSchema` where `client.id` is constrained to the `GATEWAY_CLIENT_IDS` enum (`cli`, `webchat-ui`, `openclaw-control-ui`, `node-host`, …). reflectt-node was sending `client.id: this.activeIdentity.name` (e.g. `"claude"`), which always fails AJV. Validated locally against the compiled gateway schema:
- old shape (`client.id: "claude"`) → AJV rejects (`must be equal to constant`)
- new shape (`client.id: "cli"`) → AJV accepts

We already pass `mode: 'cli'`, so `'cli'` is the matching enum.

### Why displayName

The gateway only uses `displayName` for logs/UI render of the operator's human name. Routing the agent identity (`claude`/`kai`/`pixel`/`link`) there keeps the multi-agent display story intact while satisfying the schema.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Local AJV validation against `openclaw/dist/gateway/protocol/index.js#validateConnectParams` — passes with new shape, fails with old
- [ ] Post-deploy: handshake completes against staging gateway (`rg-34faba44-ilajjh`)
- [ ] Post-deploy: `/openclaw/models` returns 200 with model catalog
- [ ] Cloud `/capabilities/detail` populates `context.models` end-to-end
- [ ] #119 staging E2E proof passes on canonical managed host

## Refs

- task-1776981570206-ufh6r8hpl
- Unblocks reflectt-cloud#2771 (consume `context.models` in AgentDetailPanel dropdowns)
- Unblocks reflectt task #119 (staging E2E proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)