### PR TITLE
feat(mcp): expose attachments on send_message tool

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -41,15 +41,22 @@ const tool: (...args: any[]) => void = server.tool.bind(server)
 
 tool(
   "send_message",
-  "Send a message to the team chat. Use this to communicate with other agents.",
+  "Send a message to the team chat. Use this to communicate with other agents. When reporting on a tool result that produced an image, file, or other binary artifact (screenshot, generated image, document, etc.), pass the artifact via the `attachments` parameter using the actual values from the tool result — do NOT inline base64 or paste the raw URL into `content`.",
   {
     from: z.string().describe("Your agent name (e.g., 'main', 'builder', 'ops')"),
     content: z.string().describe("Message content"),
     to: z.string().optional().describe("Recipient agent name (optional, omit for broadcast)"),
     metadata: z.record(z.unknown()).optional().describe("Optional metadata"),
+    attachments: z.array(z.object({
+      id: z.string().describe("Stable id for the attachment (use the producing tool's id if present, e.g. screenshot id, generated image id)"),
+      name: z.string().describe("Filename to display (e.g. 'screenshot.png', 'diagram.png')"),
+      size: z.number().describe("Size in bytes from the tool result"),
+      mimeType: z.string().describe("MIME type from the tool result (e.g. 'image/png')"),
+      url: z.string().describe("Source URL from the tool result — http(s):// or data:<mime>;base64,... — use the value the tool returned, do not re-encode"),
+    })).optional().describe("File attachments produced by a real tool result (images, documents, screenshots). Set only when an upstream tool actually returned an artifact with these fields."),
   },
-  async ({ from, content, to, metadata }: any) => {
-    const message = await chatManager.sendMessage({ from, content, to, metadata })
+  async ({ from, content, to, metadata, attachments }: any) => {
+    const message = await chatManager.sendMessage({ from, content, to, metadata, attachments })
     return {
       content: [{
         type: "text",


### PR DESCRIPTION
## Summary

Add an optional `attachments` array to the MCP `send_message` tool so managed-host agents can natively emit structured attachments from real tool results, instead of inlining base64 or markdown image links into `content`.

## Why

Closes the agent-emit half of the canvas-attachments lane. Sibling task `task-1777083698115-whb9ltyro` shipped via PR #1289 just landed the transport seam. node-to-cloud sync now carries `attachments` end-to-end and the canvas renders them. But no managed-host agent could actually emit attachments because the MCP `send_message` tool did not expose the parameter, even though every layer below it accepts the field:

- chatManager.sendMessage accepts attachments via AgentMessage
- POST /chat/messages Zod validator already accepts attachments
- SQLite already persists attachments via safeJsonStringify
- Cloud sync already passes attachments through at cloud.ts:1200, shipped in 3d1dbfb
- Canvas already renders via AttachmentView

The MCP tool was the one missing layer. This patch is exactly that: schema plus handler destructure.

## Scope

- One tool, one file, +10/-3 lines
- No type changes, AgentMessage already has attachments?
- No DB migrations
- No cloud-side changes
- No renderer or canvas changes
- No text parsing, no UI heuristics, no synthesis

## Tool description constraint

The new parameter description tells the model to set it only when an upstream tool actually returned an artifact with these fields. The parent tool description tells the model to pass the artifact via the attachments parameter using the actual values from the tool result and not inline base64 or paste the raw URL into content. This keeps provenance native to the real envelope.

## Test plan

- npx tsc --noEmit clean locally
- After merge plus node bump on canonical staging host rn-34faba44-wlgkeq, verify a real managed-host agent invocation produces a chat message with native attachments populated. No synthetic POST proof per kai instruction.

## Refs

- Task: task-1777086068762-3mxn48pmx
- Sibling: task-1777083698115-whb9ltyro
- Sibling PR: reflectt-node#1289 / 3d1dbfb