### PR TITLE
fix(room): route room events to founding agent (mj2z6nzjz)

### DIFF
--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -84,12 +84,11 @@ function resolveDefaultAgent(): string | null {
 }
 
 // Why @-mention in the body even though we also set `to:` —
-// mj2z6nzjz proof on canonical: the live OpenClaw plugin's handleInbound
-// (reflectt-channel index.ts) gates dispatch on body @-mentions and
-// ignores the message `to:` field. Without an @-mention the plugin drops
-// the message and the agent never sees it. `to:` still matters for
-// node-side inbox priority (DM path), so we set both. Kai signoff
-// msg-1777223002661.
+// the live OpenClaw plugin's handleInbound (reflectt-channel index.ts)
+// gates dispatch on body @-mentions and ignores the message `to:` field.
+// Without an @-mention the plugin drops the message and the agent never
+// sees it. `to:` still matters for node-side inbox priority (DM path),
+// so we set both.
 
 function formatJoin(p: RoomJoinPayload['participant'], defaultAgent: string): string {
   return `@${defaultAgent} 🚪 **${p.displayName}** joined the room (${p.device})`

--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -26,6 +26,7 @@
  */
 import { eventBus } from './events.js'
 import { chatManager } from './chat.js'
+import { getAgentRoles } from './assignment.js'
 
 interface BridgeState {
   initialized: boolean
@@ -61,39 +62,49 @@ interface RoomArtifactSharedPayload {
     id: string
     kind: string | null
     name: string
+    mimeType: string
+    sizeBytes: number
     createdAt: number
     sharedBy: string | null
     sharedByDisplayName: string | null
+    dimensions: { width: number; height: number } | null
+    url: string
+    thumbnailUrl: string
   }
   by: string
   hostId: string
 }
 
-/**
- * Format a join into a single concise chat line. Kept terse on purpose —
- * the seed rule in AGENTS.md tells the agent what to do; this is just the
- * trigger they need to see.
- */
-function formatJoin(p: RoomJoinPayload['participant']): string {
-  return `🚪 **${p.displayName}** joined the room (${p.device})`
+// Resolve the founding/default agent for this host. Same pattern used
+// throughout server.ts (getAgentRoles()[0]?.name) — first entry in
+// TEAM-ROLES.yaml. Room-originated events route here so the OpenClaw
+// dispatch path (which gates on body @mention) actually wakes someone.
+function resolveDefaultAgent(): string | null {
+  return getAgentRoles()[0]?.name ?? null
 }
 
-/**
- * Format an artifact share into a single utilitarian chat line. Per
- * kai's lock (msg-1777191217389): "thin factual notification only —
- * utilitarian, not narration." No URL, no thumbnail, no guess at
- * content. Agents that care look in the room (pull); agents that
- * don't, don't get a wall of "here's what's in the snapshot"
- * hallucinations they didn't ask for.
- *
- * Per-kind dispatch — v0 only handles `kind='snapshot'`. Future kinds
- * (recordings, agent outputs) add their own one-liner here without
- * changing the event name.
- */
-function formatArtifactShared(p: RoomArtifactSharedPayload): string | null {
+// Why @-mention in the body even though we also set `to:` —
+// mj2z6nzjz proof on canonical: the live OpenClaw plugin's handleInbound
+// (reflectt-channel index.ts) gates dispatch on body @-mentions and
+// ignores the message `to:` field. Without an @-mention the plugin drops
+// the message and the agent never sees it. `to:` still matters for
+// node-side inbox priority (DM path), so we set both. Kai signoff
+// msg-1777223002661.
+
+function formatJoin(p: RoomJoinPayload['participant'], defaultAgent: string): string {
+  return `@${defaultAgent} 🚪 **${p.displayName}** joined the room (${p.device})`
+}
+
+// Per-kind dispatch — v0 only handles `kind='snapshot'`. Future kinds
+// (recordings, agent outputs) add their own one-liner here without
+// changing the event name. Body stays utilitarian (kai lock
+// msg-1777191217389: "thin factual notification, not narration") — the
+// actionable context (url, thumbnailUrl, dimensions, sharedByDisplayName)
+// rides in metadata for the agent to pull on demand.
+function formatArtifactShared(p: RoomArtifactSharedPayload, defaultAgent: string): string | null {
   const who = p.artifact.sharedByDisplayName ?? 'Someone'
   switch (p.artifact.kind) {
-    case 'snapshot': return `📸 **${who}** shared a snapshot`
+    case 'snapshot': return `@${defaultAgent} 📸 **${who}** shared a snapshot`
     default: return null
   }
 }
@@ -111,10 +122,17 @@ export function initRoomEventBridge(): boolean {
       const p = payload?.participant
       if (!p || p.kind !== 'human' || !p.id || !p.displayName) return
 
+      const defaultAgent = resolveDefaultAgent()
+      if (!defaultAgent) {
+        console.warn(`[room-event-bridge] no default agent (TEAM-ROLES empty) — dropping join for ${p.id}`)
+        return
+      }
+
       state.joinCount++
       void chatManager.sendMessage({
         from: 'room',
-        content: formatJoin(p),
+        to: defaultAgent,
+        content: formatJoin(p, defaultAgent),
         channel: 'general',
         metadata: {
           source: 'room-event',
@@ -124,6 +142,7 @@ export function initRoomEventBridge(): boolean {
           userId: p.userId,
           hostId: payload?.hostId ?? p.hostId,
           device: p.device,
+          displayName: p.displayName,
           // dedup_key: chatManager's ledger swallows repeats with the
           // same key. Using participant.id (ephemeral session id) means
           // greet-once per session; new session → fresh greet.
@@ -138,7 +157,14 @@ export function initRoomEventBridge(): boolean {
     if (event.type === 'room_artifact_shared') {
       const payload = event.data as RoomArtifactSharedPayload | undefined
       if (!payload?.artifact?.id || !payload.artifact.kind) return
-      const line = formatArtifactShared(payload)
+
+      const defaultAgent = resolveDefaultAgent()
+      if (!defaultAgent) {
+        console.warn(`[room-event-bridge] no default agent (TEAM-ROLES empty) — dropping artifact ${payload.artifact.id}`)
+        return
+      }
+
+      const line = formatArtifactShared(payload, defaultAgent)
       // Unknown kind in v0 → silent. Future kinds add a formatter case
       // when they ship their own slice. We do NOT post a generic
       // "an artifact was shared" line — that would lie about what
@@ -148,6 +174,7 @@ export function initRoomEventBridge(): boolean {
       state.artifactCount++
       void chatManager.sendMessage({
         from: 'room',
+        to: defaultAgent,
         content: line,
         channel: 'general',
         metadata: {
@@ -157,7 +184,13 @@ export function initRoomEventBridge(): boolean {
           artifactId: payload.artifact.id,
           kind: payload.artifact.kind,
           sharedBy: payload.by,
+          sharedByDisplayName: payload.artifact.sharedByDisplayName,
           hostId: payload.hostId,
+          url: payload.artifact.url,
+          thumbnailUrl: payload.artifact.thumbnailUrl,
+          dimensions: payload.artifact.dimensions,
+          mimeType: payload.artifact.mimeType,
+          sizeBytes: payload.artifact.sizeBytes,
           // Artifacts have stable unique ids — strict per-id dedup so
           // a duplicate emit (rare but possible on retry) doesn't
           // double-post. Unlike `room-join-${id}` (per-session) this

--- a/tests/room-event-bridge.test.ts
+++ b/tests/room-event-bridge.test.ts
@@ -5,6 +5,7 @@
 // only produce one user-visible chat message even on event re-emit.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setTestRoles } from '../src/assignment.js'
 
 // Mock chatManager BEFORE importing the bridge so the bridge picks up
 // the mock instead of the real chatManager. vi.mock is hoisted above
@@ -56,10 +57,17 @@ describe('room-event-bridge', () => {
   beforeEach(() => {
     sendMessageMock.mockClear()
     shutdownRoomEventBridge()
+    // mj2z6nzjz contract: bridge resolves the founding agent via
+    // getAgentRoles()[0]?.name and routes there. Pin the test roster so
+    // the @-mention assertions are deterministic.
+    setTestRoles([
+      { name: 'genesis', role: 'founding', affinityTags: [], wipCap: 1 },
+    ])
   })
 
   afterEach(() => {
     shutdownRoomEventBridge()
+    setTestRoles(null)
   })
 
   it('initRoomEventBridge() returns true on first call, false on re-init', () => {
@@ -75,11 +83,14 @@ describe('room-event-bridge', () => {
     expect(sendMessageMock).toHaveBeenCalledTimes(1)
     const call = sendMessageMock.mock.calls[0][0]
     expect(call.from).toBe('room')
+    expect(call.to).toBe('genesis')
     expect(call.channel).toBe('general')
+    expect(call.content).toContain('@genesis')
     expect(call.content).toContain('Ryan')
     expect(call.content).toContain('big-screen')
     expect(call.metadata.source).toBe('room-event')
     expect(call.metadata.participantId).toBe('session-abc-123')
+    expect(call.metadata.displayName).toBe('Ryan')
     expect(call.metadata.dedup_key).toBe('room-join-session-abc-123')
     expect(call.metadata.hostId).toBe('host-1')
   })
@@ -148,9 +159,14 @@ describe('room-event-bridge', () => {
           id: 'art-abc-123',
           kind: 'snapshot',
           name: 'screen.png',
+          mimeType: 'image/png',
+          sizeBytes: 12345,
           createdAt: Date.now(),
           sharedBy: 'session-abc-123',
           sharedByDisplayName: 'Ryan',
+          dimensions: { width: 1920, height: 1080 },
+          url: 'https://cdn.example/art-abc-123.png',
+          thumbnailUrl: 'https://cdn.example/art-abc-123.thumb.png',
         },
         by: 'session-abc-123',
         hostId: 'host-1',
@@ -160,13 +176,21 @@ describe('room-event-bridge', () => {
     expect(sendMessageMock).toHaveBeenCalledTimes(1)
     const call = sendMessageMock.mock.calls[0][0]
     expect(call.from).toBe('room')
+    expect(call.to).toBe('genesis')
     expect(call.channel).toBe('general')
+    expect(call.content).toContain('@genesis')
     expect(call.content).toContain('Ryan')
     expect(call.content).toContain('snapshot')
     expect(call.metadata.source).toBe('room-event')
     expect(call.metadata.category).toBe('room-artifact')
     expect(call.metadata.artifactId).toBe('art-abc-123')
     expect(call.metadata.kind).toBe('snapshot')
+    expect(call.metadata.sharedByDisplayName).toBe('Ryan')
+    expect(call.metadata.url).toBe('https://cdn.example/art-abc-123.png')
+    expect(call.metadata.thumbnailUrl).toBe('https://cdn.example/art-abc-123.thumb.png')
+    expect(call.metadata.dimensions).toEqual({ width: 1920, height: 1080 })
+    expect(call.metadata.mimeType).toBe('image/png')
+    expect(call.metadata.sizeBytes).toBe(12345)
     expect(call.metadata.dedup_key).toBe('room-artifact-art-abc-123')
     expect(getRoomEventBridgeStatus().artifactCount).toBe(1)
   })


### PR DESCRIPTION
## Summary
- Bridge resolves the founding agent (`getAgentRoles()[0]?.name`) and sets it as the message `to:` so node-side inbox routes as DM
- Body now leads with `@${defaultAgent}` because the live OpenClaw plugin (`reflectt-channel/index.ts handleInbound`) drops messages without an in-body @mention — `to:` alone is ignored
- Snapshot metadata widened to carry `url`, `thumbnailUrl`, `dimensions`, `mimeType`, `sizeBytes`, and `sharedByDisplayName` so the agent has the full pull-context without re-fetching
- Body stays utilitarian per kai's earlier lock (msg-1777191217389); only the routing affordance changed

## Why
On canonical staging (`rn-34faba44-wlgkeq`) no-mention room events (joins, snapshot shares) never reached the founding agent. Plugin gates dispatch on body @mentions and ignores message `to:`. Spec source: kai's signoff msg-1777223002661 calling `Do #1 now for mj2z6nzjz`.

## Test plan
- [x] Unit: `tests/room-event-bridge.test.ts` — pins a single founding role via `setTestRoles`, asserts `to:`, `@genesis` body prefix, and full snapshot metadata shape (9/9 pass)
- [ ] Canonical staging proof (will follow before close):
  1. No-mention room join → founding agent's session sees a single chat line with `@<agent>` prefix
  2. No-mention snapshot share → agent receives chat line with metadata.url + thumbnailUrl + dimensions
  3. Snapshot context is visible/actionable in metadata
  4. Sharer's human display name renders correctly in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)