### PR TITLE
fix(team-roles): sanitize host-internal path leakage in /team/roles response

### DIFF
--- a/public/docs.md
+++ b/public/docs.md
@@ -808,7 +808,7 @@ Autonomous work-continuity system. Monitors agent queue floors and auto-replenis
 | GET | `/polls/:id` | Get poll with results. Returns `{ poll }` with vote counts and voter lists. |
 | POST | `/polls/:id/vote` | Cast a vote. Body: `{ voter, choice }` (choice is 0-indexed). Allows changing vote. |
 | POST | `/polls/:id/close` | Close a poll manually. |
-| GET | `/team/roles` | TEAM-ROLES routing matrix — agent skills, affinity scores, WIP caps |
+| GET | `/team/roles` | TEAM-ROLES routing matrix — agent skills, affinity scores, WIP caps. `config.source` and `roleRegistry.source` are logical identifiers (e.g. `team-roles:default`, `builtin`) — host-internal absolute paths are never exposed across the cloud proxy boundary. |
 | GET | `/policy/intensity` | Current intensity preset + limits (wipLimit, maxPullsPerHour, batchIntervalMs). |
 | PUT | `/policy/intensity` | Set intensity preset. Body: `{ preset: "low"|"normal"|"high", updatedBy? }`. Returns new state. |
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -250,6 +250,17 @@ const CreateTaskSchema = z.object({
 })
 
 /**
+ * Replace any host-internal absolute path in a roles-source value with a
+ * logical identifier so the cloud proxy never sees node filesystem layout.
+ * Sentinel values produced by the loader ('builtin', 'test-override',
+ * 'TEAM_INTENT-bootstrap') and any other non-path string pass through.
+ */
+export function sanitizeRolesSource(raw: string | null | undefined): string {
+  if (raw == null) return 'team-roles:default'
+  return raw.startsWith('/') ? 'team-roles:default' : raw
+}
+
+/**
  * Definition-of-ready check: validates task quality at creation time.
  * Returns array of problems (empty = ready).
  */
@@ -11159,13 +11170,18 @@ export async function createServer(): Promise<FastifyInstance> {
     }
   })
 
-  // Team-scoped alias for assignment-engine consumers
+  // Team-scoped alias for assignment-engine consumers.
+  // Sanitizes config.source / roleRegistry.source so host-internal absolute
+  // paths (e.g. /home/node/.reflectt/TEAM-ROLES.yaml) do not cross the cloud
+  // proxy. Sentinel values like 'builtin' / 'test-override' pass through.
   app.get('/team/roles', async () => {
     const payload = buildRoleRegistryPayload()
+    const logicalSource = sanitizeRolesSource(payload.config.source)
     return {
       ...payload,
+      config: { ...payload.config, source: logicalSource },
       roleRegistry: {
-        source: payload.config.source,
+        source: logicalSource,
         count: payload.config.count,
         format: 'TEAM-ROLES.yaml',
       },

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -3231,6 +3231,32 @@ describe('Agent roles config', () => {
     expect(body.roleRegistry?.count).toBeGreaterThan(0)
   })
 
+  it('GET /team/roles does not leak host-internal absolute paths in source fields', async () => {
+    const { body } = await req('GET', '/team/roles')
+    // Both source fields must be a logical identifier — never an absolute path.
+    // Catches regression of TASK jonx1h7v2 (was leaking /home/node/.reflectt/TEAM-ROLES.yaml).
+    expect(typeof body.config?.source).toBe('string')
+    expect(body.config.source).not.toMatch(/^\//)
+    expect(body.config.source).not.toContain('/home/')
+    expect(body.config.source).not.toContain('.yaml')
+    expect(typeof body.roleRegistry?.source).toBe('string')
+    expect(body.roleRegistry.source).not.toMatch(/^\//)
+    expect(body.roleRegistry.source).not.toContain('/home/')
+    expect(body.roleRegistry.source).not.toContain('.yaml')
+  })
+
+  it('sanitizeRolesSource replaces absolute paths with logical identifier', async () => {
+    const { sanitizeRolesSource } = await import('../src/server.js')
+    expect(sanitizeRolesSource('/home/node/.reflectt/TEAM-ROLES.yaml')).toBe('team-roles:default')
+    expect(sanitizeRolesSource('/etc/reflectt/roles.yaml')).toBe('team-roles:default')
+    expect(sanitizeRolesSource(null)).toBe('team-roles:default')
+    expect(sanitizeRolesSource(undefined)).toBe('team-roles:default')
+    // Sentinel values pass through unchanged
+    expect(sanitizeRolesSource('builtin')).toBe('builtin')
+    expect(sanitizeRolesSource('test-override')).toBe('test-override')
+    expect(sanitizeRolesSource('TEAM_INTENT-bootstrap')).toBe('TEAM_INTENT-bootstrap')
+  })
+
   it('each agent has required fields', async () => {
     const { body } = await req('GET', '/agents/roles')
     for (const agent of body.agents) {


### PR DESCRIPTION
## Summary

`GET /team/roles` was leaking the absolute filesystem path `/home/node/.reflectt/TEAM-ROLES.yaml` in two fields (`config.source`, `roleRegistry.source`), exposing host filesystem layout to cloud / UI consumers of the proxied endpoint.

Per kai's `task-1776931753185-jonx1h7v2`: **exact-scope** fix at the response boundary only.

## What changed

- **`src/server.ts`** — `sanitizeRolesSource()`: replaces any value starting with `/` with the logical identifier `team-roles:default`. Sentinel values (`builtin`, `test-override`, `TEAM_INTENT-bootstrap`) pass through unchanged. Applied only at the `/team/roles` route (both `config.source` and `roleRegistry.source` get sanitized).
- **`tests/api.test.ts`** — Two new assertions:
  - Integration: `/team/roles` response — neither source field starts with `/`, contains `/home/`, or contains `.yaml`
  - Unit: `sanitizeRolesSource` with absolute path → `team-roles:default`; sentinels pass through

## Done-criteria

- [x] `GET /team/roles` no longer leaks `/home/node/.reflectt/TEAM-ROLES.yaml` in `config.source` or `roleRegistry.source`
- [x] Source fields replaced with logical identifier (`team-roles:default`)
- [x] Regression assertion added to node test suite

## Out of scope (intentionally untouched)

- `/agents` and `/agents/roles` — same `payload.config.source` underneath, but kai's task scope is `/team/roles` only. Separate seam if/when needed.
- `getAgentRolesSource()` in `src/assignment.ts` — internal callers (e.g. `continuity-loop`) still get the real path; only the response surface is sanitized.

## Test plan

- [x] `npx vitest run tests/api.test.ts` — 228/228 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Post-merge staging proof: `curl https://api.reflectt.ai/api/hosts/e4e35463-02d7-420d-a00d-65e765ade5a2/team/roles` → confirm `config.source === "team-roles:default"` and `roleRegistry.source === "team-roles:default"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)