### PR TITLE
feat(canvas): include real agent presence in canvas state push

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12946,9 +12946,19 @@ export async function createServer(): Promise<FastifyInstance> {
     const hostToken = process.env.REFLECTT_HOST_TOKEN
     const hostId = process.env.REFLECTT_HOST_ID
     if (!cloudUrl || !hostToken || !hostId) return
-    // Snapshot current canvas state
+    // Snapshot current canvas state. Project presence into the canvas `agents`
+    // map so the cloud relay (and SSE subscribers) see the real reply lifecycle:
+    // working/reviewing → 'working', everything else → 'ambient'. Offline agents
+    // are skipped so they don't render. No new states introduced.
     const activeSlots = canvasSlots.getActive()
-    const state = { slots: activeSlots, pushedAt: Date.now() }
+    const presences = presenceManager.getAllPresence()
+    const agents: Record<string, { state: string; task?: string | null }> = {}
+    for (const p of presences) {
+      if (p.status === 'offline') continue
+      const canvasState = (p.status === 'working' || p.status === 'reviewing') ? 'working' : 'ambient'
+      agents[p.agent] = { state: canvasState, task: p.task ?? null }
+    }
+    const state = { slots: activeSlots, agents, pushedAt: Date.now() }
     const stateJson = JSON.stringify(state)
     if (stateJson === lastPushedState) return
     try {


### PR DESCRIPTION
## Summary

`pushCanvasStateToCloud` now projects `presenceManager.getAllPresence()` into the canvas `state.agents` map so the cloud relay (and SSE subscribers to canvas) see the real reply lifecycle, not an inferred state from message arrival.

Mapping:
- `working` / `reviewing` → canvas `'working'` (renders existing `workingRing` in canvas)
- `idle` / `blocked` / `waiting` → canvas `'ambient'`
- `offline` → skipped (no ghost agents)

No new states introduced. Existing canvas renderer already handles `state==='working'`. Cloud relay (`apps/api/src/index.ts:5407`) already accepts `state.agents` map and upserts to `host_canvas_state`.

## Pairs with

- reflectt-channel-openclaw PR (POST /presence/:agent on real onReplyStart/onCleanup)

## Test plan

- [x] Type-check clean
- [x] Cloud relay route already accepts agents map (existing path, no schema changes)
- [x] Canvas already renders `state === 'working'` (`living-canvas.tsx:1769` workingRing)
- [ ] Canonical staging proof on host `e4e35463-...`: real agent reply drives canvas `working` live, then clears on done

## Scope (deferred)

- Canvas takeover wiring (POST /canvas/takeover) — held until working/idle proven
- No WebRTC/media transport, no generic health, no UI theater