### PR TITLE
fix(transcript): route browser-STT to founding agent (mj2z6nzjz follow-up)

### DIFF
--- a/src/room-transcript-bridge.ts
+++ b/src/room-transcript-bridge.ts
@@ -28,6 +28,7 @@
  */
 import { eventBus } from './events.js'
 import { chatManager } from './chat.js'
+import { getAgentRoles } from './assignment.js'
 import { listRoomParticipants } from './room-presence-store.js'
 import type { RoomTranscriptSegment } from './room-transcript-store.js'
 
@@ -46,6 +47,14 @@ const LISTENER_ID = 'room-transcript-bridge'
 interface RoomTranscriptPayload {
   segment: RoomTranscriptSegment
   hostId: string
+}
+
+// Resolve the founding/default agent for this host. Same pattern used by
+// room-event-bridge (see #1304) — the OpenClaw plugin's handleInbound
+// gates dispatch on body @-mentions, so without an @-mention the
+// transcript line drops on the floor and the agent never sees STT.
+function resolveDefaultAgent(): string | null {
+  return getAgentRoles()[0]?.name ?? null
 }
 
 /**
@@ -67,9 +76,13 @@ function resolveSpeakerName(participantId: string, userId: string): string {
  * Format a finalized segment into a single concise chat line. Kept terse
  * — agents already have AGENTS.md guidance on what to do with transcript
  * context. The line is the trigger; the rule is the response.
+ *
+ * Body @-mentions the default agent for the same reason room-event-bridge
+ * does: the live OpenClaw plugin's handleInbound gates dispatch on body
+ * @-mentions and ignores `to:`. Without the prefix the message drops.
  */
