### PR TITLE
canvas: slice-2 addendum — pushCanvasStateToCloud env fallback

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12943,7 +12943,7 @@ export async function createServer(): Promise<FastifyInstance> {
 
   async function pushCanvasStateToCloud() {
     const cloudUrl = process.env.REFLECTT_CLOUD_URL
-    const hostToken = process.env.REFLECTT_HOST_TOKEN
+    const hostToken = process.env.REFLECTT_HOST_TOKEN || process.env.REFLECTT_HOST_CREDENTIAL
     const hostId = process.env.REFLECTT_HOST_ID
     if (!cloudUrl || !hostToken || !hostId) return
     // Snapshot current canvas state. Project presence into the canvas `agents`


### PR DESCRIPTION
## Summary

One-line fix. pushCanvasStateToCloud at server.ts:12946 read REFLECTT_HOST_TOKEN only and returned early when unset. Managed hosts boot with REFLECTT_HOST_CREDENTIAL set, not REFLECTT_HOST_TOKEN, so both the slice-2 immediate hook AND the pre-existing 5s safety timer were silent no-ops on managed hosts.

Match the fallback already used by cloudPost in cloud.ts:374 — REFLECTT_HOST_TOKEN OR REFLECTT_HOST_CREDENTIAL.

## Why this surfaced now

Slice-2 proof execution on canonical host rn-34faba44-wlgkeq showed the canvas_update SSE arriving ~5000ms after a forced presence flip — safety-timer cadence, not the sub-500ms immediate-push window. Verified on the host via fly ssh: REFLECTT_HOST_TOKEN unset, REFLECTT_HOST_CREDENTIAL set.

The line that copies credential to token at server.ts lines 17262-17263 only runs inside the /cloud/reload route handler, never at boot.

## Approvals

- kai task-comment on task-1777140469973-770cy4yma: approved addendum, make server.ts pushCanvasStateToCloud use the same fallback, then rerun the sub-500ms proof on the canonical host before any slice-3 work, one-line parity fix not a scope change.
- link: ship it, the real seam is the managed-host env fallback mismatch in pushCanvasStateToCloud.
- pixel: the one-line fix is clearly correct, ship it as a slice-2 addendum, re-run the proof, then proceed to slice 3.

## Test plan

- CI green
- Docker publish on the merge commit produces a new image
- Roll canonical host rn-34faba44-wlgkeq to the new image
- Forced-flip proof on compass shows SSE syncedAt gap under 500ms down from ~5000ms
- Post proof artifact to kai before unblocking task 202

Generated with Claude Code