### PR TITLE
fix(room): inline snapshot URL in bridge body (mj2z6nzjz follow-up)

### DIFF
--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -97,13 +97,20 @@ function formatJoin(p: RoomJoinPayload['participant'], defaultAgent: string): st
 // Per-kind dispatch — v0 only handles `kind='snapshot'`. Future kinds
 // (recordings, agent outputs) add their own one-liner here without
 // changing the event name. Body stays utilitarian (kai lock
-// msg-1777191217389: "thin factual notification, not narration") — the
-// actionable context (url, thumbnailUrl, dimensions, sharedByDisplayName)
-// rides in metadata for the agent to pull on demand.
+// msg-1777191217389: "thin factual notification, not narration") but
+// includes the artifact URL inline. The original design pushed url etc
+// into msg.metadata for "agent pulls on demand" — but receiving agents
+// only see the chat body in their prompt, so a metadata-only pointer
+// has no caller. Inline URL keeps the body factual while giving the
+// agent something to fetch (mj2z6nzjz follow-up: "noted 🧭" replies on
+// canonical staging because compass had no pointer to the bytes).
 function formatArtifactShared(p: RoomArtifactSharedPayload, defaultAgent: string): string | null {
   const who = p.artifact.sharedByDisplayName ?? 'Someone'
   switch (p.artifact.kind) {
-    case 'snapshot': return `@${defaultAgent} 📸 **${who}** shared a snapshot`
+    case 'snapshot': {
+      const dim = p.artifact.dimensions ? ` (${p.artifact.dimensions.width}×${p.artifact.dimensions.height})` : ''
+      return `@${defaultAgent} 📸 **${who}** shared a snapshot${dim} → ${p.artifact.url}`
+    }
     default: return null
   }
 }

--- a/tests/room-event-bridge.test.ts
+++ b/tests/room-event-bridge.test.ts
@@ -181,6 +181,11 @@ describe('room-event-bridge', () => {
     expect(call.content).toContain('@genesis')
     expect(call.content).toContain('Ryan')
     expect(call.content).toContain('snapshot')
+    // Body now includes the artifact URL inline so the receiving agent can
+    // fetch the bytes (mj2z6nzjz follow-up — metadata-only pointer was
+    // unreachable from the agent's prompt context).
+    expect(call.content).toContain('https://cdn.example/art-abc-123.png')
+    expect(call.content).toContain('1920×1080')
     expect(call.metadata.source).toBe('room-event')
     expect(call.metadata.category).toBe('room-artifact')
     expect(call.metadata.artifactId).toBe('art-abc-123')


### PR DESCRIPTION
## Summary
- Bridge's snapshot body now includes the artifact URL (and dimensions when known) inline
- Metadata still carries structured fields, but body is what the receiving agent's prompt actually renders
- Stays within kai's design lock (thin factual notification, not narration)

## Why
Slice 5A pushed artifact url/dimensions into `msg.metadata` on the theory that the receiving agent would pull on demand. On canonical staging, compass kept replying with generic "noted 🧭" because the prompt context only renders the chat body — metadata-only pointers have no caller. Concrete proof: `snap-and-watch` saw bridge post `📸 ... shared a snapshot` followed 6.3s later by compass `noted 🧭`.

This is the minimal fix kai approved (msg-1777247503609): inline the actionable pointer, no plugin widening.

## Test plan
- [x] `pnpm vitest run tests/room-event-bridge.test.ts` — 9/9 passed
- [ ] Roll canonical machine (`rn-34faba44-wlgkeq` machine `568354e7ad5348`) to new image
- [ ] Re-drive snapshot via `/api/hosts/{HOST}/room/artifacts` and verify compass reply contains image-grounded content (not just "noted")