### PR TITLE
feat(room): Browser-STT v0 — node ring buffer + push to chat (sibling to #2809)

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -35,6 +35,7 @@ export type EventType =
   | 'canvas_takeover'
   | 'agent_identity_changed'  // agent claims/releases full-screen takeover — orbs fade, agent content is the canvas
   | 'room_participant_joined' // room-model-v0.1.1 slice 2: a human appeared in this host's room (data: { participant, hostId })
+  | 'room_transcript_segment' // browser-STT v0: a finalized speech segment from a human in this host's room (data: { segment, hostId })
 
 export const VALID_EVENT_TYPES = new Set<EventType>([
   'message_posted',
@@ -57,6 +58,7 @@ export const VALID_EVENT_TYPES = new Set<EventType>([
   'canvas_takeover',
   'agent_identity_changed',
   'room_participant_joined',
+  'room_transcript_segment',
 ])
 
 export interface Event {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -20,6 +20,7 @@ import { PKG_VERSION } from "./version.js"
 import type { AgentMessage, Task } from "./types.js"
 import { getAgentRoles } from "./assignment.js"
 import { listRoomParticipants, getRoomPresenceStatus } from "./room-presence-store.js"
+import { getRecentTranscript, getRoomTranscriptStatus } from "./room-transcript-store.js"
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MCP Server Setup
@@ -428,6 +429,30 @@ tool(
           count: participants.length,
           hostId: status.hostId,
           initialized: status.initialized,
+        })
+      }]
+    }
+  }
+)
+
+tool(
+  "room_recent_transcript",
+  "Recent FINALIZED speech segments from humans in this host's room (browser-STT v0). Each segment has speaker identity (participantId, userId), text, startedAt, finalizedAt, and receivedAt (node arrival). Returns the last `seconds` of finals (default 30, max 60 — the ring buffer window). Browser-STT v0 is best-effort — Firefox and other browsers without the Web Speech API contribute nothing. Use this when you want to know what people just said without waiting for the next push.",
+  { seconds: z.number().int().min(1).max(60).optional() },
+  async (args: { seconds?: number }) => {
+    const seconds = typeof args?.seconds === 'number' ? args.seconds : 30
+    const since = Date.now() - seconds * 1000
+    const segments = getRecentTranscript(since)
+    const status = getRoomTranscriptStatus()
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          segments,
+          count: segments.length,
+          hostId: status.hostId,
+          initialized: status.initialized,
+          windowMs: status.windowMs,
         })
       }]
     }

--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -16,6 +16,7 @@
 
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { listRoomParticipants, getRoomPresenceStatus } from './room-presence-store.js'
+import { getRecentTranscript, getRoomTranscriptStatus } from './room-transcript-store.js'
 
 function verifyAuth(request: FastifyRequest): { ok: boolean; error?: string } {
   const expectedToken = process.env.REFLECTT_HOST_HEARTBEAT_TOKEN
@@ -50,6 +51,32 @@ export async function roomRoutes(app: FastifyInstance) {
       count: participants.length,
       hostId: status.hostId,
       initialized: status.initialized,
+    }
+  })
+
+  // ── Browser-STT v0: GET /room/transcript ────────────────────────────
+  // Recent finalized transcript segments from the room's Realtime
+  // broadcast. `?since=<unix-ms>` returns only segments with
+  // `receivedAt >= since` (use this for incremental polling). Unset =
+  // full ring (last ~60s). Agents prefer the `room_recent_transcript`
+  // MCP tool; this HTTP endpoint exists for parity and debugging.
+  app.get('/room/transcript', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const query = request.query as Record<string, unknown>
+    const sinceRaw = query?.since
+    const since = typeof sinceRaw === 'string' ? Number(sinceRaw) : (typeof sinceRaw === 'number' ? sinceRaw : undefined)
+    const segments = getRecentTranscript(Number.isFinite(since) ? (since as number) : undefined)
+    const status = getRoomTranscriptStatus()
+    return {
+      segments,
+      count: segments.length,
+      hostId: status.hostId,
+      initialized: status.initialized,
+      windowMs: status.windowMs,
     }
   })
 }

