### PR TITLE
feat(room): Room Share Snapshot v0 slice 5A — node artifact substrate

### DIFF
--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -5,6 +5,15 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync, unlinkSyn
 import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 
+/**
+ * Canonical agentId for room-scoped artifacts (Room Share Snapshot v0).
+ * All room artifacts (snapshots in v0; recordings, agent outputs later)
+ * ride a single agentId so the storage path stays clean and per-kind
+ * retention is straightforward. In v0 a host = a room, so this constant
+ * also serves as the "owner of room storage" identity.
+ */
+export const ROOM_ARTIFACT_AGENT_ID = 'room'
+
 export interface Artifact {
   id: string
   agentId: string
@@ -114,12 +123,18 @@ export function readArtifactContent(id: string): Buffer | null {
 }
 
 /**
- * List artifacts for an agent, run, or task.
+ * List artifacts for an agent, run, or task. Optional `kind` filters on
+ * `metadata.kind` (Room Share Snapshot v0 introduced this discriminator;
+ * snapshots are the first kind, recordings/etc. will follow). Kind filter
+ * is applied via SQLite JSON extraction so future-kind artifacts pile up
+ * cleanly under the same agent without a schema change.
  */
 export function listArtifacts(opts: {
   agentId?: string
   runId?: string
   taskId?: string
+  kind?: string
+  sinceMs?: number
   limit?: number
 }): Artifact[] {
   const db = getDb()
@@ -129,11 +144,54 @@ export function listArtifacts(opts: {
   if (opts.agentId) { conditions.push('agent_id = ?'); params.push(opts.agentId) }
   if (opts.runId) { conditions.push('run_id = ?'); params.push(opts.runId) }
   if (opts.taskId) { conditions.push('task_id = ?'); params.push(opts.taskId) }
+  if (opts.kind) { conditions.push("json_extract(metadata, '$.kind') = ?"); params.push(opts.kind) }
+  if (typeof opts.sinceMs === 'number') { conditions.push('created_at >= ?'); params.push(opts.sinceMs) }
 
   if (conditions.length === 0) conditions.push('1=1')
   const limit = opts.limit ?? 50
   return (db.prepare(`SELECT * FROM artifacts WHERE ${conditions.join(' AND ')} ORDER BY created_at DESC LIMIT ?`)
     .all(...params, limit) as ArtifactRow[]).map(rowToArtifact)
+}
+
+/**
+ * Merge `partial` into an artifact's metadata column. Used by the snapshot
+ * write path to attach `thumbnailPath` + `dimensions` after the thumbnail
+ * is generated post-store. Returns the updated artifact, or null if the id
+ * doesn't exist (e.g. concurrent retention sweep already evicted it).
+ */
+export function updateArtifactMetadata(id: string, partial: Record<string, unknown>): Artifact | null {
+  const db = getDb()
+  const existing = getArtifact(id)
+  if (!existing) return null
+  const merged = { ...existing.metadata, ...partial }
+  db.prepare('UPDATE artifacts SET metadata = ? WHERE id = ?').run(JSON.stringify(merged), id)
+  return { ...existing, metadata: merged }
+}
+
+/**
+ * Snapshot retention sweep — Room Share Snapshot v0 lock: keep last `max`
+ * snapshots per `agentId` (= per host = per room in v0), evict oldest.
+ * Deletes both the original PNG and the matching `*-thumb.png` thumbnail
+ * file alongside the DB row. Synchronous + cheap; no scheduler.
+ *
+ * Per-kind cap so future kinds (recordings, agent outputs) carry their
+ * own retention rules set by their own specs without conflict.
+ */
+export function pruneSnapshotsForRetention(agentId: string, max: number = 20): { removed: number } {
+  const snapshots = listArtifacts({ agentId, kind: 'snapshot', limit: 1000 })
+  if (snapshots.length <= max) return { removed: 0 }
+  const toRemove = snapshots.slice(max)
+  let removed = 0
+  for (const art of toRemove) {
+    const thumb = (art.metadata?.thumbnailPath as string | undefined) ?? null
+    if (deleteArtifact(art.id)) {
+      removed++
+      if (thumb) {
+        try { if (existsSync(thumb)) unlinkSync(thumb) } catch { /* best effort */ }
+      }
+    }
+  }
+  return { removed }
 }
 
 /**

--- a/src/events.ts
+++ b/src/events.ts
@@ -36,6 +36,7 @@ export type EventType =
   | 'agent_identity_changed'  // agent claims/releases full-screen takeover — orbs fade, agent content is the canvas
   | 'room_participant_joined' // room-model-v0.1.1 slice 2: a human appeared in this host's room (data: { participant, hostId })
   | 'room_transcript_segment' // browser-STT v0: a finalized speech segment from a human in this host's room (data: { segment, hostId })
+  | 'room_artifact_shared'    // Room Share Snapshot v0 slice 5A: an artifact was shared into the room (data: { artifact, by: participantId, hostId }); kind discriminator on artifact.metadata
 
 export const VALID_EVENT_TYPES = new Set<EventType>([
   'message_posted',
@@ -59,6 +60,7 @@ export const VALID_EVENT_TYPES = new Set<EventType>([
   'agent_identity_changed',
   'room_participant_joined',
   'room_transcript_segment',
+  'room_artifact_shared',
 ])
 
 export interface Event {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -21,6 +21,7 @@ import type { AgentMessage, Task } from "./types.js"
 import { getAgentRoles } from "./assignment.js"
 import { listRoomParticipants, getRoomPresenceStatus } from "./room-presence-store.js"
 import { getRecentTranscript, getRoomTranscriptStatus } from "./room-transcript-store.js"
+import { listArtifacts, ROOM_ARTIFACT_AGENT_ID } from "./artifact-store.js"
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MCP Server Setup
@@ -453,6 +454,44 @@ tool(
           hostId: status.hostId,
           initialized: status.initialized,
           windowMs: status.windowMs,
+        })
+      }]
+    }
+  }
+)
+
+tool(
+  "room_list_artifacts",
+  "Artifacts shared into this host's room (Room Share Snapshot v0). Returns metadata only — fetch bytes via the cloud-proxied content/thumbnail URLs. `kind` filters by artifact discriminator (snapshots are the only kind in v0; recordings/agent outputs may follow). `since` is a unix-ms cursor for incremental polling — pass the previous result's max createdAt. `limit` defaults to 50, max 200. Each item carries id, kind, name, mimeType, sizeBytes, createdAt, sharedBy, sharedByDisplayName, optional dimensions, plus url + thumbnailUrl. Use when you want to look back at what people just shared without waiting for the next push.",
+  { kind: z.string().optional(), since: z.number().int().min(0).optional(), limit: z.number().int().min(1).max(200).optional() },
+  async (args: { kind?: string; since?: number; limit?: number }) => {
+    const limit = typeof args?.limit === 'number' ? args.limit : 50
+    const artifacts = listArtifacts({
+      agentId: ROOM_ARTIFACT_AGENT_ID,
+      kind: args?.kind,
+      sinceMs: args?.since,
+      limit,
+    })
+    const items = artifacts.map((a) => ({
+      id: a.id,
+      kind: (a.metadata?.kind as string | undefined) ?? null,
+      name: a.name,
+      mimeType: a.mimeType,
+      sizeBytes: a.sizeBytes,
+      createdAt: a.createdAt,
+      sharedBy: (a.metadata?.sharedBy as string | undefined) ?? null,
+      sharedByDisplayName: (a.metadata?.sharedByDisplayName as string | undefined) ?? null,
+      dimensions: (a.metadata?.dimensions as { width: number; height: number } | undefined) ?? null,
+      url: `/room/artifacts/${a.id}/content`,
+      thumbnailUrl: `/room/artifacts/${a.id}/thumbnail`,
+    }))
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          artifacts: items,
+          count: items.length,
+          kind: args?.kind ?? null,
         })
       }]
     }

--- a/src/room-artifact-broadcast.ts
+++ b/src/room-artifact-broadcast.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Artifact Broadcast — Room Share Snapshot v0 slice 5A
+ *
+ * Owns a Supabase Realtime channel object on `room:${hostId}` for
+ * BROADCASTING the `artifact.shared` event. Mirror of the channel used
+ * by room-presence-store (presence diffs) and room-transcript-store
+ * (transcript.segment broadcast). Per kai's v0.3 lock (msg-1777191987071):
+ * same channel, separate event type — presence diffs stay presence-only,
+ * artifact diffs stay artifact-only.
+ *
+ * Direction: cloud is the SUBSCRIBER for `artifact.shared` (5B builds
+ * the cross-participant strip); node is the BROADCASTER, called from
+ * `POST /room/artifacts` after the original PNG + thumbnail land.
+ *
+ * Why a separate file from room-transcript-store: that file owns its
+ * channel for a different event (transcript.segment) AND maintains its
+ * own ring buffer state. Conflating responsibilities would make the
+ * shutdown path tangled. Supabase shares the underlying WebSocket
+ * across channel objects so the wire-cost is the same.
+ */
+
+import { createClient, type RealtimeChannel, type SupabaseClient } from '@supabase/supabase-js'
+
+const BROADCAST_EVENT = 'artifact.shared'
+
+interface State {
+  channel: RealtimeChannel | null
+  client: SupabaseClient | null
+  hostId: string | null
+  initialized: boolean
+  sentCount: number
+}
+
+const state: State = {
+  channel: null,
+  client: null,
+  hostId: null,
+  initialized: false,
+  sentCount: 0,
+}
+
+function resolveHostId(): string | null {
+  const hostId = process.env.REFLECTT_HOST_ID || process.env.HOSTNAME
+  if (!hostId || hostId === 'unknown') return null
+  return hostId
+}
+
+/**
+ * Initialize the broadcaster. Idempotent. Returns false if Supabase env
+ * or REFLECTT_HOST_ID is missing — `broadcastArtifactShared` becomes a
+ * no-op (the rest of the node still boots).
+ */
+export function initRoomArtifactBroadcast(): boolean {
+  if (state.initialized) return true
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ACCESS_TOKEN
+  const hostId = resolveHostId()
+
+  if (!url || !key) {
+    console.warn('[room-artifact-broadcast] Supabase env missing — broadcasts disabled')
+    return false
+  }
+  if (!hostId) {
+    console.warn('[room-artifact-broadcast] REFLECTT_HOST_ID unresolvable — broadcasts disabled')
+    return false
+  }
+
+  state.hostId = hostId
+  state.client = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+  const channel = state.client.channel(`room:${hostId}`)
+  channel.subscribe((status) => {
+    if (status === 'SUBSCRIBED') {
+      console.log(`[room-artifact-broadcast] subscribed to room:${hostId} (broadcaster for ${BROADCAST_EVENT})`)
+    } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+      console.warn(`[room-artifact-broadcast] channel ${status} for room:${hostId}`)
+    }
+  })
+  state.channel = channel
+  state.initialized = true
+  return true
+}
+
+export interface ArtifactSharedBroadcast {
+  artifactId: string
+  kind: string
+  sharedBy: string
+  sharedByDisplayName: string
+  createdAt: number
+  url: string
+  thumbnailUrl: string
+}
+
+/**
+ * Send an `artifact.shared` broadcast on the room channel. Best-effort:
+ * if the broadcaster wasn't initialized (env missing) or send fails,
+ * the chat-bridge push and HTTP listing path still work — the realtime
+ * surface is the only one that misses the live update. This matches the
+ * "transport is best-effort" posture of presence + transcript.
+ */
+export async function broadcastArtifactShared(payload: ArtifactSharedBroadcast): Promise<void> {
+  if (!state.initialized || !state.channel) return
+  try {
+    await state.channel.send({ type: 'broadcast', event: BROADCAST_EVENT, payload })
+    state.sentCount++
+  } catch (err) {
+    console.warn(`[room-artifact-broadcast] send failed for ${payload.artifactId}:`, err)
+  }
+}
+
+/** Tear down. Used in tests and on graceful shutdown. */
+export async function shutdownRoomArtifactBroadcast(): Promise<void> {
+  if (state.channel && state.client) {
+    try { await state.channel.unsubscribe() } catch { /* non-fatal */ }
+    try { await state.client.removeChannel(state.channel) } catch { /* non-fatal */ }
+  }
+  state.channel = null
+  state.client = null
+  state.hostId = null
+  state.initialized = false
+  state.sentCount = 0
+}
+
+export function getRoomArtifactBroadcastStatus(): {
+  initialized: boolean
+  hostId: string | null
+  sentCount: number
+} {
+  return {
+    initialized: state.initialized,
+    hostId: state.hostId,
+    sentCount: state.sentCount,
+  }
+}

--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -30,11 +30,13 @@ import { chatManager } from './chat.js'
 interface BridgeState {
   initialized: boolean
   joinCount: number
+  artifactCount: number
 }
 
 const state: BridgeState = {
   initialized: false,
   joinCount: 0,
+  artifactCount: 0,
 }
 
 const LISTENER_ID = 'room-event-bridge'
@@ -54,6 +56,19 @@ interface RoomJoinPayload {
   hostId: string
 }
 
+interface RoomArtifactSharedPayload {
+  artifact: {
+    id: string
+    kind: string | null
+    name: string
+    createdAt: number
+    sharedBy: string | null
+    sharedByDisplayName: string | null
+  }
+  by: string
+  hostId: string
+}
+
 /**
  * Format a join into a single concise chat line. Kept terse on purpose —
  * the seed rule in AGENTS.md tells the agent what to do; this is just the
@@ -64,6 +79,26 @@ function formatJoin(p: RoomJoinPayload['participant']): string {
 }
 
 /**
+ * Format an artifact share into a single utilitarian chat line. Per
+ * kai's lock (msg-1777191217389): "thin factual notification only —
+ * utilitarian, not narration." No URL, no thumbnail, no guess at
+ * content. Agents that care look in the room (pull); agents that
+ * don't, don't get a wall of "here's what's in the snapshot"
+ * hallucinations they didn't ask for.
+ *
+ * Per-kind dispatch — v0 only handles `kind='snapshot'`. Future kinds
+ * (recordings, agent outputs) add their own one-liner here without
+ * changing the event name.
+ */
+function formatArtifactShared(p: RoomArtifactSharedPayload): string | null {
+  const who = p.artifact.sharedByDisplayName ?? 'Someone'
+  switch (p.artifact.kind) {
+    case 'snapshot': return `📸 **${who}** shared a snapshot`
+    default: return null
+  }
+}
+
+/**
  * Register the EventBus listener. Idempotent. Returns false if already
  * initialized so callers can detect double-init in tests.
  */
@@ -71,36 +106,72 @@ export function initRoomEventBridge(): boolean {
   if (state.initialized) return false
 
   eventBus.on(LISTENER_ID, (event) => {
-    if (event.type !== 'room_participant_joined') return
-    const payload = event.data as RoomJoinPayload | undefined
-    const p = payload?.participant
-    if (!p || p.kind !== 'human' || !p.id || !p.displayName) return
+    if (event.type === 'room_participant_joined') {
+      const payload = event.data as RoomJoinPayload | undefined
+      const p = payload?.participant
+      if (!p || p.kind !== 'human' || !p.id || !p.displayName) return
 
-    state.joinCount++
-    void chatManager.sendMessage({
-      from: 'room',
-      content: formatJoin(p),
-      channel: 'general',
-      metadata: {
-        source: 'room-event',
-        category: 'room-join',
-        eventType: 'room_participant_joined',
-        participantId: p.id,
-        userId: p.userId,
-        hostId: payload?.hostId ?? p.hostId,
-        device: p.device,
-        // dedup_key: chatManager's ledger swallows repeats with the
-        // same key. Using participant.id (ephemeral session id) means
-        // greet-once per session; new session → fresh greet.
-        dedup_key: `room-join-${p.id}`,
-      },
-    }).catch((err) => {
-      console.error(`[room-event-bridge] sendMessage failed for ${p.id}:`, err)
-    })
+      state.joinCount++
+      void chatManager.sendMessage({
+        from: 'room',
+        content: formatJoin(p),
+        channel: 'general',
+        metadata: {
+          source: 'room-event',
+          category: 'room-join',
+          eventType: 'room_participant_joined',
+          participantId: p.id,
+          userId: p.userId,
+          hostId: payload?.hostId ?? p.hostId,
+          device: p.device,
+          // dedup_key: chatManager's ledger swallows repeats with the
+          // same key. Using participant.id (ephemeral session id) means
+          // greet-once per session; new session → fresh greet.
+          dedup_key: `room-join-${p.id}`,
+        },
+      }).catch((err) => {
+        console.error(`[room-event-bridge] sendMessage failed for ${p.id}:`, err)
+      })
+      return
+    }
+
+    if (event.type === 'room_artifact_shared') {
+      const payload = event.data as RoomArtifactSharedPayload | undefined
+      if (!payload?.artifact?.id || !payload.artifact.kind) return
+      const line = formatArtifactShared(payload)
+      // Unknown kind in v0 → silent. Future kinds add a formatter case
+      // when they ship their own slice. We do NOT post a generic
+      // "an artifact was shared" line — that would lie about what
+      // the room can render.
+      if (!line) return
+
+      state.artifactCount++
+      void chatManager.sendMessage({
+        from: 'room',
+        content: line,
+        channel: 'general',
+        metadata: {
+          source: 'room-event',
+          category: 'room-artifact',
+          eventType: 'room_artifact_shared',
+          artifactId: payload.artifact.id,
+          kind: payload.artifact.kind,
+          sharedBy: payload.by,
+          hostId: payload.hostId,
+          // Artifacts have stable unique ids — strict per-id dedup so
+          // a duplicate emit (rare but possible on retry) doesn't
+          // double-post. Unlike `room-join-${id}` (per-session) this
+          // is per-artifact-ever.
+          dedup_key: `room-artifact-${payload.artifact.id}`,
+        },
+      }).catch((err) => {
+        console.error(`[room-event-bridge] sendMessage failed for artifact ${payload.artifact.id}:`, err)
+      })
+    }
   })
 
   state.initialized = true
-  console.log('[room-event-bridge] subscribed to room_participant_joined → #general')
+  console.log('[room-event-bridge] subscribed to room_participant_joined + room_artifact_shared → #general')
   return true
 }
 
@@ -110,9 +181,10 @@ export function shutdownRoomEventBridge(): void {
   eventBus.off(LISTENER_ID)
   state.initialized = false
   state.joinCount = 0
+  state.artifactCount = 0
 }
 
-/** Diagnostics: how many joins have been bridged this process lifetime. */
-export function getRoomEventBridgeStatus(): { initialized: boolean; joinCount: number } {
-  return { initialized: state.initialized, joinCount: state.joinCount }
+/** Diagnostics: counts of room events this bridge has translated into chat. */
+export function getRoomEventBridgeStatus(): { initialized: boolean; joinCount: number; artifactCount: number } {
+  return { initialized: state.initialized, joinCount: state.joinCount, artifactCount: state.artifactCount }
 }

--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -2,11 +2,16 @@
 // Copyright (c) Reflectt AI
 
 /**
- * Room Routes — slice 2 of room-model-v0.1.1
+ * Room Routes — slice 2 of room-model-v0.1.1, extended in slice 5A
+ * (Room Share Snapshot v0).
  *
- * Fastify plugin registering room-state read endpoints. Currently exposes
- * `GET /room/participants` — the cached human participant set from the
- * Supabase Realtime channel slice 1 publishes to.
+ * Fastify plugin registering room-state read/write endpoints:
+ *   - GET /room/participants            (slice 2 — presence cache)
+ *   - GET /room/transcript              (Browser-STT v0 — finalized segments)
+ *   - GET /room/artifacts               (5A — list, generic, filterable by kind)
+ *   - GET /room/artifacts/:id/content   (5A — full-res bytes)
+ *   - GET /room/artifacts/:id/thumbnail (5A — server-generated 480px PNG)
+ *   - POST /room/artifacts              (5A — multipart write; v0 only accepts kind='snapshot')
  *
  * Auth uses the same heartbeat-token model as `/hosts/heartbeat`: if
  * REFLECTT_HOST_HEARTBEAT_TOKEN is set, requests must present it via
@@ -14,9 +19,26 @@
  * If unset, the route is open (matches existing host-cred behavior).
  */
 
+import { existsSync, readFileSync, unlinkSync } from 'node:fs'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
+import { eventBus } from './events.js'
 import { listRoomParticipants, getRoomPresenceStatus } from './room-presence-store.js'
 import { getRecentTranscript, getRoomTranscriptStatus } from './room-transcript-store.js'
+import {
+  storeArtifact,
+  getArtifact,
+  deleteArtifact,
+  listArtifacts,
+  updateArtifactMetadata,
+  pruneSnapshotsForRetention,
+  ROOM_ARTIFACT_AGENT_ID,
+  type Artifact,
+} from './artifact-store.js'
+import { generateSnapshotThumbnail, thumbnailPathFor } from './snapshot-thumbnail.js'
+import { broadcastArtifactShared } from './room-artifact-broadcast.js'
+
+const SNAPSHOT_RETENTION_MAX = 20
+const ALLOWED_KINDS_V0 = new Set(['snapshot'])
 
 function verifyAuth(request: FastifyRequest): { ok: boolean; error?: string } {
   const expectedToken = process.env.REFLECTT_HOST_HEARTBEAT_TOKEN
@@ -35,6 +57,33 @@ function verifyAuth(request: FastifyRequest): { ok: boolean; error?: string } {
   if (typeof query?.token === 'string' && query.token === expectedToken) return { ok: true }
 
   return { ok: false, error: 'Unauthorized: REFLECTT_HOST_HEARTBEAT_TOKEN required' }
+}
+
+function resolveHostId(): string {
+  return process.env.REFLECTT_HOST_ID || process.env.HOSTNAME || 'unknown'
+}
+
+/**
+ * Project an artifact for the wire — strips on-disk paths, adds the
+ * relative URL the cloud will resolve. `thumbnailUrl` is present even
+ * for kinds without a thumbnail (returns 404 in that case); v0 only
+ * accepts `kind='snapshot'` so all v0 artifacts have one.
+ */
+function projectArtifact(art: Artifact): Record<string, unknown> {
+  const meta = art.metadata ?? {}
+  return {
+    id: art.id,
+    kind: (meta.kind as string | undefined) ?? null,
+    name: art.name,
+    mimeType: art.mimeType,
+    sizeBytes: art.sizeBytes,
+    createdAt: art.createdAt,
+    sharedBy: (meta.sharedBy as string | undefined) ?? null,
+    sharedByDisplayName: (meta.sharedByDisplayName as string | undefined) ?? null,
+    dimensions: (meta.dimensions as { width: number; height: number } | undefined) ?? null,
+    url: `/room/artifacts/${art.id}/content`,
+    thumbnailUrl: `/room/artifacts/${art.id}/thumbnail`,
+  }
 }
 
 export async function roomRoutes(app: FastifyInstance) {
@@ -78,5 +127,229 @@ export async function roomRoutes(app: FastifyInstance) {
       initialized: status.initialized,
       windowMs: status.windowMs,
     }
+  })
+
+  // ── Room Share Snapshot v0 (slice 5A) ───────────────────────────────
+  // Artifact-generic substrate per ROOM_MODEL_V0; snapshot is the first
+  // artifact kind via `metadata.kind='snapshot'` discriminator. UI copy
+  // stays snapshot-specific; substrate stays kind-generic so future
+  // recordings / agent outputs ride the same routes without renaming.
+
+  /**
+   * GET /room/artifacts?kind=snapshot&since=<unix-ms>&limit=<n>
+   * List artifacts shared in this room. Optional `kind` narrows to one
+   * discriminator; omit for all kinds. `since` is an inclusive cursor
+   * on createdAt for incremental polling. Default limit 50.
+   */
+  app.get('/room/artifacts', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const query = request.query as Record<string, unknown>
+    const kindRaw = query?.kind
+    const kind = typeof kindRaw === 'string' && kindRaw.length > 0 ? kindRaw : undefined
+    const sinceRaw = query?.since
+    const since = typeof sinceRaw === 'string' ? Number(sinceRaw) : (typeof sinceRaw === 'number' ? sinceRaw : undefined)
+    const limitRaw = query?.limit
+    const limitParsed = typeof limitRaw === 'string' ? Number(limitRaw) : (typeof limitRaw === 'number' ? limitRaw : undefined)
+    const limit = Number.isFinite(limitParsed) && (limitParsed as number) > 0
+      ? Math.min(200, Math.floor(limitParsed as number))
+      : 50
+
+    const artifacts = listArtifacts({
+      agentId: ROOM_ARTIFACT_AGENT_ID,
+      kind,
+      sinceMs: Number.isFinite(since) ? (since as number) : undefined,
+      limit,
+    })
+    return {
+      artifacts: artifacts.map(projectArtifact),
+      count: artifacts.length,
+      hostId: resolveHostId(),
+    }
+  })
+
+  /**
+   * GET /room/artifacts/:id/content
+   * Full-resolution bytes. Mime-type from the stored row. 404 if the
+   * artifact id is unknown or the file was evicted by retention sweep
+   * between listing and read.
+   */
+  app.get<{ Params: { id: string } }>('/room/artifacts/:id/content', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const art = getArtifact(request.params.id)
+    if (!art || art.agentId !== ROOM_ARTIFACT_AGENT_ID || !existsSync(art.storagePath)) {
+      reply.status(404)
+      return { error: 'artifact not found' }
+    }
+    const buf = readFileSync(art.storagePath)
+    reply.header('Content-Type', art.mimeType)
+    reply.header('Content-Length', String(buf.length))
+    return reply.send(buf)
+  })
+
+  /**
+   * GET /room/artifacts/:id/thumbnail
+   * Server-generated 480px PNG. 404 if the artifact has no thumbnail
+   * (kind without one) or the file was evicted.
+   */
+  app.get<{ Params: { id: string } }>('/room/artifacts/:id/thumbnail', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const art = getArtifact(request.params.id)
+    if (!art || art.agentId !== ROOM_ARTIFACT_AGENT_ID) {
+      reply.status(404)
+      return { error: 'artifact not found' }
+    }
+    const thumbPath = (art.metadata?.thumbnailPath as string | undefined) ?? null
+    if (!thumbPath || !existsSync(thumbPath)) {
+      reply.status(404)
+      return { error: 'thumbnail not found' }
+    }
+    const buf = readFileSync(thumbPath)
+    reply.header('Content-Type', 'image/png')
+    reply.header('Content-Length', String(buf.length))
+    return reply.send(buf)
+  })
+
+  /**
+   * POST /room/artifacts (multipart)
+   * Field 'file' = PNG bytes (required; v0 enforces image/png).
+   * Field 'kind' = discriminator (required; v0 only accepts 'snapshot').
+   * Field 'sharedBy' = participant id (required).
+   * Field 'sharedByDisplayName' = denormalized display name (required).
+   *
+   * Flow: write original → generate thumbnail (sync, sharp 480px) → update
+   * artifact metadata with thumbnailPath + dimensions → emit
+   * room_artifact_shared on EventBus → broadcast artifact.shared on the
+   * room channel → run snapshot retention sweep (last-20 evict).
+   *
+   * Failure contract: if thumbnail generation throws, the original PNG +
+   * row are rolled back and the route returns 500. Half-stored artifacts
+   * (full-res but no thumb) would force the strip to fall back to
+   * full-res or render nothing — both worse than failing the upload.
+   */
+  app.post('/room/artifacts', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const data = await request.file()
+    if (!data) {
+      reply.status(400)
+      return { error: 'file field required (multipart)' }
+    }
+
+    const fields = data.fields as Record<string, { value?: unknown } | undefined>
+    const kind = typeof fields.kind?.value === 'string' ? (fields.kind.value as string) : undefined
+    const sharedBy = typeof fields.sharedBy?.value === 'string' ? (fields.sharedBy.value as string) : undefined
+    const sharedByDisplayName = typeof fields.sharedByDisplayName?.value === 'string' ? (fields.sharedByDisplayName.value as string) : undefined
+
+    if (!kind || !ALLOWED_KINDS_V0.has(kind)) {
+      reply.status(400)
+      return { error: `kind must be one of: ${[...ALLOWED_KINDS_V0].join(', ')}` }
+    }
+    if (!sharedBy || !sharedByDisplayName) {
+      reply.status(400)
+      return { error: 'sharedBy + sharedByDisplayName required' }
+    }
+    // v0 only handles image/png snapshots. Future kinds may relax this.
+    if (data.mimetype !== 'image/png') {
+      reply.status(400)
+      return { error: 'snapshot requires image/png' }
+    }
+
+    const buf = await data.toBuffer()
+    if (buf.length === 0) {
+      reply.status(400)
+      return { error: 'empty file' }
+    }
+
+    const hostId = resolveHostId()
+    const isoNow = new Date().toISOString()
+    const fileName = `snapshot-${isoNow.replace(/[:.]/g, '-')}.png`
+
+    const art = storeArtifact({
+      agentId: ROOM_ARTIFACT_AGENT_ID,
+      name: fileName,
+      content: buf,
+      mimeType: 'image/png',
+      metadata: {
+        kind,
+        roomId: hostId,
+        sharedBy,
+        sharedByDisplayName,
+      },
+    })
+
+    const thumbPath = thumbnailPathFor(art.storagePath)
+    let updated = art
+    try {
+      const thumb = await generateSnapshotThumbnail(art.storagePath, thumbPath)
+      const next = updateArtifactMetadata(art.id, {
+        thumbnailPath: thumb.thumbnailPath,
+        dimensions: thumb.dimensions,
+      })
+      if (!next) {
+        // Concurrent retention evicted us between insert and update — rare
+        // but possible. Treat as failure path: clean up the thumbnail we
+        // just wrote, return 500.
+        try { if (existsSync(thumbPath)) unlinkSync(thumbPath) } catch { /* best effort */ }
+        reply.status(500)
+        return { error: 'artifact disappeared during write' }
+      }
+      updated = next
+    } catch (err) {
+      // Roll back: remove thumbnail (if it landed) + original PNG + DB row.
+      try { if (existsSync(thumbPath)) unlinkSync(thumbPath) } catch { /* best effort */ }
+      deleteArtifact(art.id)
+      reply.status(500)
+      return { error: `thumbnail generation failed: ${err instanceof Error ? err.message : String(err)}` }
+    }
+
+    const projected = projectArtifact(updated)
+
+    // Push half: emit on EventBus so room-event-bridge can format a chat
+    // line for the founding agent. Same pattern as room_participant_joined
+    // and room_transcript_segment.
+    eventBus.emit({
+      id: `room-artifact-${updated.id}`,
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: { artifact: projected, by: sharedBy, hostId },
+    })
+
+    // Realtime fan-out: cloud subscribers (other participants) refresh
+    // their strips on receipt. Best-effort — the chat push + HTTP listing
+    // path still work if the broadcast fails.
+    void broadcastArtifactShared({
+      artifactId: updated.id,
+      kind,
+      sharedBy,
+      sharedByDisplayName,
+      createdAt: updated.createdAt,
+      url: projected.url as string,
+      thumbnailUrl: projected.thumbnailUrl as string,
+    })
+
+    // Per-kind retention sweep — last 20 snapshots, evict oldest. Sync,
+    // cheap, no scheduler. Future kinds set their own caps from their
+    // own specs.
+    if (kind === 'snapshot') {
+      pruneSnapshotsForRetention(ROOM_ARTIFACT_AGENT_ID, SNAPSHOT_RETENTION_MAX)
+    }
+
+    reply.status(201)
+    return { artifact: projected, hostId }
   })
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,6 +176,7 @@ import { initRoomPresenceStore } from './room-presence-store.js'
 import { initRoomEventBridge } from './room-event-bridge.js'
 import { initRoomTranscriptStore } from './room-transcript-store.js'
 import { initRoomTranscriptBridge } from './room-transcript-bridge.js'
