### PR TITLE
feat(room): add captureLanes? to HumanParticipant (type-only)

### DIFF
--- a/src/room-presence-store.ts
+++ b/src/room-presence-store.ts
@@ -31,6 +31,16 @@ import { eventBus } from './events.js'
 // happens on read, not here.
 export type Device = 'big-screen' | 'desktop' | 'tablet' | 'phone'
 
+// Real device state — set when the browser actually opens the device, not
+// intent. 'denied' means the OS/browser refused; 'off' means the user toggled
+// it off (or never enabled it). Optional so older cloud builds that never
+// publish lanes still validate against this type.
+export type CaptureLaneState = 'on' | 'off' | 'denied'
+export interface CaptureLanes {
+  mic?: CaptureLaneState
+  camera?: CaptureLaneState
+}
+
 export interface HumanParticipant {
   kind: 'human'
   id: string
@@ -41,6 +51,7 @@ export interface HumanParticipant {
   device: Device
   joinedAt: number
   lastBeaconAt: number
+  captureLanes?: CaptureLanes
 }
 
 interface StoreState {


### PR DESCRIPTION
## Summary

Forward-compat type-only addition for cloud's Capture Lanes v0 slice (https://github.com/reflectt/reflectt-cloud/pull/new/feat/room-capture-lanes-mic-cam).

Humans publish real mic/camera state via Realtime presence. The presence-state spread in `recompute()` passes the new field through unchanged — no logic changes needed in this slice. Reflectt-node will gain read-side surfacing (room/participants response, `room_list_participants` MCP tool) once the cloud side is shipping the data and we have a real consumer for it.

Field is optional on the wire so older cloud builds that don't publish lanes continue to validate against this type.

## Test plan

- [ ] Build succeeds (verified locally — `npm run build` clean)
- [ ] Existing room-presence tests still pass
- [ ] Once cloud PR merges and rolls to a managed host, confirm `room_list_participants` shows the field on humans whose tabs have a lane on

🤖 Generated with [Claude Code](https://claude.com/claude-code)