### PR TITLE
feat(room): slice 2 — agents see humans (room-model-v0.1.1)

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -34,6 +34,7 @@ export type EventType =
   | 'canvas_artifact'  // proof artifact drifts through canvas on task/PR completion (commit/pr/test/run/approval)
   | 'canvas_takeover'
   | 'agent_identity_changed'  // agent claims/releases full-screen takeover — orbs fade, agent content is the canvas
+  | 'room_participant_joined' // room-model-v0.1.1 slice 2: a human appeared in this host's room (data: { participant, hostId })
 
 export const VALID_EVENT_TYPES = new Set<EventType>([
   'message_posted',
@@ -55,6 +56,7 @@ export const VALID_EVENT_TYPES = new Set<EventType>([
   'canvas_artifact',
   'canvas_takeover',
   'agent_identity_changed',
+  'room_participant_joined',
 ])
 
 export interface Event {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -19,6 +19,7 @@ import { eventBus } from "./events.js"
 import { PKG_VERSION } from "./version.js"
 import type { AgentMessage, Task } from "./types.js"
 import { getAgentRoles } from "./assignment.js"
+import { listRoomParticipants, getRoomPresenceStatus } from "./room-presence-store.js"
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MCP Server Setup
@@ -403,6 +404,31 @@ tool(
       content: [{
         type: "text",
         text: JSON.stringify({ ts: Date.now(), board, agents: agentStates })
+      }]
+    }
+  }
+)
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Room Tools (room-model-v0.1.1 slice 2 — agents see humans)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+tool(
+  "room_list_participants",
+  "List humans currently present in this host's room. Returns the ephemeral participant set from the live Supabase Realtime presence channel — these are the people who have a /canvas tab open right now. Use this when deciding whether to greet someone, hold off on autonomous chatter, or check if a human is around to answer a question. Empty list = nobody on canvas right now (autonomous mode).",
+  {},
+  async () => {
+    const participants = listRoomParticipants()
+    const status = getRoomPresenceStatus()
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          participants,
+          count: participants.length,
+          hostId: status.hostId,
+          initialized: status.initialized,
+        })
       }]
     }
   }

