### PR TITLE
fix(chat): suppression ledger respects explicit metadata.dedup_key

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -459,11 +459,13 @@ class ChatManager {
     let dedupKey: string | undefined
 
     if (isSystemSource && !bypassBudget) {
+      const explicitDedupKey = typeof msgMeta.dedup_key === 'string' ? msgMeta.dedup_key : undefined
       const check = suppressionLedger.check({
         category,
         channel,
         from: message.from,
         content: message.content,
+        dedup_key: explicitDedupKey,
       })
       dedupKey = check.dedup_key
 

--- a/src/suppression-ledger.ts
+++ b/src/suppression-ledger.ts
@@ -83,8 +83,16 @@ export class SuppressionLedger {
     channel: string
     from: string
     content: string
+    /**
+     * Optional explicit dedup key from the caller's metadata. When provided,
+     * it overrides the content-derived key — required for events where the
+     * caller's identity (e.g. room session id) is the source of truth for
+     * "same vs. different", not the rendered message text. Without this,
+     * different sessions emitting the same templated string would collapse.
+     */
+    dedup_key?: string
   }): SuppressionCheckResult {
-    const dedup_key = this.computeDedupKey(opts.category, opts.channel, opts.content)
+    const dedup_key = opts.dedup_key ?? this.computeDedupKey(opts.category, opts.channel, opts.content)
     const now = Date.now()
     const db = getDb()
 

--- a/tests/suppression-ledger.test.ts
+++ b/tests/suppression-ledger.test.ts
@@ -122,6 +122,34 @@ describe('Suppression Ledger', () => {
     expect(stats.total_entries).toBe(0)
   })
 
+  // Regression for slice 3B: room-event-bridge emits the same templated
+  // string ("🚪 X joined …") for every join, but each browser session has a
+  // distinct id. Without honoring the caller's explicit dedup_key, two
+  // different sessions joining the same room would collapse and only the
+  // first would post — defeating the room push contract.
+  it('honors caller-supplied dedup_key over content-derived key', () => {
+    const base = {
+      category: 'room-join',
+      channel: 'general',
+      from: 'room',
+      content: '🚪 **Proveout-Ryan** joined the room (big-screen)',
+    }
+
+    const first = ledger.check({ ...base, dedup_key: 'room-join-session-A' })
+    expect(first.isDuplicate).toBe(false)
+    expect(first.dedup_key).toBe('room-join-session-A')
+
+    // Same content, different explicit key → must NOT be flagged duplicate.
+    const second = ledger.check({ ...base, dedup_key: 'room-join-session-B' })
+    expect(second.isDuplicate).toBe(false)
+    expect(second.dedup_key).toBe('room-join-session-B')
+
+    // Same explicit key replayed → IS a duplicate (greet-once per session).
+    const third = ledger.check({ ...base, dedup_key: 'room-join-session-A' })
+    expect(third.isDuplicate).toBe(true)
+    expect(third.dedup_key).toBe('room-join-session-A')
+  })
+
   it('persists across ledger instances', () => {
     const opts = { category: 'alert', channel: 'ops', from: 'system', content: 'Persistent check' }
 


### PR DESCRIPTION
## Summary
- Slice 3B prove-out exposed a regression: every fresh-session room join after the first was suppressed because the persistent suppression ledger ignored the explicit `metadata.dedup_key` and recomputed a key from content alone.
- Threads the caller's `metadata.dedup_key` from `chatManager.sendMessage` into `suppressionLedger.check()`. When provided, the ledger uses it verbatim; otherwise it still falls back to the content-derived hash.
- This brings the ledger in line with `NoiseBudget.checkDuplicate`, which already honored an explicit key.

## Why this matters
The room-event-bridge emits a templated string (`🚪 **X** joined the room (big-screen)`) for every join. Each browser session has a distinct id and the bridge correctly sets `dedup_key=room-join-{participantId}`. Without honoring that key, two different sessions joining the same room collapse into one ledger entry and only the first posts — defeating the slice 3B push contract.

System messages without their own opinion (status digests, watchdog alerts) keep their existing content-only behavior unchanged.

## Failing hop on canonical staging
Confirmed via `/tmp/proveout-3b.mjs` against canonical host `e4e35463-…`:
- ✓ first session joined → message posted
- ✓ same-session reconnect → no duplicate (NoiseBudget already correct)
- ✗ fresh session → no message — traced to `chat.ts:462 → suppression-ledger.ts:87`

## Test plan
- [x] `npx vitest run tests/suppression-ledger.test.ts` — 9/9 pass including new regression
- [x] `npx vitest run tests/room-event-bridge.test.ts` — 6/6 still pass
- [x] `npx vitest run tests/chat-dedup.test.ts` — 6/6 still pass
- [ ] After merge + image roll: re-run `/tmp/proveout-3b.mjs` against canonical staging — fresh session must produce a 2nd join message