-function formatSegment(speakerName: string, text: string): string {
-  return `🎙️ **${speakerName}**: ${text}`
+function formatSegment(speakerName: string, text: string, defaultAgent: string): string {
+  return `@${defaultAgent} 🎙️ **${speakerName}**: ${text}`
 }
 
 /**
@@ -88,11 +101,18 @@ export function initRoomTranscriptBridge(): boolean {
     // contract ever loosens we still want only finals reaching chat.
     if (!seg.isFinal) return
 
+    const defaultAgent = resolveDefaultAgent()
+    if (!defaultAgent) {
+      console.warn(`[room-transcript-bridge] no default agent (TEAM-ROLES empty) — dropping segment ${seg.id}`)
+      return
+    }
+
     state.segmentCount++
     const speakerName = resolveSpeakerName(seg.participantId, seg.userId)
     void chatManager.sendMessage({
       from: 'room',
-      content: formatSegment(speakerName, seg.text),
+      to: defaultAgent,
+      content: formatSegment(speakerName, seg.text, defaultAgent),
       channel: 'general',
       metadata: {
         source: 'room-event',

--- a/tests/room-transcript-bridge.test.ts
+++ b/tests/room-transcript-bridge.test.ts
@@ -1,0 +1,153 @@
+// Browser-STT v0 routing regression: when room_transcript_segment fires on
+// the EventBus, the bridge must call chatManager.sendMessage with `to:
+// <defaultAgent>` and an @-mention in the body so the OpenClaw plugin's
+// handleInbound dispatch gate routes the segment to the agent. Mirrors the
+// #1304 fix shape for room-event-bridge.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setTestRoles } from '../src/assignment.js'
+
+const { sendMessageMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn(async (msg: any) => ({
+    ...msg,
+    id: 'mock-msg-id',
+    timestamp: Date.now(),
+    reactions: {},
+  })),
+}))
+
+vi.mock('../src/chat.js', () => ({
+  chatManager: {
+    sendMessage: sendMessageMock,
+  },
+}))
+
+import { eventBus } from '../src/events.js'
+import {
+  initRoomTranscriptBridge,
+  shutdownRoomTranscriptBridge,
+  getRoomTranscriptBridgeStatus,
+} from '../src/room-transcript-bridge.js'
+
+const SAMPLE_SEGMENT = {
+  id: 'seg-abc-123',
+  participantId: 'session-abc-123',
+  userId: 'user-xyz',
+  text: 'hello team',
+  isFinal: true,
+  startedAt: Date.now() - 1500,
+  finalizedAt: Date.now(),
+}
+
+function emitSegment(segment = SAMPLE_SEGMENT, hostId = 'host-1') {
+  eventBus.emit({
+    id: `room-transcript-${segment.id}-${Date.now()}`,
+    type: 'room_transcript_segment',
+    timestamp: Date.now(),
+    data: { segment, hostId },
+  })
+}
+
+describe('room-transcript-bridge', () => {
+  beforeEach(() => {
+    sendMessageMock.mockClear()
+    shutdownRoomTranscriptBridge()
+    // mj2z6nzjz contract: bridge resolves the founding agent via
+    // getAgentRoles()[0]?.name and routes there. Pin the test roster so
+    // the @-mention assertions are deterministic.
+    setTestRoles([
+      { name: 'genesis', role: 'founding', affinityTags: [], wipCap: 1 },
+    ])
+  })
+
+  afterEach(() => {
+    shutdownRoomTranscriptBridge()
+    setTestRoles(null)
+  })
+
+  it('initRoomTranscriptBridge() returns true on first call, false on re-init', () => {
+    expect(initRoomTranscriptBridge()).toBe(true)
+    expect(initRoomTranscriptBridge()).toBe(false)
+    expect(getRoomTranscriptBridgeStatus().initialized).toBe(true)
+  })
+
+  it('forwards a final segment with `to: <defaultAgent>` + @-mention so plugin routes it', () => {
+    initRoomTranscriptBridge()
+    emitSegment()
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.from).toBe('room')
+    expect(call.to).toBe('genesis')
+    expect(call.channel).toBe('general')
+    expect(call.content).toContain('@genesis')
+    expect(call.content).toContain('hello team')
+    expect(call.metadata.source).toBe('room-event')
+    expect(call.metadata.category).toBe('room-transcript')
+    expect(call.metadata.eventType).toBe('room_transcript_segment')
+    expect(call.metadata.segmentId).toBe('seg-abc-123')
+    expect(call.metadata.participantId).toBe('session-abc-123')
+    expect(call.metadata.userId).toBe('user-xyz')
+    expect(call.metadata.hostId).toBe('host-1')
+    expect(call.metadata.dedup_key).toBe('room-transcript-seg-abc-123')
+  })
+
+  it('drops non-final segments and malformed events', () => {
+    initRoomTranscriptBridge()
+    eventBus.emit({
+      id: 'bad-1', type: 'room_transcript_segment', timestamp: Date.now(),
+      data: { segment: { ...SAMPLE_SEGMENT, isFinal: false }, hostId: 'host-1' },
+    })
+    eventBus.emit({
+      id: 'bad-2', type: 'room_transcript_segment', timestamp: Date.now(),
+      data: { segment: { ...SAMPLE_SEGMENT, id: '' }, hostId: 'host-1' },
+    })
+    eventBus.emit({
+      id: 'bad-3', type: 'room_transcript_segment', timestamp: Date.now(),
+      data: { segment: { ...SAMPLE_SEGMENT, text: '' }, hostId: 'host-1' },
+    })
+    eventBus.emit({
+      id: 'bad-4', type: 'room_transcript_segment', timestamp: Date.now(),
+      data: undefined,
+    })
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated event types', () => {
+    initRoomTranscriptBridge()
+    eventBus.emit({
+      id: 'unrelated', type: 'message_posted', timestamp: Date.now(),
+      data: { from: 'noise', content: 'noise', channel: 'general' },
+    })
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('uses segment id as dedup_key so retries collapse downstream', () => {
+    initRoomTranscriptBridge()
+    emitSegment()
+    emitSegment() // same segment id — bridge still calls sendMessage twice
+    expect(sendMessageMock).toHaveBeenCalledTimes(2)
+    expect(sendMessageMock.mock.calls[0][0].metadata.dedup_key).toBe(
+      sendMessageMock.mock.calls[1][0].metadata.dedup_key
+    )
+    expect(getRoomTranscriptBridgeStatus().segmentCount).toBe(2)
+  })
+
+  it('shutdown unsubscribes — no further calls after teardown', () => {
+    initRoomTranscriptBridge()
+    emitSegment()
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    shutdownRoomTranscriptBridge()
+    expect(getRoomTranscriptBridgeStatus().initialized).toBe(false)
+    emitSegment()
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the segment if no default agent is configured', () => {
+    initRoomTranscriptBridge()
+    setTestRoles([])
+    emitSegment()
+    expect(sendMessageMock).not.toHaveBeenCalled()
+    expect(getRoomTranscriptBridgeStatus().segmentCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Mirrors the #1304 fix shape into `room-transcript-bridge.ts`: resolves the founding agent via `getAgentRoles()[0]?.name`, sets `to: defaultAgent`, and prepends `@${defaultAgent}` in `formatSegment` so the OpenClaw plugin's `handleInbound` dispatch gate routes the segment.
- Without this fix, browser-STT finalized segments posted with `from: 'room'` and no @-mention — same symptom #1304 fixed for joins/snapshots. Captured live on canonical staging at `msg-1777224920964` (`to: undefined`, no `@compass` in body).
- Adds `tests/room-transcript-bridge.test.ts` (7/7 green) — same shape as `room-event-bridge.test.ts` with the genesis-pinned roster pattern.

## Why now
kai's call (msg-1777224975183): ship the narrow transcript routing fix first, audit-report second, capability/behavior beyond routing stays separate.

## Test plan
- [x] `npx vitest run tests/room-transcript-bridge.test.ts` → 7/7 pass
- [x] `npx vitest run tests/room-event-bridge.test.ts` → 9/9 pass (sibling unaffected)
- [x] `npx tsc --noEmit` → clean
- [x] `node tools/check-internal-names-guard.mjs` → OK
- [ ] After merge + canonical deploy: drive synthetic `transcript.segment` broadcast at `room:e4e35463-...`; expect compass inbox entry with `priority: high`, `reason: dm`, `type: mention` (mirrors mj2z6nzjz proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)