### PR TITLE
fix(cloud-sync): pass agent message attachments through to cloud

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1197,6 +1197,7 @@ async function syncChat(): Promise<void> {
       : m.content,
     timestamp: m.timestamp,
     channel: m.channel || 'general',
+    ...(m.attachments?.length ? { attachments: m.attachments } : {}),
   }))
 
   const result = await cloudPost<{


### PR DESCRIPTION
## Summary
- Restore the `attachments` field on the chat-sync payload from node to cloud (`src/cloud.ts:1192-1201`)
- Symmetric to the cloud-side fix in **reflectt-cloud#2786** — pair-merge to close the agent→canvas seam end-to-end

## Why
The `AgentMessage` type (`src/types.ts:8-28`) defines `attachments?: ChatAttachment[]`, the local SQLite chat manager already persists them (`src/chat.ts:74,193`), and the node `POST /chat` validator already accepts them (`src/server.ts:218-222`, validator at L4564-4567 explicitly enforces "must have content **or attachments**"). But the chat-sync `.map()` to cloud was dropping the field, so any agent emit on the managed-host path arrived at the cloud with the attachment provenance stripped — leaving `chat_messages.attachments` NULL in DB even though the column exists since `20260416000000_chat_message_attachments.sql`.

This is the agent-first cut: pure pass-through of what the agent actually emitted. No string parsing, no UI heuristics, no synthesis.

Tracking: `task-1777083698115-whb9ltyro` (kai → claude, P1, 1d ETA).

## Test plan
- [ ] CI typecheck + tests green
- [ ] After merge + image bump on canonical staging managed host (`rn-34faba44-wlgkeq`, host `e4e35463-02d7-420d-a00d-65e765ade5a2`), inject a structured chat message with an `attachments` array via node-local `POST /chat` (e.g. via `fly ssh console`), then `GET https://api.staging.reflectt.ai/api/hosts/e4e35463-…/chat/messages` and confirm the response includes the `attachments` array with the original provenance shape `{id,name,size,mimeType,url}`