### PR TITLE
feat(room): slice 3B — room-event push to agent chat session

### DIFF
--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Event Bridge — slice 3B of room-model-v0.1.1
+ *
+ * Push half of the room-model contract: turns `room_participant_joined`
+ * EventBus events (emitted by slice 2's room-presence-store) into chat
+ * messages on the founding agent's #general channel — same shape the
+ * GitHub webhook bridge already uses.
+ *
+ * Why: slice 2 gave agents pull (`room_list_participants` MCP tool +
+ * `GET /room/participants`). Slice 3A seeded the greet-on-join rule into
+ * AGENTS.md. But a passive seed only fires if the agent is awake AND
+ * polling. Per kai's room-model rule (msg-1777169506243):
+ *   "APIs/MCP for pull, chat/session event delivery for responsiveness"
+ * This file is the responsiveness half — once a join becomes a chat
+ * message, it flows to every SSE subscriber including the running
+ * founding agent's session ("another message to the LLM" — ryan
+ * msg-1777169499379).
+ *
+ * Greet-once semantics: dedup_key = participant.id (ephemeral session
+ * id). Same browser session reconnecting has the same id and the
+ * chatManager dedup ledger swallows the repeat. Different session →
+ * different id → fresh greet, which matches "you're back, hello again".
+ */
+import { eventBus } from './events.js'
+import { chatManager } from './chat.js'
+
+interface BridgeState {
+  initialized: boolean
+  joinCount: number
+}
+
+const state: BridgeState = {
+  initialized: false,
+  joinCount: 0,
+}
+
+const LISTENER_ID = 'room-event-bridge'
+
+interface RoomJoinPayload {
+  participant: {
+    id: string
+    userId: string
+    hostId: string
+    displayName: string
+    identityColor: string
+    device: 'big-screen' | 'desktop' | 'tablet' | 'phone'
+    joinedAt: number
+    lastBeaconAt: number
+    kind: 'human'
+  }
+  hostId: string
+}
+
+/**
+ * Format a join into a single concise chat line. Kept terse on purpose —
+ * the seed rule in AGENTS.md tells the agent what to do; this is just the
+ * trigger they need to see.
+ */
+function formatJoin(p: RoomJoinPayload['participant']): string {
+  return `🚪 **${p.displayName}** joined the room (${p.device})`
+}
+
+/**
+ * Register the EventBus listener. Idempotent. Returns false if already
+ * initialized so callers can detect double-init in tests.
+ */
+export function initRoomEventBridge(): boolean {
+  if (state.initialized) return false
+
+  eventBus.on(LISTENER_ID, (event) => {
+    if (event.type !== 'room_participant_joined') return
+    const payload = event.data as RoomJoinPayload | undefined
+    const p = payload?.participant
+    if (!p || p.kind !== 'human' || !p.id || !p.displayName) return
+
+    state.joinCount++
+    void chatManager.sendMessage({
+      from: 'room',
+      content: formatJoin(p),
+      channel: 'general',
+      metadata: {
+        source: 'room-event',
+        category: 'room-join',
+        eventType: 'room_participant_joined',
+        participantId: p.id,
+        userId: p.userId,
+        hostId: payload?.hostId ?? p.hostId,
+        device: p.device,
+        // dedup_key: chatManager's ledger swallows repeats with the
+        // same key. Using participant.id (ephemeral session id) means
+        // greet-once per session; new session → fresh greet.
+        dedup_key: `room-join-${p.id}`,
+      },
+    }).catch((err) => {
+      console.error(`[room-event-bridge] sendMessage failed for ${p.id}:`, err)
+    })
+  })
+
+  state.initialized = true
+  console.log('[room-event-bridge] subscribed to room_participant_joined → #general')
+  return true
+}
+
+/** Tear down the listener. Used in tests and on graceful shutdown. */
+export function shutdownRoomEventBridge(): void {
+  if (!state.initialized) return
+  eventBus.off(LISTENER_ID)
+  state.initialized = false
+  state.joinCount = 0
+}
+
+/** Diagnostics: how many joins have been bridged this process lifetime. */
+export function getRoomEventBridgeStatus(): { initialized: boolean; joinCount: number } {
+  return { initialized: state.initialized, joinCount: state.joinCount }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,6 +173,7 @@ import { processRender, logRejection, getRecentRejections, subscribeCanvas } fro
 import { canvasReadRoutes, canvasPhase2Routes, formatRecency } from './canvas-routes.js'
 import { roomRoutes } from './room-routes.js'
 import { initRoomPresenceStore } from './room-presence-store.js'
+import { initRoomEventBridge } from './room-event-bridge.js'
 import { startTeamPulse, stopTeamPulse, postTeamPulse, computeTeamPulse, getTeamPulseConfig, configureTeamPulse, getTeamPulseHistory } from './team-pulse.js'
 import { runTeamDoctor } from './team-doctor.js'
 import { createStarterTeam } from './starter-team.js'
@@ -12294,6 +12295,13 @@ export async function createServer(): Promise<FastifyInstance> {
   // `room_list_participants` MCP tool. Non-fatal if Supabase env missing.
   await app.register(roomRoutes)
   initRoomPresenceStore()
+
+  // ── Room event bridge (room-model-v0.1.1 slice 3B) ───────────────────
+  // Push half of the room-model contract: turn `room_participant_joined`
+  // EventBus events into chat messages on #general so the founding agent
+  // sees them as `message_posted` SSE events (the same path webhooks use).
+  // Pairs with slice 3A's seeded greet-on-join rule in AGENTS.md.
+  initRoomEventBridge()
 
   // ── Canvas read routes (extracted to src/canvas-routes.ts) ───────────
   // Phase 1: states, slots, slots/all, rejections

--- a/tests/room-event-bridge.test.ts
+++ b/tests/room-event-bridge.test.ts
@@ -1,0 +1,135 @@
+// Slice 3B regression: when room_participant_joined fires on the EventBus,
+// the bridge must call chatManager.sendMessage with the right shape so the
+// founding agent receives "another message to the LLM" via the existing
+// SSE message_posted channel. Greet-once means same participant id should
+// only produce one user-visible chat message even on event re-emit.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Mock chatManager BEFORE importing the bridge so the bridge picks up
+// the mock instead of the real chatManager. vi.mock is hoisted above
+// imports, so we must use vi.hoisted to keep the mock fn accessible.
+const { sendMessageMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn(async (msg: any) => ({
+    ...msg,
+    id: 'mock-msg-id',
+    timestamp: Date.now(),
+    reactions: {},
+  })),
+}))
+
+vi.mock('../src/chat.js', () => ({
+  chatManager: {
+    sendMessage: sendMessageMock,
+  },
+}))
+
+import { eventBus } from '../src/events.js'
+import {
+  initRoomEventBridge,
+  shutdownRoomEventBridge,
+  getRoomEventBridgeStatus,
+} from '../src/room-event-bridge.js'
+
+const SAMPLE_PARTICIPANT = {
+  kind: 'human' as const,
+  id: 'session-abc-123',
+  userId: 'user-xyz',
+  hostId: 'host-1',
+  displayName: 'Ryan',
+  identityColor: '#ff8800',
+  device: 'big-screen' as const,
+  joinedAt: Date.now(),
+  lastBeaconAt: Date.now(),
+}
+
+function emitJoin(participant = SAMPLE_PARTICIPANT, hostId = 'host-1') {
+  eventBus.emit({
+    id: `room-join-${participant.id}-${Date.now()}`,
+    type: 'room_participant_joined',
+    timestamp: Date.now(),
+    data: { participant, hostId },
+  })
+}
+
+describe('room-event-bridge', () => {
+  beforeEach(() => {
+    sendMessageMock.mockClear()
+    shutdownRoomEventBridge()
+  })
+
+  afterEach(() => {
+    shutdownRoomEventBridge()
+  })
+
+  it('initRoomEventBridge() returns true on first call, false on re-init', () => {
+    expect(initRoomEventBridge()).toBe(true)
+    expect(initRoomEventBridge()).toBe(false)
+    expect(getRoomEventBridgeStatus().initialized).toBe(true)
+  })
+
+  it('forwards a join into chatManager.sendMessage with the right shape', () => {
+    initRoomEventBridge()
+    emitJoin()
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.from).toBe('room')
+    expect(call.channel).toBe('general')
+    expect(call.content).toContain('Ryan')
+    expect(call.content).toContain('big-screen')
+    expect(call.metadata.source).toBe('room-event')
+    expect(call.metadata.participantId).toBe('session-abc-123')
+    expect(call.metadata.dedup_key).toBe('room-join-session-abc-123')
+    expect(call.metadata.hostId).toBe('host-1')
+  })
+
+  it('ignores non-human payloads and malformed events', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'bad-1', type: 'room_participant_joined', timestamp: Date.now(),
+      data: { participant: { kind: 'agent', id: 'a-1', displayName: 'bot' }, hostId: 'host-1' },
+    })
+    eventBus.emit({
+      id: 'bad-2', type: 'room_participant_joined', timestamp: Date.now(),
+      data: { participant: { kind: 'human', id: '', displayName: 'Anon' }, hostId: 'host-1' },
+    })
+    eventBus.emit({
+      id: 'bad-3', type: 'room_participant_joined', timestamp: Date.now(),
+      data: undefined,
+    })
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated event types', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'unrelated', type: 'message_posted', timestamp: Date.now(),
+      data: { from: 'noise', content: 'noise', channel: 'general' },
+    })
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('uses participant id as dedup_key so reconnects with the same id collapse downstream', () => {
+    initRoomEventBridge()
+    emitJoin()
+    emitJoin() // same participant id — bridge still calls sendMessage twice
+    expect(sendMessageMock).toHaveBeenCalledTimes(2)
+    // Both calls share the dedup_key — chatManager's suppression ledger
+    // is what enforces greet-once at the user-visible layer.
+    expect(sendMessageMock.mock.calls[0][0].metadata.dedup_key).toBe(
+      sendMessageMock.mock.calls[1][0].metadata.dedup_key
+    )
+    expect(getRoomEventBridgeStatus().joinCount).toBe(2)
+  })
+
+  it('shutdown unsubscribes — no further calls after teardown', () => {
+    initRoomEventBridge()
+    emitJoin()
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    shutdownRoomEventBridge()
+    expect(getRoomEventBridgeStatus().initialized).toBe(false)
+    emitJoin()
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- New `src/room-event-bridge.ts`: subscribes to `room_participant_joined` on the EventBus and posts a join line to `#general` via `chatManager.sendMessage` — the same path GitHub webhooks already use to reach the founding agent's running session.
- Wired into `createServer()` alongside `initRoomPresenceStore()`.
- 6 vitest cases covering shape, filter/validate, dedup_key consistency, shutdown.

## Why

Slice 3A ([cloud #2806](https://github.com/reflectt/reflectt-cloud/pull/2806), merged as `22c3abed`) seeded the greet-on-join rule into managed-host `AGENTS.md`. A passive seed only fires if the agent is awake AND polling.

Per kai's room-model rule (msg-1777169506243):
> APIs/MCP for pull, chat/session event delivery for responsiveness

This is the responsiveness half. Once a join becomes a `message_posted` event, every SSE subscriber (including the running founding agent's session) sees it — what ryan called "another message to the LLM" (msg-1777169499379).

## Greet-once semantics

`metadata.dedup_key = room-join-{participant.id}`. participant.id is the ephemeral session id — same browser session reconnecting hits the chatManager dedup ledger and collapses. New session → fresh greet, which matches "you're back, hello again".

## Test plan

- [x] `npx vitest run tests/room-event-bridge.test.ts` — 6/6 passing locally
- [x] `npx vitest run tests/room-presence-store.test.ts` — slice 2 still passing
- [x] `npx tsc --noEmit` — clean
- [ ] CI green
- [ ] After merge: provision fresh canonical staging host (`e4e35463-…`), join from a real browser, confirm greet message lands in #general from the founding agent

## Refs

- task `1777140469973-770cy4yma`
- slice 3A merge `22c3abed` (cloud)
- link's ordering directive (msg-1777169542359): "land #2806; immediately open 3B as the minimal node push path"