--- a/src/room-transcript-bridge.ts
+++ b/src/room-transcript-bridge.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Transcript Bridge — Browser-STT v0 (room-model-v0.1.1)
+ *
+ * Push half of the transcript contract: turns `room_transcript_segment`
+ * EventBus events (emitted by room-transcript-store) into chat messages
+ * on the founding agent's #general channel — same shape as
+ * room-event-bridge.ts (slice 3B) and the GitHub webhook bridge.
+ *
+ * Why: agents pull recent transcript via `room_recent_transcript` MCP
+ * tool and `GET /room/transcript`. Pull alone only fires if the agent is
+ * awake AND polling. Per kai's room-model rule:
+ *   "APIs/MCP for pull, chat/session event delivery for responsiveness"
+ * This file is the responsiveness half — once a finalized segment becomes
+ * a chat message, it flows to every SSE subscriber including the running
+ * founding agent's session.
+ *
+ * Locked rule (kai's mini-spec refinement #2): humans see interim+final
+ * via the channel directly; agents only get FINALS. The store already
+ * filters; this bridge inherits that filter for free.
+ *
+ * Once-per-segment semantics: dedup_key = segment.id (sender-side stable
+ * id). Replays of the same segment id (shouldn't happen in v0, but
+ * possible if a sender retries) are swallowed by the chatManager dedup
+ * ledger.
+ */
+import { eventBus } from './events.js'
+import { chatManager } from './chat.js'
+import { listRoomParticipants } from './room-presence-store.js'
+import type { RoomTranscriptSegment } from './room-transcript-store.js'
+
+interface BridgeState {
+  initialized: boolean
+  segmentCount: number
+}
+
+const state: BridgeState = {
+  initialized: false,
+  segmentCount: 0,
+}
+
+const LISTENER_ID = 'room-transcript-bridge'
+
+interface RoomTranscriptPayload {
+  segment: RoomTranscriptSegment
+  hostId: string
+}
+
+/**
+ * Resolve a participantId to a human display name via the presence store.
+ * If the speaker isn't currently in the presence map (race between
+ * transcript broadcast and presence sync, or speaker just left), fall
+ * back to a short suffix of the userId so the message still has identity.
+ */
+function resolveSpeakerName(participantId: string, userId: string): string {
+  const participants = listRoomParticipants()
+  const match = participants.find((p) => p.id === participantId)
+  if (match) return match.displayName
+  // Best-effort fallback. Short suffix is enough to disambiguate without
+  // leaking the full uuid.
+  return `human-${userId.slice(0, 6)}`
+}
+
+/**
+ * Format a finalized segment into a single concise chat line. Kept terse
+ * — agents already have AGENTS.md guidance on what to do with transcript
+ * context. The line is the trigger; the rule is the response.
+ */
+function formatSegment(speakerName: string, text: string): string {
+  return `🎙️ **${speakerName}**: ${text}`
+}
+
+/**
+ * Register the EventBus listener. Idempotent. Returns false if already
+ * initialized so callers can detect double-init in tests.
+ */
+export function initRoomTranscriptBridge(): boolean {
+  if (state.initialized) return false
+
+  eventBus.on(LISTENER_ID, (event) => {
+    if (event.type !== 'room_transcript_segment') return
+    const payload = event.data as RoomTranscriptPayload | undefined
+    const seg = payload?.segment
+    if (!seg || !seg.id || !seg.text || !seg.participantId || !seg.userId) return
+    // Defense-in-depth: store already filters to finals, but if the
+    // contract ever loosens we still want only finals reaching chat.
+    if (!seg.isFinal) return
+
+    state.segmentCount++
+    const speakerName = resolveSpeakerName(seg.participantId, seg.userId)
+    void chatManager.sendMessage({
+      from: 'room',
+      content: formatSegment(speakerName, seg.text),
+      channel: 'general',
+      metadata: {
+        source: 'room-event',
+        category: 'room-transcript',
+        eventType: 'room_transcript_segment',
+        participantId: seg.participantId,
+        userId: seg.userId,
+        hostId: payload?.hostId,
+        segmentId: seg.id,
+        startedAt: seg.startedAt,
+        finalizedAt: seg.finalizedAt,
+        // dedup_key: chatManager's ledger swallows repeats. Sender-side
+        // segment id is stable; same final segment replayed (shouldn't
+        // happen in v0) gets swallowed.
+        dedup_key: `room-transcript-${seg.id}`,
+      },
+    }).catch((err) => {
+      console.error(`[room-transcript-bridge] sendMessage failed for ${seg.id}:`, err)
+    })
+  })
+
+  state.initialized = true
+  console.log('[room-transcript-bridge] subscribed to room_transcript_segment → #general')
+  return true
+}
+
+/** Tear down the listener. Used in tests and on graceful shutdown. */
+export function shutdownRoomTranscriptBridge(): void {
+  if (!state.initialized) return
+  eventBus.off(LISTENER_ID)
+  state.initialized = false
+  state.segmentCount = 0
+}
+
+/** Diagnostics: how many segments have been bridged this process lifetime. */
+export function getRoomTranscriptBridgeStatus(): { initialized: boolean; segmentCount: number } {
+  return { initialized: state.initialized, segmentCount: state.segmentCount }
+}

--- a/src/room-transcript-store.ts
+++ b/src/room-transcript-store.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Transcript Store — Browser-STT v0 (room-model-v0.1.1)
+ *
+ * Server-side mirror of the Supabase Realtime broadcast cloud's
+ * `useRoomTranscript` hook publishes to. Subscribes to the same
+ * `room:${hostId}` channel slice 2's room-presence-store rides on, but
+ * listens for the `transcript.segment` broadcast event rather than
+ * presence diffs.
+ *
+ * What this is:
+ *   - Ring buffer of FINAL transcript segments only (kai's locked rule:
+ *     humans see interim+final via the channel, agents only see finals)
+ *   - Truth-cache, not a source of truth — the channel is truth; if it
+ *     drops, the buffer empties and that's the contract
+ *   - Slice scope: 60-second rolling window per host (one host per node,
+ *     so per-process)
+ *
+ * What this is NOT:
+ *   - Durable transcript history (that's slice 5 with LiveKit egress)
+ *   - A retry/resend layer (browser-STT v0 is best-effort; lost segments
+ *     are lost)
+ *   - A second source of truth — the channel is truth
+ *
+ * THIS IS A BRIDGE. Server-side STT (Deepgram/AssemblyAI via LiveKit
+ * egress) replaces this in slice 5. Until then, browser-STT v0 buys us a
+ * real, mic-derived transcript with zero new infra.
+ */
+
+import { createClient, type RealtimeChannel, type SupabaseClient } from '@supabase/supabase-js'
+import { eventBus } from './events.js'
+
+const BROADCAST_EVENT = 'transcript.segment'
+// Rolling window: how far back we keep finalized segments for the
+// `room_recent_transcript` MCP tool and `GET /room/transcript` endpoint.
+// 60s matches the spec — enough for "what did I just miss?" recall, short
+// enough that the buffer stays tiny and ephemeral by feel.
+const RING_BUFFER_WINDOW_MS = 60_000
+// Cap segments held to defend against pathological broadcast storms. At a
+// natural ~1 segment/sec per active speaker, 200 covers ~3 minutes of 1-2
+// concurrent speakers — comfortably above the 60s window.
+const MAX_BUFFERED_SEGMENTS = 200
+
+// Mirror of RoomTranscriptSegment in apps/web/src/app/presence/use-room-transcript.ts.
+// Wire-format from the channel; `receivedAt` is restamped on node arrival
+// so query ordering is consistent with our local clock.
+export interface RoomTranscriptSegment {
+  participantId: string
+  userId: string
+  id: string
+  text: string
+  isFinal: boolean
+  startedAt: number
+  finalizedAt?: number
+  receivedAt: number
+}
+
+interface StoreState {
+  segments: RoomTranscriptSegment[] // sorted by receivedAt asc; finals only
+  channel: RealtimeChannel | null
+  client: SupabaseClient | null
+  hostId: string | null
+  initialized: boolean
+  receivedCount: number             // diagnostics: total finals seen this process lifetime
+}
+
+const state: StoreState = {
+  segments: [],
+  channel: null,
+  client: null,
+  hostId: null,
+  initialized: false,
+  receivedCount: 0,
+}
+
+function resolveHostId(): string | null {
+  const hostId = process.env.REFLECTT_HOST_ID || process.env.HOSTNAME
+  if (!hostId || hostId === 'unknown') return null
+  return hostId
+}
+
+function pruneOldSegments(now: number): void {
+  const cutoff = now - RING_BUFFER_WINDOW_MS
+  // Trim from the front (sorted asc by receivedAt). Two-pass is fine at
+  // this size; we don't need a deque.
+  let drop = 0
+  while (drop < state.segments.length && state.segments[drop]!.receivedAt < cutoff) {
+    drop++
+  }
+  if (drop > 0) state.segments.splice(0, drop)
+  // Cap defense against broadcast storms — keep newest.
+  if (state.segments.length > MAX_BUFFERED_SEGMENTS) {
+    state.segments.splice(0, state.segments.length - MAX_BUFFERED_SEGMENTS)
+  }
+}
+
+function isValidSegment(raw: unknown): raw is RoomTranscriptSegment {
+  if (!raw || typeof raw !== 'object') return false
+  const r = raw as Record<string, unknown>
+  return (
+    typeof r.participantId === 'string' &&
+    typeof r.userId === 'string' &&
+    typeof r.id === 'string' &&
+    typeof r.text === 'string' &&
+    typeof r.isFinal === 'boolean' &&
+    typeof r.startedAt === 'number'
+  )
+}
+
+/**
+ * Initialize the store. Idempotent. Returns false if Supabase env or
+ * REFLECTT_HOST_ID is missing — the rest of the node still boots.
+ *
+ * Opens a SECOND channel object on the same `room:${hostId}` name as
+ * room-presence-store. Supabase shares the underlying WebSocket across
+ * channel objects, so this is the same transport — separate channel
+ * objects are just for clean responsibility split (presence vs transcript
+ * broadcast). Same shape we use on the cloud side.
+ */
+export function initRoomTranscriptStore(): boolean {
+  if (state.initialized) return true
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ACCESS_TOKEN
+  const hostId = resolveHostId()
+
+  if (!url || !key) {
+    console.warn('[room-transcript] Supabase env missing — store stays empty')
+    return false
+  }
+  if (!hostId) {
+    console.warn('[room-transcript] REFLECTT_HOST_ID unresolvable — store stays empty')
+    return false
+  }
+
+  state.hostId = hostId
+  state.client = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+
+  const channel = state.client.channel(`room:${hostId}`)
+
+  channel.on('broadcast', { event: BROADCAST_EVENT }, (msg: { payload?: unknown }) => {
+    const payload = msg.payload
+    if (!isValidSegment(payload)) return
+    // Locked rule (kai #2): humans see interim+final via the channel
+    // directly; agents only get finals. Drop interims at the buffer edge.
+    if (!payload.isFinal) return
+
+    const now = Date.now()
+    const seg: RoomTranscriptSegment = {
+      participantId: payload.participantId,
+      userId: payload.userId,
+      id: payload.id,
+      text: payload.text,
+      isFinal: true,
+      startedAt: payload.startedAt,
+      ...(typeof payload.finalizedAt === 'number' ? { finalizedAt: payload.finalizedAt } : {}),
+      receivedAt: now,
+    }
+
+    state.segments.push(seg)
+    state.receivedCount++
+    pruneOldSegments(now)
+
+    // Push half: emit on the eventBus so room-transcript-bridge can turn
+    // this into a chat message for the founding agent. Same pattern as
+    // room-presence-store → room-event-bridge.
+    eventBus.emit({
+      id: `room-transcript-${seg.id}`,
+      type: 'room_transcript_segment',
+      timestamp: now,
+      data: { segment: seg, hostId },
+    })
+  })
+
+  channel.subscribe((status) => {
+    if (status === 'SUBSCRIBED') {
+      console.log(`[room-transcript] subscribed to room:${hostId} (${BROADCAST_EVENT})`)
+    } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+      console.warn(`[room-transcript] channel ${status} for room:${hostId}`)
+    }
+  })
+
+  state.channel = channel
+  state.initialized = true
+  return true
+}
+
+/** Tear down. Used in tests and on graceful shutdown. */
+export async function shutdownRoomTranscriptStore(): Promise<void> {
+  if (state.channel && state.client) {
+    try { await state.channel.unsubscribe() } catch { /* non-fatal */ }
+    try { await state.client.removeChannel(state.channel) } catch { /* non-fatal */ }
+  }
+  state.channel = null
+  state.client = null
+  state.hostId = null
+  state.initialized = false
+  state.segments = []
+  state.receivedCount = 0
+}
+
+/**
+ * Read recent finalized segments. `sinceMs` is a wall-clock ms cutoff
+ * (e.g. `Date.now() - 30_000` for last 30s); when omitted, returns the
+ * full ring (last `RING_BUFFER_WINDOW_MS`). Sorted by receivedAt asc so
+ * callers get them in arrival order.
+ */
+export function getRecentTranscript(sinceMs?: number): RoomTranscriptSegment[] {
+  pruneOldSegments(Date.now())
+  if (typeof sinceMs !== 'number') return [...state.segments]
+  return state.segments.filter((s) => s.receivedAt >= sinceMs)
+}
+
+/** Diagnostics for /room/transcript?debug=1 and tests. */
+export function getRoomTranscriptStatus(): {
+  initialized: boolean
+  hostId: string | null
+  bufferedCount: number
+  totalReceived: number
+  windowMs: number
+} {
+  pruneOldSegments(Date.now())
+  return {
+    initialized: state.initialized,
+    hostId: state.hostId,
+    bufferedCount: state.segments.length,
+    totalReceived: state.receivedCount,
+    windowMs: RING_BUFFER_WINDOW_MS,
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,6 +174,8 @@ import { canvasReadRoutes, canvasPhase2Routes, formatRecency } from './canvas-ro
 import { roomRoutes } from './room-routes.js'
 import { initRoomPresenceStore } from './room-presence-store.js'
 import { initRoomEventBridge } from './room-event-bridge.js'
+import { initRoomTranscriptStore } from './room-transcript-store.js'
+import { initRoomTranscriptBridge } from './room-transcript-bridge.js'
 import { startTeamPulse, stopTeamPulse, postTeamPulse, computeTeamPulse, getTeamPulseConfig, configureTeamPulse, getTeamPulseHistory } from './team-pulse.js'
 import { runTeamDoctor } from './team-doctor.js'
 import { createStarterTeam } from './starter-team.js'
@@ -12302,6 +12304,16 @@ export async function createServer(): Promise<FastifyInstance> {
   // sees them as `message_posted` SSE events (the same path webhooks use).
   // Pairs with slice 3A's seeded greet-on-join rule in AGENTS.md.
   initRoomEventBridge()
+
+  // ── Browser-STT v0: room transcript store + bridge ───────────────────
+  // Subscribes to the `room:${hostId}` Realtime channel for the
+  // `transcript.segment` broadcast event and ring-buffers FINAL segments
+  // (last 60s). Bridge turns each final into a #general chat message so
+  // the founding agent receives it as `message_posted` SSE — same path
+  // webhooks and room-join events use. Humans see interim+final via the
+  // channel directly; agents only get finals (kai's locked rule).
+  initRoomTranscriptStore()
+  initRoomTranscriptBridge()
 
   // ── Canvas read routes (extracted to src/canvas-routes.ts) ───────────
   // Phase 1: states, slots, slots/all, rejections


### PR DESCRIPTION
## Summary

Node half of the **Browser-STT v0** mini-spec (kai+link+pixel approved). Pairs with reflectt-cloud **PR #2809** which ships the browser hooks (`useTranscript` + `useRoomTranscript`) that publish `transcript.segment` broadcasts on the `room:\${hostId}` Realtime channel.

This PR makes the agent side of the room-model push contract real for transcript: when a human speaks, the founding agent's chat session receives a finalized segment as a `message_posted` SSE event — same path room-join events and webhooks already ride on.

## What this adds

- `src/room-transcript-store.ts` — second channel object on the same `room:\${hostId}` name as `room-presence-store`; listens for `transcript.segment` broadcasts; ring-buffers **FINAL** segments only (60s window, 200-segment storm cap)
- `src/room-transcript-bridge.ts` — `eventBus` listener that turns each finalized segment into a `#general` chat message so the founding agent sees it via SSE; resolves `participantId → displayName` via the presence store
- `GET /room/transcript` — recent finalized segments; `?since=<unix-ms>` for incremental polling (auth uses existing `REFLECTT_HOST_HEARTBEAT_TOKEN` scheme)
- `room_recent_transcript` MCP tool — last `seconds` of finals (default 30, max 60 — matches ring-buffer window)
- `room_transcript_segment` `EventType` added to `events.ts`
- Init wiring in `server.ts` mirrors slice 2 / slice 3B pattern

## Locked design rules (from approved mini-spec)

1. **Humans see interim+final via the channel directly; agents only get FINALS.** Store filters at the buffer edge; bridge inherits the filter for free.
2. **Ephemeral by contract.** Buffer empties if the channel drops. No DB writes. No retry. No resend.
3. **Pull AND push.** HTTP/MCP for pull (\`GET /room/transcript\` + \`room_recent_transcript\`); chat-session event for responsiveness — both halves of kai's room-model contract.
4. **Browser-STT v0 is a bridge, not the seam.** Slice 5 (LiveKit egress + Deepgram/AssemblyAI) is the long-term path. v0 buys us a real mic-derived transcript with zero new infra and exercises the agent push path end-to-end.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Deploy to canonical staging managed host (e4e35463-...) once cloud PR #2809 lands on develop
- [ ] One human speaks in /canvas → another human's caption rail shows the line live
- [ ] Same finalized segment lands in the founding agent's chat session as a \`🎙️ **{name}**: {text}\` message
- [ ] \`GET /room/transcript\` returns the segment within the 60s window
- [ ] \`room_recent_transcript\` MCP call returns it as well
- [ ] Firefox tab joins room → contributes nothing (Web Speech API unavailable); other speakers' captions still flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)