--- a/src/room-presence-store.ts
+++ b/src/room-presence-store.ts
@@ -77,7 +77,9 @@ export function initRoomPresenceStore(): boolean {
   if (state.initialized) return true
 
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  // Managed hosts ship the service-role JWT under SUPABASE_ACCESS_TOKEN
+  // (CLI convention), self-hosted setups under SUPABASE_SERVICE_ROLE_KEY.
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ACCESS_TOKEN
   const hostId = resolveHostId()
 
   if (!url || !key) {

--- a/src/room-presence-store.ts
+++ b/src/room-presence-store.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Presence Store — slice 2 of room-model-v0.1.1
+ *
+ * Server-side mirror of the Supabase Realtime presence channel that
+ * cloud's `useRoomPresence` hook publishes to (slice 1). Node subscribes
+ * to the same `room:${hostId}` channel as a third party so that agents
+ * can see who's in the room via `GET /room/participants` and the
+ * `room_list_participants` MCP tool.
+ *
+ * Per ROOM_MODEL_V0.md anchor rule: the room creates truth (via the
+ * channel), agents access truth via APIs/MCP. This file is the API/MCP
+ * side of that contract — it does NOT invent state, it observes the
+ * channel cloud already publishes to.
+ *
+ * What this is NOT:
+ *   - durable history (participants[] is ephemeral; if the channel drops,
+ *     the cache empties — that's the contract, not a bug)
+ *   - a second source of truth (the channel is truth; this is a cache)
+ *   - heartbeat extension (slice 2 explicitly defers HostHeartbeatV1 changes
+ *     until media/transcript lanes need server-side derivation)
+ */
+
+import { createClient, type RealtimeChannel, type SupabaseClient } from '@supabase/supabase-js'
+import { eventBus } from './events.js'
+
+// Mirrors HumanParticipant in apps/web/src/app/presence/use-room-presence.ts.
+// Fields are wire-format from the channel — re-stamping (e.g. lastBeaconAt)
+// happens on read, not here.
+export type Device = 'big-screen' | 'desktop' | 'tablet' | 'phone'
+
+export interface HumanParticipant {
+  kind: 'human'
+  id: string
+  userId: string
+  hostId: string
+  displayName: string
+  identityColor: string
+  device: Device
+  joinedAt: number
+  lastBeaconAt: number
+}
+
+interface StoreState {
+  participants: Map<string, HumanParticipant> // keyed by ephemeral session id
+  channel: RealtimeChannel | null
+  client: SupabaseClient | null
+  hostId: string | null
+  initialized: boolean
+}
+
+const state: StoreState = {
+  participants: new Map(),
+  channel: null,
+  client: null,
+  hostId: null,
+  initialized: false,
+}
+
+function resolveHostId(): string | null {
+  const hostId = process.env.REFLECTT_HOST_ID || process.env.HOSTNAME
+  if (!hostId || hostId === 'unknown') return null
+  return hostId
+}
+
+/**
+ * Initialize the store: create the Supabase client, subscribe to
+ * `room:${hostId}` channel, and start listening for presence sync events.
+ * Idempotent. Safe to call multiple times — only the first call wires up.
+ *
+ * If Supabase env is missing or hostId is unresolvable, the store stays
+ * empty (returns false) — the rest of the node still boots.
+ */
+export function initRoomPresenceStore(): boolean {
+  if (state.initialized) return true
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const hostId = resolveHostId()
+
+  if (!url || !key) {
+    console.warn('[room-presence] Supabase env missing — store stays empty')
+    return false
+  }
+  if (!hostId) {
+    console.warn('[room-presence] REFLECTT_HOST_ID unresolvable — store stays empty')
+    return false
+  }
+
+  state.hostId = hostId
+  state.client = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+
+  const channel = state.client.channel(`room:${hostId}`, {
+    // Listening as a service-role client — node never publishes its own
+    // presence track. The presence key is required by Supabase even for
+    // listen-only subscribers; we use a stable node sentinel that won't
+    // collide with browser session ids (which are random uuids).
+    config: { presence: { key: `node:${hostId}` } },
+  })
+
+  const recompute = () => {
+    const presenceState = channel.presenceState() as Record<string, HumanParticipant[]>
+    const seenIds = new Set<string>()
+    const newJoins: HumanParticipant[] = []
+    for (const entries of Object.values(presenceState)) {
+      for (const entry of entries) {
+        // Defensive: filter out our own listen-only sentinel and any non-human
+        // payloads. Slice 1 only publishes humans; future slices that publish
+        // other kinds on the same channel must continue to use { kind } shape.
+        if (!entry || (entry as any).kind !== 'human' || !entry.id) continue
+        seenIds.add(entry.id)
+        const isNewJoin = !state.participants.has(entry.id)
+        const stamped: HumanParticipant = { ...entry, lastBeaconAt: Date.now() }
+        state.participants.set(entry.id, stamped)
+        if (isNewJoin) newJoins.push(stamped)
+      }
+    }
+    // Prune anyone who left
+    for (const id of [...state.participants.keys()]) {
+      if (!seenIds.has(id)) state.participants.delete(id)
+    }
+    // Emit one event per new join — agents subscribe to room_participant_joined
+    // for "should I greet this person?" decisions.
+    for (const p of newJoins) {
+      eventBus.emit({
+        id: `room-join-${p.id}-${Date.now()}`,
+        type: 'room_participant_joined',
+        timestamp: Date.now(),
+        data: { participant: p, hostId },
+      })
+    }
+  }
+
+  channel
+    .on('presence', { event: 'sync' }, recompute)
+    .on('presence', { event: 'join' }, recompute)
+    .on('presence', { event: 'leave' }, recompute)
+    .subscribe((status) => {
+      if (status === 'SUBSCRIBED') {
+        console.log(`[room-presence] subscribed to room:${hostId}`)
+      } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+        console.warn(`[room-presence] channel ${status} for room:${hostId}`)
+      }
+    })
+
+  state.channel = channel
+  state.initialized = true
+  return true
+}
+
+/**
+ * Tear down the channel subscription. Used in tests and on graceful
+ * shutdown. Clears the cache.
+ */
+export async function shutdownRoomPresenceStore(): Promise<void> {
+  if (state.channel && state.client) {
+    try { await state.channel.unsubscribe() } catch { /* non-fatal */ }
+    try { await state.client.removeChannel(state.channel) } catch { /* non-fatal */ }
+  }
+  state.channel = null
+  state.client = null
+  state.hostId = null
+  state.initialized = false
+  state.participants.clear()
+}
+
+/** Read the current participant set, sorted by joinedAt (stable order). */
+export function listRoomParticipants(): HumanParticipant[] {
+  return [...state.participants.values()].sort((a, b) => a.joinedAt - b.joinedAt)
+}
+
+/** Diagnostics for /room/participants?debug=1 and tests. */
+export function getRoomPresenceStatus(): { initialized: boolean; hostId: string | null; count: number } {
+  return {
+    initialized: state.initialized,
+    hostId: state.hostId,
+    count: state.participants.size,
+  }
+}

--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Routes — slice 2 of room-model-v0.1.1
+ *
+ * Fastify plugin registering room-state read endpoints. Currently exposes
+ * `GET /room/participants` — the cached human participant set from the
+ * Supabase Realtime channel slice 1 publishes to.
+ *
+ * Auth uses the same heartbeat-token model as `/hosts/heartbeat`: if
+ * REFLECTT_HOST_HEARTBEAT_TOKEN is set, requests must present it via
+ * `Authorization: Bearer`, `x-heartbeat-token` header, or `?token=` query.
+ * If unset, the route is open (matches existing host-cred behavior).
+ */
+
+import type { FastifyInstance, FastifyRequest } from 'fastify'
+import { listRoomParticipants, getRoomPresenceStatus } from './room-presence-store.js'
+
+function verifyAuth(request: FastifyRequest): { ok: boolean; error?: string } {
+  const expectedToken = process.env.REFLECTT_HOST_HEARTBEAT_TOKEN
+  if (!expectedToken) return { ok: true }
+
+  const headers = request.headers as Record<string, string | string[] | undefined>
+  const authHeader = (headers.authorization || headers.Authorization) as string | undefined
+  if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+    const provided = authHeader.slice('Bearer '.length).trim()
+    if (provided === expectedToken) return { ok: true }
+  }
+  const headerToken = headers['x-heartbeat-token']
+  if (typeof headerToken === 'string' && headerToken === expectedToken) return { ok: true }
+
+  const query = request.query as Record<string, unknown>
+  if (typeof query?.token === 'string' && query.token === expectedToken) return { ok: true }
+
+  return { ok: false, error: 'Unauthorized: REFLECTT_HOST_HEARTBEAT_TOKEN required' }
+}
+
+export async function roomRoutes(app: FastifyInstance) {
+  app.get('/room/participants', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const participants = listRoomParticipants()
+    const status = getRoomPresenceStatus()
+    return {
+      participants,
+      count: participants.length,
+      hostId: status.hostId,
+      initialized: status.initialized,
+    }
+  })
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -171,6 +171,8 @@ import { startOpenClawUsageSync, stopOpenClawUsageSync, syncOpenClawUsage } from
 import { initContactsTable, createContact, getContact, updateContact, deleteContact, listContacts, countContacts } from './contacts.js'
 import { processRender, logRejection, getRecentRejections, subscribeCanvas } from './canvas-multiplexer.js'
 import { canvasReadRoutes, canvasPhase2Routes, formatRecency } from './canvas-routes.js'
+import { roomRoutes } from './room-routes.js'
+import { initRoomPresenceStore } from './room-presence-store.js'
 import { startTeamPulse, stopTeamPulse, postTeamPulse, computeTeamPulse, getTeamPulseConfig, configureTeamPulse, getTeamPulseHistory } from './team-pulse.js'
 import { runTeamDoctor } from './team-doctor.js'
 import { createStarterTeam } from './starter-team.js'
@@ -12285,6 +12287,13 @@ export async function createServer(): Promise<FastifyInstance> {
       }
     })
   })()
