### PR TITLE
fix(ci): harden pr-scope-gate against PR-body shell injection

### DIFF
--- a/.github/workflows/pr-scope-gate.yml
+++ b/.github/workflows/pr-scope-gate.yml
@@ -21,13 +21,20 @@ jobs:
           node-version: '20'
 
       - name: Save PR body
-        run: echo "${{ github.event.pull_request.body }}" > /tmp/pr-body.txt
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > /tmp/pr-body.txt
 
       - name: Run PR scope gate
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          RULE2_N: 20
+          RULE2_THRESHOLD: 40
         run: |
           echo "=== PR Scope Policy Gate (Signal #3) ==="
-          echo "Base: ${{ github.base_ref }}"
-          echo "Head: ${{ github.head_ref }}"
+          echo "Base: $BASE_REF"
+          echo "Head: $HEAD_REF"
           echo ""
           echo "Rule 1 (BLOCK): Stash residue — files modified before branch first commit"
           echo "Rule 2 (WARN):  File count > N×2 (default N=${RULE2_N}, threshold=${RULE2_THRESHOLD})"
@@ -35,9 +42,6 @@ jobs:
           echo "Rule 4 (BLOCK): Sensitive-path files without task ID in commit message"
           echo ""
           node tools/pr-scope-check.mjs \
-            --base origin/${{ github.base_ref }} \
+            --base "origin/$BASE_REF" \
             --pr-body /tmp/pr-body.txt \
             --verbose
-        env:
-          RULE2_N: 20
-          RULE2_THRESHOLD: 40


### PR DESCRIPTION
Surfaced by PR #1296.

The Save PR body step in pr-scope-gate.yml interpolated github.event.pull_request.body straight into a bash echo command. Two failure modes, both silent maskers of the real scope-check result:

1. Backtick plus dollar-brace content in the body — totally normal in markdown code spans like room hostId references — gets evaluated as command substitution.
2. Literal double-quote characters in the body toggle quote state. List items beginning with a dash then leak into bash and produce dash colon command not found.

Same vector applied to base_ref and head_ref.

Fix: pass each untrusted github-event field through env then reference it via a quoted bash variable. Standard GitHub Actions hardening per the upstream guidance from the github blog vulnerability-research post on workflow injections.

Per link msg-1777165661230. Treated as narrow workflow hardening, not part of the slice 2 feature lane.

## Test plan

- [x] YAML syntactically valid
- [x] No duplicate env keys
- [ ] Once merged, retrigger PR #1296 and confirm scope-policy gate runs cleanly against a body containing backticks plus dollar-braces and double quotes
