### PR TITLE
fix(room-card): use dedicated room-cards: topic to escape supabase-js subscribe-hang

### DIFF
--- a/src/room-card-store.ts
+++ b/src/room-card-store.ts
@@ -5,11 +5,20 @@
  * Room Card Store — reply-card backfill v0
  *
  * Server-side mirror of the asker's `roomCard.publish()` fan-out from the
- * web side (apps/web/src/app/presence/use-room-card.ts). Subscribes to the
- * same `room:${hostId}` Realtime channel as room-presence-store and
- * room-transcript-store, listens for the `card.fanout` broadcast event
- * (the asker tab emits it whenever a fresh `canvas_message` SSE lands on
- * the asker's screen), and ring-buffers the recent payloads.
+ * web side (apps/web/src/app/presence/use-room-card.ts). Subscribes to a
+ * dedicated `room-cards:${hostId}` Realtime channel, listens for the
+ * `card.fanout` broadcast event (the asker tab emits it whenever a fresh
+ * `canvas_message` SSE lands on the asker's screen), and ring-buffers the
+ * recent payloads.
+ *
+ * Why a dedicated channel topic and NOT the shared `room:${hostId}`:
+ * supabase-js v2 silently hangs subscribe callbacks when multiple channel
+ * instances on one client share a topic. The web side opens 6+ channel
+ * objects on `room:${hostId}` (presence, transcript, composer, voice,
+ * reply, card) — only the first one to win the race actually reaches
+ * SUBSCRIBED. The card fan-out lost the race. Moving to a unique topic
+ * fixes the room-card leg without touching the still-broken shared-topic
+ * pattern that the other hooks share (separate decision).
  *
  * Why: live `card.fanout` is asker→peers Realtime broadcast — anyone who
  * joins the room AFTER a reply landed never sees the card. Snapshots
@@ -139,10 +148,8 @@ function isValidEnvelope(raw: unknown): raw is { senderParticipantId: string; se
  * Initialize the store. Idempotent. Returns false if Supabase env or
  * REFLECTT_HOST_ID is missing — the rest of the node still boots.
  *
- * Opens a SECOND channel object on the same `room:${hostId}` name as
- * presence/transcript stores. Supabase shares the underlying WebSocket
- * across channel objects, so this is the same transport — separate
- * channel objects for clean responsibility split.
+ * Opens a channel on `room-cards:${hostId}` — dedicated topic to avoid the
+ * supabase-js multi-channel-same-topic subscribe-hang (see file header).
  */
 export function initRoomCardStore(): boolean {
   if (state.initialized) return true
@@ -165,7 +172,7 @@ export function initRoomCardStore(): boolean {
     auth: { persistSession: false, autoRefreshToken: false },
   })
 
-  const channel = state.client.channel(`room:${hostId}`)
+  const channel = state.client.channel(`room-cards:${hostId}`)
 
   channel.on('broadcast', { event: BROADCAST_EVENT }, (msg: { payload?: unknown }) => {
     const payload = msg.payload
@@ -194,9 +201,9 @@ export function initRoomCardStore(): boolean {
 
   channel.subscribe((status) => {
     if (status === 'SUBSCRIBED') {
-      console.log(`[room-card] subscribed to room:${hostId} (${BROADCAST_EVENT})`)
+      console.log(`[room-card] subscribed to room-cards:${hostId} (${BROADCAST_EVENT})`)
     } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
-      console.warn(`[room-card] channel ${status} for room:${hostId}`)
+      console.warn(`[room-card] channel ${status} for room-cards:${hostId}`)
     }
   })
 


### PR DESCRIPTION
## Summary

The room-card backfill ring buffer (#1308) was never receiving any envelopes from the asker tab on staging — `GET /room/cards` always returned `entries: []`. Root cause is on the web client: supabase-js v2 silently hangs the `channel.subscribe()` callback when multiple channel instances on one client share a topic, and the web side opens 6+ channels on `room:${hostId}` (presence/transcript/composer/voice/reply/card). The card-fanout channel lost the race — its subscribe never reached SUBSCRIBED, so no broadcast ever made it through.

This PR moves the node listener to a dedicated `room-cards:${hostId}` topic where there's no contention. The matching change on the web side flips `useRoomCard.publish()` to the same topic in the cloud PR.

The broader 6-hook shared-channel-pattern (transcript/composer/voice/reply also affected) is left for a separate decision — out of scope for this narrow fix.

## Test plan

- [x] `npm run build` passes
- [x] `npm test -- --run tests/room-card-store.test.ts` passes (6/6)
- [ ] After cloud-side PR ships: re-run `_verify-room-cards-buffer.spec.ts` against new node + new cloud preview → entries > 0