+
+  // ── Room presence (room-model-v0.1.1 slice 2) ────────────────────────
+  // Subscribe to the Supabase Realtime presence channel slice 1 publishes
+  // to so agents can read who's in the room via /room/participants and the
+  // `room_list_participants` MCP tool. Non-fatal if Supabase env missing.
+  await app.register(roomRoutes)
+  initRoomPresenceStore()
 
   // ── Canvas read routes (extracted to src/canvas-routes.ts) ───────────
   // Phase 1: states, slots, slots/all, rejections

--- a/tests/room-presence-store.test.ts
+++ b/tests/room-presence-store.test.ts
@@ -1,0 +1,42 @@
+// Slice 2 regression: store must boot quietly when Supabase env is missing.
+// We don't want a node deployment without SUPABASE_URL/SERVICE_ROLE_KEY to
+// crash on startup — empty cache is the correct degraded state.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  initRoomPresenceStore,
+  shutdownRoomPresenceStore,
+  listRoomParticipants,
+  getRoomPresenceStatus,
+} from '../src/room-presence-store.js'
+
+describe('room-presence-store', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(async () => {
+    await shutdownRoomPresenceStore()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('returns false from init when SUPABASE_URL is missing', () => {
+    delete process.env.SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'irrelevant'
+    process.env.REFLECTT_HOST_ID = 'test-host'
+    expect(initRoomPresenceStore()).toBe(false)
+    expect(listRoomParticipants()).toEqual([])
+    expect(getRoomPresenceStatus()).toEqual({ initialized: false, hostId: null, count: 0 })
+  })
+
+  it('returns false from init when REFLECTT_HOST_ID is unresolvable', () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'irrelevant'
+    delete process.env.REFLECTT_HOST_ID
+    delete process.env.HOSTNAME
+    expect(initRoomPresenceStore()).toBe(false)
+    expect(listRoomParticipants()).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Slice 2 of docs/ROOM_MODEL_V0.md (room-model-v0.1.1) — agents see humans. Per kai direction msg-1777164520230 with option 1 channel-as-truth approval.

The Supabase Realtime presence channel that cloud already publishes to from the browser, namespaced by hostId, is the single source of truth for who is on canvas right now. This PR makes node a listen-only subscriber that caches the ephemeral participant set and surfaces it to agents.

## Design — option 1, channel-as-truth

- Node subscribes to the same room channel using a sentinel presence key prefixed with **node:** so it never collides with browser uuid session ids.
- Listeners on **sync / join / leave** filter payloads where **kind** is **human** and id matches the entry, restamping lastBeaconAt to now.
- New joins emit a typed **room_participant_joined** event on the EventBus.
- **No heartbeat changes.** No new endpoints from cloud. No DB writes for ephemeral state.
- Boots quietly when SUPABASE_URL or REFLECTT_HOST_ID is missing — empty cache is the correct degraded state for nodes deployed without Supabase env.

## Files

- **src/room-presence-store.ts** — new, ~165 lines. Singleton subscriber + in-memory Map of sessionId to HumanParticipant + lifecycle helpers
- **src/room-routes.ts** — new, ~50 lines. Fastify plugin exposing **GET /room/participants** with heartbeat-token auth, same model as /hosts/heartbeat
- **src/events.ts** — added **room_participant_joined** to EventType union AND VALID_EVENT_TYPES Set
- **src/mcp.ts** — added **room_list_participants** MCP tool
- **src/server.ts** — registers the room-routes plugin + calls **initRoomPresenceStore()** on boot. 2-line addition, follows canvas-routes plugin extraction precedent
- **tests/room-presence-store.test.ts** — new. 2 regression tests for degraded-state boot

## Surface for agents

- **MCP tool: room_list_participants** — returns participants, count, hostId, initialized
- **HTTP: GET /room/participants** — same shape, bearer-token auth (REFLECTT_HOST_HEARTBEAT_TOKEN), open if unset
- **EventBus: room_participant_joined** — agents can subscribe for someone-just-appeared signal, payload is participant + hostId

HumanParticipant envelope mirrors slice 1 cloud shape exactly — kind=human, id, userId, hostId, displayName, identityColor, device, joinedAt, lastBeaconAt.

## What is NOT in this PR

- **Bootstrap prompt rule** — greet a freshly-arrived human once then check for any open task addressed to you. That is workspace-seed work in cloud, not a node code change. Wording handed back to kai separately.
- **Anything that writes ephemeral presence to Postgres.** Channel-as-truth means the channel IS the truth.
- **Any cloud-side change.** Slice 1 PR #2805 is already merged to develop and serves the channel.

## Test plan

- [x] Type-check clean — npm run build green
- [x] All 2574 existing tests still pass; 2 new tests pass in tests/room-presence-store.test.ts
- [x] Degraded-state boot with no Supabase env does not crash node startup
- [ ] **Canonical-staging proof** pending CI green and deploy to rn-34faba44-wlgkeq:
  - Open /canvas on canonical staging host e4e35463- as a SHARED_TEAM user
  - Hit GET /room/participants on the staging node — should show me as a participant
  - Hit room_list_participants via MCP — same shape
  - Verify reconnect/no-dup behavior — close tab, reopen, sessionId rotates, count stays at 1
  - Verify room_participant_joined event fires once on first join
  - Once kai bootstrap rule lands in the workspace seed — an agent on host e4e35463- greets me when I open /canvas

## Constraints honored

- Memory rule: node repo to main, no gitflow — PR targets main
- Memory rule: always commit as kai@itskai.dev — verified
- Memory rule: don't widen server.ts beyond minimum — 2-line registration + 2 imports, plugin-extracted

Refs docs/ROOM_MODEL_V0.md slice 2.