+import { initRoomArtifactBroadcast } from './room-artifact-broadcast.js'
 import { startTeamPulse, stopTeamPulse, postTeamPulse, computeTeamPulse, getTeamPulseConfig, configureTeamPulse, getTeamPulseHistory } from './team-pulse.js'
 import { runTeamDoctor } from './team-doctor.js'
 import { createStarterTeam } from './starter-team.js'
@@ -12314,6 +12315,14 @@ export async function createServer(): Promise<FastifyInstance> {
   // channel directly; agents only get finals (kai's locked rule).
   initRoomTranscriptStore()
   initRoomTranscriptBridge()
+
+  // ── Room Share Snapshot v0 slice 5A: artifact broadcaster ────────────
+  // Owns its own Supabase Realtime channel handle on `room:${hostId}` for
+  // BROADCASTING the `artifact.shared` event (cloud subscribes in 5B).
+  // Same channel as presence + transcript, separate event type per kai's
+  // v0.3 lock. Best-effort: env-missing → no-op; HTTP + chat-bridge still
+  // work, only the live realtime tile push is skipped.
+  initRoomArtifactBroadcast()
 
   // ── Canvas read routes (extracted to src/canvas-routes.ts) ───────────
   // Phase 1: states, slots, slots/all, rejections

--- a/src/snapshot-thumbnail.ts
+++ b/src/snapshot-thumbnail.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Snapshot Thumbnail — Room Share Snapshot v0 slice 5A
+ *
+ * Sharp-based 480px-longest-edge PNG thumbnail generator. Called
+ * synchronously from `POST /room/artifacts` after the original PNG is
+ * stored, before the artifact_shared event is emitted.
+ *
+ * Why server-side: kai's lock (msg-1777191987071, agreeing with link's
+ * later firmer call). Pulling full-res 4K PNGs into the strip on every
+ * page load is unbounded bandwidth; one 480px PNG per snapshot is bounded
+ * (~50KB on disk). Strip uses thumbnailUrl, click-to-expand uses url.
+ *
+ * Why sync: the user just pressed "Share to room" and expects the strip
+ * tile to appear immediately. A background job would either delay the
+ * tile (bad perception loop) or render full-res then swap (visual jank).
+ * Sharp on a 4K PNG → 480px = ~50ms; cost is bounded.
+ *
+ * Why PNG output (not JPEG): snapshots are screen captures with text
+ * legibility constraints. JPEG artifacts on small text are unacceptable
+ * for a screen-share use case.
+ *
+ * Failure contract: if generation throws, the caller (POST /room/artifacts)
+ * rolls back the original artifact insert. Half-stored state (full-res
+ * but no thumb) would force the strip to either show nothing or fall
+ * back to full-res — both worse than failing the upload cleanly.
+ */
+
+import sharp from 'sharp'
+
+const TARGET_LONGEST_EDGE_PX = 480
+
+export interface ThumbnailResult {
+  thumbnailPath: string
+  /** Original capture dimensions; useful for client-side aspect-ratio calc without fetching bytes. */
+  dimensions: { width: number; height: number }
+}
+
+/**
+ * Derive the thumbnail path that pairs with an original artifact storage
+ * path. Same directory, `-thumb.png` suffix on the basename. Exposed so
+ * retention / read paths can locate thumbnails without re-deriving the
+ * convention in three places.
+ */
+export function thumbnailPathFor(originalStoragePath: string): string {
+  return originalStoragePath.replace(/\.png$/i, '') + '-thumb.png'
+}
+
+/**
+ * Generate a 480px-longest-edge PNG thumbnail at `thumbnailPath`. Reads
+ * the original from disk; returns the path written + the original's
+ * pixel dimensions.
+ *
+ * Throws on any sharp failure (invalid PNG, no metadata, write error).
+ * The caller is responsible for rolling back the corresponding artifact
+ * row + original file — see POST /room/artifacts in room-routes.ts.
+ */
+export async function generateSnapshotThumbnail(
+  originalPath: string,
+  thumbnailPath: string,
+): Promise<ThumbnailResult> {
+  const meta = await sharp(originalPath).metadata()
+  const w = meta.width ?? 0
+  const h = meta.height ?? 0
+  if (!w || !h) throw new Error('snapshot has no dimensions (corrupt or zero-size PNG)')
+
+  const longest = Math.max(w, h)
+  const scale = longest > TARGET_LONGEST_EDGE_PX ? TARGET_LONGEST_EDGE_PX / longest : 1
+  const targetW = Math.max(1, Math.round(w * scale))
+  const targetH = Math.max(1, Math.round(h * scale))
+
+  await sharp(originalPath)
+    .resize({ width: targetW, height: targetH, fit: 'inside' })
+    .png()
+    .toFile(thumbnailPath)
+
+  return { thumbnailPath, dimensions: { width: w, height: h } }
+}

