### PR TITLE
fix(canvas): push resolved reply card upstream so /room/cards backfill carries the answer

### DIFF
--- a/src/canvas-push.ts
+++ b/src/canvas-push.ts
@@ -9,6 +9,7 @@ import { emitActivationEvent } from './activationEvents.js'
 import type { CanvasStateEntry } from './canvas-routes.js'
 import { getAgentRoles } from './assignment.js'
 import { getIdentityColor } from './agent-config.js'
+import { postCanvasResponse } from './cloud.js'
 
 interface CanvasPushDeps {
   eventBus: typeof eventBusInstance
@@ -128,12 +129,17 @@ export async function canvasPushRoutes(
       payload = { ...payload, card, query }
 
       const agentColor = getIdentityColor(agentId, '#60a5fa')
+      const resolvedCard = { ...card, agentId, agentColor, query }
       eventBus.emit({
         id: `cmsg-${now}-${Math.random().toString(36).slice(2, 8)}`,
         type: 'canvas_message' as const,
         timestamp: now,
-        data: { ...card, agentId, agentColor, query },
+        data: resolvedCard,
       })
+
+      // Push the resolved card upstream to cloud → asker browser SSE → shared
+      // sink → card.fanout → room-card-store ring buffer → late-joiner backfill.
+      postCanvasResponse(resolvedCard).catch(() => { /* best-effort */ })
     }
 
     eventBus.emit({ id: `push-${now}-${Math.random().toString(36).slice(2, 6)}`, type: 'canvas_push', timestamp: now, data: payload })

--- a/src/canvas-query.ts
+++ b/src/canvas-query.ts
@@ -5,6 +5,7 @@
 import type { FastifyInstance } from 'fastify'
 import type { eventBus as eventBusInstance } from './events.js'
 import { getIdentityColor } from './agent-config.js'
+import { postCanvasResponse } from './cloud.js'
 
 interface CanvasStateEntry {
   state: string
@@ -391,19 +392,25 @@ export async function canvasQueryRoutes(
 
     const agentColor = getIdentityColor(from, '#94a3b8')
 
+    const resolvedCard = {
+      type: 'info',
+      data: { text: cleanContent },
+      agentId: from,
+      agentColor,
+      isResponse: true,
+    }
+
     // Emit as canvas_message — browser pulse stream picks it up
     eventBus.emit({
       id: `cmsg-response-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
       type: 'canvas_message' as const,
       timestamp: Date.now(),
-      data: {
-        type: 'info',
-        data: { text: cleanContent },
-        agentId: from,
-        agentColor,
-        isResponse: true,
-      },
+      data: resolvedCard,
     })
+
+    // Push the resolved card upstream to cloud → asker browser SSE → shared
+    // sink → card.fanout → room-card-store ring buffer → late-joiner backfill.
+    postCanvasResponse(resolvedCard).catch(() => { /* best-effort */ })
   })
 
 }

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1668,6 +1668,33 @@ async function pollAgentDecisions(): Promise<void> {
   }
 }
 
+/**
+ * Push a RESOLVED canvas reply card to cloud so it broadcasts to the asker
+ * browser via SSE. The asker's shared sink then publishes `card.fanout` over
+ * Realtime, which the room-card-store ring-buffers — late joiners then pick
+ * it up via /room/cards backfill.
+ *
+ * The synchronous /canvas/query/ack relay only carries the pending placeholder
+ * (returned from POST /canvas/query before the agent has answered). When the
+ * actual agent reply lands later — via canvas-query-response-bridge or
+ * /canvas/push canvas_response — this is the second-leg upstream POST that
+ * closes the loop.
+ *
+ * Best-effort: failures are logged but do not throw, mirroring the rest of
+ * the canvas relay (agents shouldn't block on transport jitter).
+ */
+export async function postCanvasResponse(card: Record<string, unknown>): Promise<void> {
+  if (!state.hostId || !config) return
+  try {
+    const result = await cloudPost(`/api/hosts/${state.hostId}/canvas/response`, { card })
+    if (!result.success) {
+      console.warn(`[CanvasResponseRelay] upstream POST failed: ${result.error ?? 'unknown'}`)
+    }
+  } catch (err) {
+    console.warn(`[CanvasResponseRelay] upstream POST error: ${(err as Error).message}`)
+  }
+}
+
 // ── Canvas query relay polling ────────────────────────────────────────────────
 // When canvas/query is called from a NAT-behind node, the cloud queues the query
 // at GET /api/hosts/:id/canvas/query/pending. We poll here, POST each query to


### PR DESCRIPTION
## Summary

Closes the second leg of the canvas reply-card relay so late joiners actually see the **resolved** agent answer in `/room/cards`, not just the pending `Asking <agent>…` placeholder.

Pairs with **reflectt-cloud PR #2844** which adds `handleCanvasResponse` + `POST /api/hosts/:id/canvas/response`.

## The blocker

Backfill (`/room/cards`) was single-leg only. The pending placeholder card from `canvas-query.ts:309` rode the synchronous `canvas/query/ack` relay → cloud `broadcastCanvasMessageCard` → SSE → asker shared sink → `card.fanout` → node room-card-store ring buffer → late-joiner backfill. Worked.

The agent's later **resolved** reply, emitted by `canvas-query-response-bridge` (canvas-query.ts:368-407) or `POST /canvas/push canvas_response` (canvas-push.ts:121-137), was only emitted on node's local eventBus. Never reached cloud. Never reached asker browser. Never landed in the ring buffer.

## The fix

- `src/cloud.ts` — new `postCanvasResponse(card)` that POSTs to cloud's new `/api/hosts/:id/canvas/response` endpoint
- `src/canvas-query.ts` — call it from the `canvas-query-response-bridge` after the local `eventBus.emit`
- `src/canvas-push.ts` — call it from the `canvas_response` branch after the local `eventBus.emit`

## Scope discipline (per kai msg-1777299338016)

- ✅ narrow upstream POST from the two real resolved-card emit points
- ❌ NO broader relay redesign
- ❌ NO transcript widening
- ❌ NO extra history surface

## Proof bar

- [ ] Tab A asks
- [ ] resolved non-pending agent reply card relays upstream
- [ ] Tab B joins cold
- [ ] Tab B sees that resolved reply card in `/room/cards` backfill and on canvas

Will run `_room-card-backfill-resolved-late-join-proof.spec.ts` against canonical staging once both PRs land + node image is redeployed.

cc @link for exact-scope review (not gate, per kai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)