### PR TITLE
feat(room): reply-card backfill ring buffer + GET /room/cards

### DIFF
--- a/src/room-card-store.ts
+++ b/src/room-card-store.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Room Card Store — reply-card backfill v0
+ *
+ * Server-side mirror of the asker's `roomCard.publish()` fan-out from the
+ * web side (apps/web/src/app/presence/use-room-card.ts). Subscribes to the
+ * same `room:${hostId}` Realtime channel as room-presence-store and
+ * room-transcript-store, listens for the `card.fanout` broadcast event
+ * (the asker tab emits it whenever a fresh `canvas_message` SSE lands on
+ * the asker's screen), and ring-buffers the recent payloads.
+ *
+ * Why: live `card.fanout` is asker→peers Realtime broadcast — anyone who
+ * joins the room AFTER a reply landed never sees the card. Snapshots
+ * already have a backfill path (room-artifact-store + GET /room/artifacts);
+ * reply cards did not. Late joiners walked into a blank canvas with avatars
+ * and no idea what the meeting was just about. This store is the smallest
+ * cut that closes that gap, mirroring the artifact pattern exactly.
+ *
+ * Per kai's locks (msg-1777285834854):
+ *   - bounded last-N
+ *   - fetch on mount
+ *   - broadcast/re-fetch on new event
+ *   - same `serverTs` identity used for live dedupe
+ *   - reply cards only (NOT transcript)
+ *   - bounded ephemeral, NOT permanent history
+ *   - same peer/asker ownership rules — wire shape includes
+ *     senderParticipantId so the client can drop self-broadcasts on
+ *     backfill the same way it does on live receive
+ *   - if backfill can't be tied to the same reply identity, don't show it
+ *     — payload MUST carry serverTs and id; otherwise rejected at the
+ *     buffer edge
+ *
+ * What this is NOT:
+ *   - Durable history (the eviction window is short by intent)
+ *   - A second source of truth — the channel is truth; this is a cache
+ *   - A retry/resend layer — best-effort like the live broadcast
+ */
+
+import { createClient, type RealtimeChannel, type SupabaseClient } from '@supabase/supabase-js'
+
+const BROADCAST_EVENT = 'card.fanout'
+// Rolling window: how far back we keep reply cards for backfill. Cards are
+// sparse (one per agent reply, not per-spoken-segment) so this is wider
+// than the transcript ring — but still bounded, ephemeral by feel. 10min
+// covers "what was happening when I joined" without becoming a meeting
+// log.
+const RING_BUFFER_WINDOW_MS = 10 * 60_000
+// Cap entries held to defend against pathological broadcast storms. Cards
+// at natural cadence are 1-3/min; 50 covers ~15-50 minutes of activity,
+// well above the time window.
+const MAX_BUFFERED_CARDS = 50
+
+// Mirror of PeerCanvasCardPayload in apps/web/src/app/presence/use-room-card.ts.
+// Wire format from the channel.
+export interface RoomCardPayload {
+  id: string
+  type: string
+  agentId: string
+  agentColor: string
+  query?: string
+  ttl?: number
+  data: Record<string, unknown>
+  arrivedAt: number
+  serverTs: number
+}
+
+// What the node stores and returns. Same envelope shape as the live
+// broadcast so the client can apply the SAME drop-self / dedupe logic on
+// backfill that it already applies on live receive.
+export interface RoomCardEntry {
+  senderParticipantId: string
+  senderUserId: string
+  card: RoomCardPayload
+  receivedAt: number   // node clock — query ordering uses this
+}
+
+interface StoreState {
+  entries: RoomCardEntry[]   // sorted by receivedAt asc
+  channel: RealtimeChannel | null
+  client: SupabaseClient | null
+  hostId: string | null
+  initialized: boolean
+  receivedCount: number      // diagnostics
+}
+
+const state: StoreState = {
+  entries: [],
+  channel: null,
+  client: null,
+  hostId: null,
+  initialized: false,
+  receivedCount: 0,
+}
+
+function resolveHostId(): string | null {
+  const hostId = process.env.REFLECTT_HOST_ID || process.env.HOSTNAME
+  if (!hostId || hostId === 'unknown') return null
+  return hostId
+}
+
+function pruneOldEntries(now: number): void {
+  const cutoff = now - RING_BUFFER_WINDOW_MS
+  let drop = 0
+  while (drop < state.entries.length && state.entries[drop]!.receivedAt < cutoff) {
+    drop++
+  }
+  if (drop > 0) state.entries.splice(0, drop)
+  if (state.entries.length > MAX_BUFFERED_CARDS) {
+    state.entries.splice(0, state.entries.length - MAX_BUFFERED_CARDS)
+  }
+}
+
+function isValidCardPayload(raw: unknown): raw is RoomCardPayload {
+  if (!raw || typeof raw !== 'object') return false
+  const r = raw as Record<string, unknown>
+  return (
+    typeof r.id === 'string' &&
+    typeof r.type === 'string' &&
+    typeof r.agentId === 'string' &&
+    typeof r.agentColor === 'string' &&
+    typeof r.serverTs === 'number' &&
+    typeof r.arrivedAt === 'number' &&
+    !!r.data && typeof r.data === 'object'
+  )
+}
+
+function isValidEnvelope(raw: unknown): raw is { senderParticipantId: string; senderUserId: string; card: RoomCardPayload } {
+  if (!raw || typeof raw !== 'object') return false
+  const r = raw as Record<string, unknown>
+  if (typeof r.senderParticipantId !== 'string' || r.senderParticipantId.length === 0) return false
+  if (typeof r.senderUserId !== 'string' || r.senderUserId.length === 0) return false
+  if (!isValidCardPayload(r.card)) return false
+  return true
+}
+
+/**
+ * Initialize the store. Idempotent. Returns false if Supabase env or
+ * REFLECTT_HOST_ID is missing — the rest of the node still boots.
+ *
+ * Opens a SECOND channel object on the same `room:${hostId}` name as
+ * presence/transcript stores. Supabase shares the underlying WebSocket
+ * across channel objects, so this is the same transport — separate
+ * channel objects for clean responsibility split.
+ */
+export function initRoomCardStore(): boolean {
+  if (state.initialized) return true
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ACCESS_TOKEN
+  const hostId = resolveHostId()
+
+  if (!url || !key) {
+    console.warn('[room-card] Supabase env missing — store stays empty')
+    return false
+  }
+  if (!hostId) {
+    console.warn('[room-card] REFLECTT_HOST_ID unresolvable — store stays empty')
+    return false
+  }
+
+  state.hostId = hostId
+  state.client = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+
+  const channel = state.client.channel(`room:${hostId}`)
+
+  channel.on('broadcast', { event: BROADCAST_EVENT }, (msg: { payload?: unknown }) => {
+    const payload = msg.payload
+    if (!isValidEnvelope(payload)) return
+
+    const now = Date.now()
+    const entry: RoomCardEntry = {
+      senderParticipantId: payload.senderParticipantId,
+      senderUserId: payload.senderUserId,
+      card: payload.card,
+      receivedAt: now,
+    }
+
+    // Dedup HARD by serverTs — kai's lock: one reply = one meeting event.
+    // If a duplicate arrives (e.g. broadcast retransmit), replace the
+    // existing entry rather than stack so eviction stays clean.
+    const existingIdx = state.entries.findIndex((e) => e.card.serverTs === entry.card.serverTs)
+    if (existingIdx >= 0) {
+      state.entries[existingIdx] = entry
+    } else {
+      state.entries.push(entry)
+    }
+    state.receivedCount++
+    pruneOldEntries(now)
+  })
+
+  channel.subscribe((status) => {
+    if (status === 'SUBSCRIBED') {
+      console.log(`[room-card] subscribed to room:${hostId} (${BROADCAST_EVENT})`)
+    } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+      console.warn(`[room-card] channel ${status} for room:${hostId}`)
+    }
+  })
+
+  state.channel = channel
+  state.initialized = true
+  return true
+}
+
+/** Tear down. Used in tests and on graceful shutdown. */
+export async function shutdownRoomCardStore(): Promise<void> {
+  if (state.channel && state.client) {
+    try { await state.channel.unsubscribe() } catch { /* non-fatal */ }
+    try { await state.client.removeChannel(state.channel) } catch { /* non-fatal */ }
+  }
+  state.channel = null
+  state.client = null
+  state.hostId = null
+  state.initialized = false
+  state.entries = []
+  state.receivedCount = 0
+}
+
+/**
+ * Read recent reply cards. `sinceMs` is a wall-clock ms cutoff (e.g.
+ * `Date.now() - 60_000` for last minute); when omitted, returns the full
+ * ring (last `RING_BUFFER_WINDOW_MS`). Sorted by receivedAt asc so callers
+ * get them in arrival order; the client sorts by arrivedAt for display.
+ *
+ * Optional `limit` caps the result set from the END (newest entries) so a
+ * caller can pull "last N" without scanning the whole window.
+ */
+export function getRecentCards(opts?: { sinceMs?: number; limit?: number }): RoomCardEntry[] {
+  pruneOldEntries(Date.now())
+  let result = state.entries
+  if (typeof opts?.sinceMs === 'number') {
+    const cutoff = opts.sinceMs
+    result = result.filter((e) => e.receivedAt >= cutoff)
+  } else {
+    result = [...result]
+  }
+  if (typeof opts?.limit === 'number' && opts.limit > 0 && result.length > opts.limit) {
+    result = result.slice(-opts.limit)
+  }
+  return result
+}
+
+/** Diagnostics for /room/cards?debug=1 and tests. */
+export function getRoomCardStatus(): {
+  initialized: boolean
+  hostId: string | null
+  bufferedCount: number
+  totalReceived: number
+  windowMs: number
+  maxEntries: number
+} {
+  pruneOldEntries(Date.now())
+  return {
+    initialized: state.initialized,
+    hostId: state.hostId,
+    bufferedCount: state.entries.length,
+    totalReceived: state.receivedCount,
+    windowMs: RING_BUFFER_WINDOW_MS,
+    maxEntries: MAX_BUFFERED_CARDS,
+  }
+}
+
+/** Test-only: inject an entry directly without going through the channel. */
+export function _testInjectCardEntry(entry: RoomCardEntry): void {
+  const existingIdx = state.entries.findIndex((e) => e.card.serverTs === entry.card.serverTs)
+  if (existingIdx >= 0) {
+    state.entries[existingIdx] = entry
+  } else {
+    state.entries.push(entry)
+  }
+  state.receivedCount++
+  pruneOldEntries(Date.now())
+}
+
+/** Test-only: reset state without going through shutdown. */
+export function _testResetCardStore(): void {
+  state.entries = []
+  state.receivedCount = 0
+  state.initialized = false
+  state.channel = null
+  state.client = null
+  state.hostId = null
+}