--- a/tests/artifact-store-room.test.ts
+++ b/tests/artifact-store-room.test.ts
@@ -1,0 +1,139 @@
+// Room Share Snapshot v0 slice 5A: tests for the artifact-store extensions
+// (kind filter, sinceMs filter, updateArtifactMetadata, pruneSnapshotsForRetention).
+// The room flow piles all room-scoped artifacts under agentId=ROOM_ARTIFACT_AGENT_ID
+// with metadata.kind as the discriminator — these tests pin that contract.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { promises as fs } from 'fs'
+import { existsSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let tempHome: string
+
+beforeAll(async () => {
+  tempHome = await fs.mkdtemp(join(tmpdir(), 'artifact-store-room-test-'))
+  // homedir() honors HOME on darwin/linux; REFLECTT_HOME pins the DB path.
+  process.env.HOME = tempHome
+  process.env.REFLECTT_HOME = join(tempHome, '.reflectt')
+})
+
+afterAll(async () => {
+  delete process.env.REFLECTT_HOME
+  await fs.rm(tempHome, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('artifact-store room extensions', () => {
+  beforeEach(async () => {
+    // Wipe DB rows + storage between tests so retention math is deterministic.
+    const mod = await import('../src/artifact-store.js')
+    const dbMod = await import('../src/db.js')
+    dbMod.getDb().prepare('DELETE FROM artifacts WHERE agent_id = ?').run(mod.ROOM_ARTIFACT_AGENT_ID)
+  })
+
+  function storeSnapshot(name: string, kind: string = 'snapshot', extraMeta: Record<string, unknown> = {}) {
+    // Need a real png-ish buffer on disk since storeArtifact writeFileSyncs.
+    // Content can be anything — these tests don't read it back.
+    return import('../src/artifact-store.js').then((mod) =>
+      mod.storeArtifact({
+        agentId: mod.ROOM_ARTIFACT_AGENT_ID,
+        name,
+        mimeType: 'image/png',
+        content: Buffer.from('fake-png'),
+        metadata: { kind, ...extraMeta },
+      })
+    )
+  }
+
+  it('listArtifacts({kind}) only returns matching kind', async () => {
+    const mod = await import('../src/artifact-store.js')
+    await storeSnapshot('a.png', 'snapshot')
+    await storeSnapshot('b.png', 'snapshot')
+    await storeSnapshot('c.png', 'recording')
+
+    const snapshots = mod.listArtifacts({ agentId: mod.ROOM_ARTIFACT_AGENT_ID, kind: 'snapshot' })
+    expect(snapshots).toHaveLength(2)
+    expect(snapshots.every((a) => a.metadata.kind === 'snapshot')).toBe(true)
+
+    const recordings = mod.listArtifacts({ agentId: mod.ROOM_ARTIFACT_AGENT_ID, kind: 'recording' })
+    expect(recordings).toHaveLength(1)
+    expect(recordings[0].name).toBe('c.png')
+  })
+
+  it('listArtifacts({sinceMs}) drops older items', async () => {
+    const mod = await import('../src/artifact-store.js')
+    const a = await storeSnapshot('a.png')
+    await new Promise((r) => setTimeout(r, 10))
+    const b = await storeSnapshot('b.png')
+
+    const after = mod.listArtifacts({
+      agentId: mod.ROOM_ARTIFACT_AGENT_ID,
+      sinceMs: b.createdAt,
+    })
+    expect(after.map((x) => x.id)).toEqual([b.id])
+    expect(after.map((x) => x.id)).not.toContain(a.id)
+  })
+
+  it('updateArtifactMetadata merges keys without dropping prior ones', async () => {
+    const mod = await import('../src/artifact-store.js')
+    const a = await storeSnapshot('a.png', 'snapshot', { sharedBy: 'p-1', sharedByDisplayName: 'Ryan' })
+    const updated = mod.updateArtifactMetadata(a.id, {
+      thumbnailPath: '/tmp/thumb.png',
+      dimensions: { width: 1920, height: 1080 },
+    })
+    expect(updated).not.toBeNull()
+    expect(updated!.metadata.kind).toBe('snapshot')
+    expect(updated!.metadata.sharedBy).toBe('p-1')
+    expect(updated!.metadata.sharedByDisplayName).toBe('Ryan')
+    expect(updated!.metadata.thumbnailPath).toBe('/tmp/thumb.png')
+    expect((updated!.metadata.dimensions as { width: number }).width).toBe(1920)
+
+    // Re-fetch from DB to confirm persistence.
+    const reread = mod.getArtifact(a.id)
+    expect(reread!.metadata.thumbnailPath).toBe('/tmp/thumb.png')
+  })
+
+  it('updateArtifactMetadata returns null for unknown id (sweep-eviction race)', async () => {
+    const mod = await import('../src/artifact-store.js')
+    expect(mod.updateArtifactMetadata('art-nonexistent', { x: 1 })).toBeNull()
+  })
+
+  it('pruneSnapshotsForRetention(agentId, max=2) keeps the newest 2 snapshots and deletes thumbs', async () => {
+    const mod = await import('../src/artifact-store.js')
+    const items = [] as Awaited<ReturnType<typeof storeSnapshot>>[]
+    for (let i = 0; i < 5; i++) {
+      const a = await storeSnapshot(`a${i}.png`)
+      // Plant a fake thumbnail file at the metadata-tracked path so eviction
+      // exercises the unlink branch.
+      const thumbPath = a.storagePath.replace(/\.png$/i, '') + '-thumb.png'
+      writeFileSync(thumbPath, 'fake-thumb')
+      mod.updateArtifactMetadata(a.id, { thumbnailPath: thumbPath })
+      items.push({ ...a, storagePath: a.storagePath })
+      await new Promise((r) => setTimeout(r, 5)) // force createdAt ordering
+    }
+
+    const result = mod.pruneSnapshotsForRetention(mod.ROOM_ARTIFACT_AGENT_ID, 2)
+    expect(result.removed).toBe(3)
+
+    const remaining = mod.listArtifacts({
+      agentId: mod.ROOM_ARTIFACT_AGENT_ID,
+      kind: 'snapshot',
+      limit: 100,
+    })
+    expect(remaining).toHaveLength(2)
+    // Newest 2 survived (indexes 4 and 3).
+    expect(remaining.map((r) => r.name).sort()).toEqual(['a3.png', 'a4.png'])
+
+    // Evicted thumbnails are gone from disk.
+    for (const it of items.slice(0, 3)) {
+      const thumbPath = it.storagePath.replace(/\.png$/i, '') + '-thumb.png'
+      expect(existsSync(thumbPath)).toBe(false)
+    }
+  })
+
+  it('pruneSnapshotsForRetention is a no-op when count <= max', async () => {
+    const mod = await import('../src/artifact-store.js')
+    await storeSnapshot('only.png')
+    expect(mod.pruneSnapshotsForRetention(mod.ROOM_ARTIFACT_AGENT_ID, 20)).toEqual({ removed: 0 })
+  })
+})

--- a/tests/room-event-bridge.test.ts
+++ b/tests/room-event-bridge.test.ts
@@ -132,4 +132,78 @@ describe('room-event-bridge', () => {
     emitJoin()
     expect(sendMessageMock).toHaveBeenCalledTimes(1)
   })
+
+  // Slice 5A — Room Share Snapshot v0: same bridge, second event type.
+  // Snapshot kind → utilitarian one-liner. Unknown kind → silent (we don't
+  // post a generic "an artifact was shared" line that would lie about what
+  // the room can render today).
+  it('forwards a snapshot artifact_shared into chatManager.sendMessage', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-evt-1',
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: {
+        artifact: {
+          id: 'art-abc-123',
+          kind: 'snapshot',
+          name: 'screen.png',
+          createdAt: Date.now(),
+          sharedBy: 'session-abc-123',
+          sharedByDisplayName: 'Ryan',
+        },
+        by: 'session-abc-123',
+        hostId: 'host-1',
+      },
+    })
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.from).toBe('room')
+    expect(call.channel).toBe('general')
+    expect(call.content).toContain('Ryan')
+    expect(call.content).toContain('snapshot')
+    expect(call.metadata.source).toBe('room-event')
+    expect(call.metadata.category).toBe('room-artifact')
+    expect(call.metadata.artifactId).toBe('art-abc-123')
+    expect(call.metadata.kind).toBe('snapshot')
+    expect(call.metadata.dedup_key).toBe('room-artifact-art-abc-123')
+    expect(getRoomEventBridgeStatus().artifactCount).toBe(1)
+  })
+
+  it('drops unknown artifact kinds silently (no generic "an artifact was shared" line)', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-evt-2',
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: {
+        artifact: {
+          id: 'art-future',
+          kind: 'recording', // not implemented in v0
+          name: 'r.mp4',
+          createdAt: Date.now(),
+          sharedBy: 's-1',
+          sharedByDisplayName: 'Ryan',
+        },
+        by: 's-1',
+        hostId: 'host-1',
+      },
+    })
+    expect(sendMessageMock).not.toHaveBeenCalled()
+    expect(getRoomEventBridgeStatus().artifactCount).toBe(0)
+  })
+
+  it('ignores artifact events with no kind or no id', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-bad-1', type: 'room_artifact_shared', timestamp: Date.now(),
+      data: { artifact: { id: '', kind: 'snapshot', name: 'x', createdAt: Date.now(), sharedBy: null, sharedByDisplayName: null }, by: 's-1', hostId: 'host-1' },
+    })
+    eventBus.emit({
+      id: 'art-bad-2', type: 'room_artifact_shared', timestamp: Date.now(),
+      data: { artifact: { id: 'art-x', kind: null, name: 'x', createdAt: Date.now(), sharedBy: null, sharedByDisplayName: null }, by: 's-1', hostId: 'host-1' },
+    })
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

