### PR TITLE
fix(canvas): overlay live presence over auto floor stubs in syncCanvas

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1462,6 +1462,31 @@ async function syncCanvas(): Promise<void> {
     }
   } catch { /* non-fatal */ }
 
+  // ── Presence overlay (live reply lifecycle wins) ──────────────────────
+  // Real-time presenceManager truth wins over auto-derived floor stubs
+  // and other gap-fillers. When an agent is actively producing a reply
+  // (status='working' or 'reviewing'), overlay 'working' onto the
+  // outgoing agents map so the cloud canvas reflects the live lifecycle.
+  // Idle/other statuses are NOT overlaid — the underlying state (auto,
+  // task-derived, native) stays in place, so 'working' clears naturally
+  // back out on reply done via the next auto-state sweep.
+  // task-1777092014973-yet31f5py
+  try {
+    const livePresences = presenceManager.getAllPresence()
+    const nowOverlay = Date.now()
+    for (const p of livePresences) {
+      if (p.status !== 'working' && p.status !== 'reviewing') continue
+      const existing = (agents[p.agent] ?? {}) as Record<string, unknown>
+      agents[p.agent] = {
+        ...existing,
+        state: 'working',
+        updatedAt: nowOverlay,
+        source: 'presence-live',
+        avatar: (existing.avatar as string | null | undefined) ?? avatarMap[p.agent] ?? null,
+      }
+    }
+  } catch { /* non-fatal */ }
+
   // ── Needs-attention call hook ───────────────────────────────────────────
   // Check for new needs-attention transitions BEFORE pushing to cloud.
   // The Fly canvas handler also triggers auto-calls, but this node-side hook


### PR DESCRIPTION
## Summary

- `cloud.ts:syncCanvas` was building the outgoing canvas `agents` map from `canvasStateMap`, which the auto-state sweep (`canvas-auto-state.ts`) refreshes to `state: 'floor'` every 2s for any agent without a doing task.
- That race overwrote the new `pushCanvasStateToCloud` presence push (#1291) — Supabase `host_canvas_state` never reflected real reply-lifecycle `'working'` on the canonical staging host.
- Patch: overlay `presenceManager.getAllPresence()` onto the agents map after auto/task/thinking inference and before `cloudPost`. Any agent with `status='working'|'reviewing'` is overlaid as `state: 'working'`. Idle/other statuses are NOT overlaid, so `'working'` clears back out naturally via the next auto-state sweep.
- In-path only: same `syncCanvas`, same `/api/hosts/:hostId/canvas` endpoint, no new state values, no new endpoints.

## Why this is the missing hop

Canonical-host probe (msg-1777094585916-f7e3qpqor):
- Plugin onReplyStart → POST `/presence/compass` captured at `2026-04-25T05:23:08Z` and `05:23:11Z`
- Compass actually replied at `05:23:11Z`: `Reply → general: Canvas presence verified 🧭`
- Supabase `host_canvas_state` for compass/main/orbit polled every 0.5s for 30s → `state: 'floor'` the entire window. Never flipped to `'working'`.

Root cause: `syncCanvas` reads `canvasStateMap` (auto-state's `_auto: true` floor stubs) and POSTs them to the same per-agent table that the presence push targets, racing/winning.

## Test plan

- [ ] Vercel/CI checks green
- [ ] Deploy to canonical staging host (Fly app `rn-34faba44-wlgkeq`, machine `568354e7ad5348`)
- [ ] Send fresh probe to `@compass` on `e4e35463-02d7-420d-a00d-65e765ade5a2`
- [ ] Poll Supabase `host_canvas_state` and confirm `state` flips to `'working'` mid-reply
- [ ] Confirm `state` clears back out (to floor/ambient) after reply done

task-1777092014973-yet31f5py

🤖 Generated with [Claude Code](https://claude.com/claude-code)