--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -24,6 +24,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { eventBus } from './events.js'
 import { listRoomParticipants, getRoomPresenceStatus } from './room-presence-store.js'
 import { getRecentTranscript, getRoomTranscriptStatus } from './room-transcript-store.js'
+import { getRecentCards, getRoomCardStatus } from './room-card-store.js'
 import {
   storeArtifact,
   getArtifact,
@@ -126,6 +127,42 @@ export async function roomRoutes(app: FastifyInstance) {
       hostId: status.hostId,
       initialized: status.initialized,
       windowMs: status.windowMs,
+    }
+  })
+
+  // ── Reply-card backfill v0 ──────────────────────────────────────────
+  // Recent reply cards from the room's Realtime broadcast. `?since=<ms>`
+  // returns only entries with `receivedAt >= since` (incremental polling).
+  // `?limit=<n>` caps from the END (newest entries), default unbounded
+  // within the rolling window. Wire shape mirrors the broadcast envelope
+  // so the client can apply the same drop-self / dedupe logic on backfill
+  // that it does on live receive.
+  app.get('/room/cards', async (request, reply) => {
+    const auth = verifyAuth(request)
+    if (!auth.ok) {
+      reply.status(401)
+      return { error: auth.error }
+    }
+    const query = request.query as Record<string, unknown>
+    const sinceRaw = query?.since
+    const since = typeof sinceRaw === 'string' ? Number(sinceRaw) : (typeof sinceRaw === 'number' ? sinceRaw : undefined)
+    const limitRaw = query?.limit
+    const limitParsed = typeof limitRaw === 'string' ? Number(limitRaw) : (typeof limitRaw === 'number' ? limitRaw : undefined)
+    const limit = Number.isFinite(limitParsed) && (limitParsed as number) > 0
+      ? Math.min(50, Math.floor(limitParsed as number))
+      : undefined
+    const entries = getRecentCards({
+      sinceMs: Number.isFinite(since) ? (since as number) : undefined,
+      limit,
+    })
+    const status = getRoomCardStatus()
+    return {
+      entries,
+      count: entries.length,
+      hostId: status.hostId,
+      initialized: status.initialized,
+      windowMs: status.windowMs,
+      maxEntries: status.maxEntries,
     }
   })
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -175,6 +175,7 @@ import { roomRoutes } from './room-routes.js'
 import { initRoomPresenceStore } from './room-presence-store.js'
 import { initRoomEventBridge } from './room-event-bridge.js'
 import { initRoomTranscriptStore } from './room-transcript-store.js'
