### PR TITLE
canvas: immediate cloud push on presence_updated (slice 2)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12983,6 +12983,20 @@ export async function createServer(): Promise<FastifyInstance> {
   // Start pushing canvas state to cloud
   scheduleCloudPush()
 
+  // Immediate push on presence change — without this, transitions land on web up to
+  // CLOUD_PUSH_INTERVAL (5s) late. presence.ts already debounces emissions per-agent
+  // (60s same-status floor), so a 200ms trailing coalesce is enough to absorb
+  // multi-agent bursts. lastPushedState dedup short-circuits no-op pushes.
+  let immediateCloudPushTimer: ReturnType<typeof setTimeout> | null = null
+  eventBus.on('canvas-immediate-push-on-presence', (event) => {
+    if (event.type !== 'presence_updated') return
+    if (immediateCloudPushTimer) return
+    immediateCloudPushTimer = setTimeout(() => {
+      immediateCloudPushTimer = null
+      void pushCanvasStateToCloud()
+    }, 200)
+  })
+
   // ── Feedback Collection ─────────────────────────────────────────────
 
   const VALID_CATEGORIES = new Set(['bug', 'feature', 'general'])


### PR DESCRIPTION
## Summary
- Adds a single `eventBus.on('canvas-immediate-push-on-presence', ...)` listener in `server.ts` that calls the existing `pushCanvasStateToCloud()` on every `presence_updated` event.
- 200ms trailing coalesce absorbs multi-agent bursts → 1 fetch, not N.
- Same POST path (`/api/hosts/{hostId}/canvas`), same payload shape, same 5s safety timer left in place.
- Visible effect: agent state transitions (idle→working / working→idle) reach the cloud canvas + `/canvas/stream` SSE subscribers in ~200ms instead of polling-style 5s lag.

## Constraints honored (per @kai's slice 2 approval msg-1777145810469)
- Existing presence/runtime truth only (uses already-emitted `presence_updated`).
- No new event types.
- No new endpoint or path widening.
- No semantic changes to the canvas state payload.
- 5s safety timer untouched.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test -- tests/canvas-orb-state.test.ts tests/agent-runtime-truth.test.ts` → 18 passed
- [ ] Verify on staging: presence transition lag drops from ~5s to ~200ms on the canvas page

## Slice context
- Slice 1 (reflectt-cloud PR #2798): collapse 4 ad-hoc `/canvas/stream` EventSources to one refcounted singleton — merged.
- This slice 2: server-side immediate push — this PR.
- Slice 3 (held): visible enter/state-change animations on `presence-cluster.tsx` once #2 is proven on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)