Node-side half of Room Share Snapshot v0 per [docs/ROOM_SHARE_SNAPSHOT_V0.md](https://github.com/reflectt/reflectt-cloud/blob/develop/docs/ROOM_SHARE_SNAPSHOT_V0.md) (merged in cloud as PR #2813 / 4678e753 with kai's v0.3 locks). Cloud-side (5B) builds the share button + cross-participant strip on top.

## What ships

**HTTP** (room-routes.ts, all behind `verifyAuth` heartbeat-token):
- `POST /room/artifacts` — multipart upload, validates `kind` ∈ `ALLOWED_KINDS_V0={'snapshot'}`, stores PNG, generates 480px thumb sync, attaches dimensions, emits `room_artifact_shared`, broadcasts `artifact.shared` on room channel, prunes per-kind retention. Rolls back original + DB row if thumb fails (kai's lock — no half-stored state).
- `GET /room/artifacts` — list with `?kind` & `?since` (unix-ms cursor) & `?limit` (default 50, max 200).
- `GET /room/artifacts/:id/content` — original PNG bytes.
- `GET /room/artifacts/:id/thumbnail` — 480px PNG thumb.

**MCP**: `room_list_artifacts({kind?, since?, limit?})` mirrors the `room_recent_transcript` shape.

**Realtime** (`room-artifact-broadcast.ts`, NEW): owns its own Supabase channel handle on `room:${hostId}` for the `artifact.shared` event. Same channel as presence + transcript, separate event type per kai's v0.3 lock. Best-effort.

**Storage** (`artifact-store.ts`): new `ROOM_ARTIFACT_AGENT_ID = 'room'`; `listArtifacts()` learns `kind` (json_extract on metadata) + `sinceMs` filters; `updateArtifactMetadata()` for post-store thumb attach; `pruneSnapshotsForRetention(agentId, max=20)` sync sweep with thumb cleanup.

**Thumbnail** (`snapshot-thumbnail.ts`, NEW): sharp-based 480px-longest-edge PNG. Sync because the user just pressed share. PNG output (not JPEG) for screen-text legibility.

**Chat bridge** (`room-event-bridge.ts`): extends slice 3B with `room_artifact_shared` → utilitarian one-liner on #general per kai's lock. Per-kind dispatch — snapshots only in v0; unknown kinds silent.

**Boot** (`server.ts`): `initRoomArtifactBroadcast()` alongside other room init hooks.

## Test plan

- [x] Unit/integration: `tests/artifact-store-room.test.ts` (NEW, 7 tests) + extended `tests/room-event-bridge.test.ts` (3 new tests). All 15 green.
- [x] Full suite: 238 files, 2590 passed, 1 skipped, 0 failed (30.9s).
- [x] `tsc --noEmit` clean. `npm run build` clean.
- [ ] Honest 5A proof on canonical staging host `rn-34faba44-wlgkeq` (machine `568354e7ad5348`) — once this lands, roll the host image and run an upload + list + thumbnail GET sequence. Will follow up.

## Notes for review

- `room-routes.ts` body grew significantly (281 lines added). Considered extracting an `artifacts/` subrouter but room-routes was already the single seam for room-scoped HTTP — splitting now would fragment the boundary. Open to feedback.
- `room-artifact-broadcast.ts` is a separate file from `room-transcript-store.ts` because that file owns ring-buffer state for a different event. Conflating responsibilities would tangle the shutdown path; Supabase shares the underlying WebSocket so wire cost is the same.
- Failure contract on thumbnail gen: throw → rollback original artifact + DB row, return 500. Half-stored state would force the strip to fall back to full-res or render nothing — both worse than failing the upload cleanly.