+import { initRoomCardStore } from './room-card-store.js'
 import { initRoomTranscriptBridge } from './room-transcript-bridge.js'
 import { initRoomArtifactBroadcast } from './room-artifact-broadcast.js'
 import { startTeamPulse, stopTeamPulse, postTeamPulse, computeTeamPulse, getTeamPulseConfig, configureTeamPulse, getTeamPulseHistory } from './team-pulse.js'
@@ -12315,6 +12316,17 @@ export async function createServer(): Promise<FastifyInstance> {
   // channel directly; agents only get finals (kai's locked rule).
   initRoomTranscriptStore()
   initRoomTranscriptBridge()
+
+  // ── Reply-card backfill v0: room card store ──────────────────────────
+  // Subscribes to the `room:${hostId}` Realtime channel for the
+  // `card.fanout` broadcast event (asker tab emits it whenever a fresh
+  // canvas_message SSE lands) and ring-buffers entries (last 10min, cap
+  // 50). Surfaces them on `GET /room/cards` so late joiners pull recent
+  // reply context on mount and re-fetch on each broadcast — same pattern
+  // the snapshot strip uses. No bridge: cards stay client-side; agents
+  // already have the upstream canvas_message events via their own session
+  // SSE.
+  initRoomCardStore()
 
   // ── Room Share Snapshot v0 slice 5A: artifact broadcaster ────────────
   // Owns its own Supabase Realtime channel handle on `room:${hostId}` for

--- a/tests/room-card-store.test.ts
+++ b/tests/room-card-store.test.ts
@@ -1,0 +1,94 @@
+// Reply-card backfill v0: ring-buffer store unit tests. The Realtime
+// channel hookup is exercised indirectly via the public API surface
+// (_testInjectCardEntry stands in for incoming broadcasts so we don't
+// need a live Supabase client in tests).
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getRecentCards,
+  getRoomCardStatus,
+  _testInjectCardEntry,
+  _testResetCardStore,
+  type RoomCardEntry,
+} from '../src/room-card-store.js'
+
+function makeEntry(overrides: Partial<RoomCardEntry> & { serverTs: number; receivedAt?: number }): RoomCardEntry {
+  return {
+    senderParticipantId: overrides.senderParticipantId ?? 'p-asker',
+    senderUserId: overrides.senderUserId ?? 'u-asker',
+    card: overrides.card ?? {
+      id: `card-${overrides.serverTs}`,
+      type: 'response',
+      agentId: 'compass',
+      agentColor: '#abc',
+      data: { text: 'hello' },
+      arrivedAt: overrides.serverTs,
+      serverTs: overrides.serverTs,
+    },
+    receivedAt: overrides.receivedAt ?? Date.now(),
+  }
+}
+
+describe('room-card-store', () => {
+  beforeEach(() => {
+    _testResetCardStore()
+  })
+
+  it('returns the full ring when no since/limit provided', () => {
+    _testInjectCardEntry(makeEntry({ serverTs: 1 }))
+    _testInjectCardEntry(makeEntry({ serverTs: 2 }))
+    const got = getRecentCards()
+    expect(got).toHaveLength(2)
+    expect(got[0]!.card.serverTs).toBe(1)
+    expect(got[1]!.card.serverTs).toBe(2)
+  })
+
+  it('dedupes by serverTs — duplicate replaces existing rather than stacks', () => {
+    const t1 = Date.now() - 5000
+    const t2 = Date.now()
+    _testInjectCardEntry(makeEntry({ serverTs: 99, receivedAt: t1 }))
+    _testInjectCardEntry(makeEntry({ serverTs: 99, receivedAt: t2 }))
+    const got = getRecentCards()
+    expect(got).toHaveLength(1)
+    expect(got[0]!.receivedAt).toBe(t2)
+  })
+
+  it('filters by sinceMs (inclusive)', () => {
+    const now = Date.now()
+    _testInjectCardEntry(makeEntry({ serverTs: 1, receivedAt: now - 10_000 }))
+    _testInjectCardEntry(makeEntry({ serverTs: 2, receivedAt: now - 1000 }))
+    const got = getRecentCards({ sinceMs: now - 5000 })
+    expect(got).toHaveLength(1)
+    expect(got[0]!.card.serverTs).toBe(2)
+  })
+
+  it('caps to limit from the END (newest entries)', () => {
+    for (let i = 1; i <= 5; i++) {
+      _testInjectCardEntry(makeEntry({ serverTs: i, receivedAt: Date.now() + i }))
+    }
+    const got = getRecentCards({ limit: 2 })
+    expect(got).toHaveLength(2)
+    expect(got.map((e) => e.card.serverTs)).toEqual([4, 5])
+  })
+
+  it('prunes entries older than the rolling window on read', () => {
+    const now = Date.now()
+    // Window is 10min; inject one entry well outside, one inside.
+    _testInjectCardEntry(makeEntry({ serverTs: 1, receivedAt: now - 11 * 60_000 }))
+    _testInjectCardEntry(makeEntry({ serverTs: 2, receivedAt: now }))
+    const got = getRecentCards()
+    expect(got).toHaveLength(1)
+    expect(got[0]!.card.serverTs).toBe(2)
+  })
+
+  it('reports status with bufferedCount + totalReceived diagnostics', () => {
+    _testInjectCardEntry(makeEntry({ serverTs: 1 }))
+    _testInjectCardEntry(makeEntry({ serverTs: 2 }))
+    _testInjectCardEntry(makeEntry({ serverTs: 1 }))  // dedupe — bufferedCount stays 2
+    const status = getRoomCardStatus()
+    expect(status.bufferedCount).toBe(2)
+    expect(status.totalReceived).toBe(3)  // diagnostics count every receive, including dedupes
+    expect(status.windowMs).toBe(10 * 60_000)
+    expect(status.maxEntries).toBe(50)
+  })
+})


### PR DESCRIPTION
## Why

Late joiners walked into a blank canvas. Cards live only on the room Realtime broadcast (`card.fanout`) which doesn't replay — anyone joining after a reply landed never saw it. Snapshots already had a backfill path (GET /room/artifacts) but reply cards did not.

Pairs with reflectt-cloud PR (https://github.com/reflectt/reflectt-cloud/pull/new/feat/room-card-backfill) which adds the cloud proxy + web hook backfill.

## What

Smallest cut that closes the gap, mirroring the snapshot pattern exactly:

- **`src/room-card-store.ts` (new)**: in-memory ring buffer (10min window, cap 50) subscribed to the same `room:${hostId}` channel. Dedup HARD by `serverTs` at the buffer edge — same identity the live broadcast uses. Hard guards reject any payload missing `serverTs/id/agentId/agentColor/data`.
- **`src/room-routes.ts`**: `GET /room/cards` endpoint with optional `?since=` and `?limit=` query params. Returns the full broadcast envelope (`senderParticipantId + senderUserId + card`) so the client applies the same drop-self/dedup logic on backfill that it does on live receive.
- **`src/server.ts`**: registers `initRoomCardStore()` next to `initRoomTranscriptStore()`.
- **`tests/room-card-store.test.ts` (new)**: 6 tests covering ring full-read, serverTs dedup, sinceMs filter, limit cap from end, window pruning, and status diagnostics.

## Per kai's locks (msg-1777285834854)

- ✅ bounded last-N
- ✅ fetch on mount (client side)
- ✅ broadcast/re-fetch on new event (client side)
- ✅ same `serverTs` identity for dedupe
- ✅ reply cards only (NOT transcript)
- ✅ bounded ephemeral, NOT permanent history (10min rolling window by intent)
- ✅ same peer/asker ownership rules — wire shape preserves senderParticipantId
- ✅ if backfill can't be tied to the same reply identity, don't show it — payloads without serverTs/id/agentId/agentColor are rejected at the buffer edge

## Test plan

- [ ] CI green
- [ ] Deploy to canonical staging host (`rn-34faba44-wlgkeq` / `e4e35463-...`)
- [ ] Real-browser proof paired with cloud PR — late joiner sees recent reply card

🤖 Generated with [Claude Code](https://claude.com/claude-code)