### PR TITLE
probe(canvas-bridge): log message_posted reaching bridge

### DIFF
--- a/src/canvas-query.ts
+++ b/src/canvas-query.ts
@@ -381,6 +381,9 @@ export async function canvasQueryRoutes(
     const isCanvasResponse = content.startsWith('[canvas-response]')
       || content.startsWith('[canvas]')
       || (channel === 'canvas' && from !== 'human')
+    // PROBE (revert after diagnosis): log every agent message_posted reaching
+    // the bridge so we can identify what path Compass's plain reply uses.
+    console.log(`[canvas-bridge-probe] from=${from} channel=${channel} matched=${isCanvasResponse} content="${content.slice(0, 80)}"`)
     if (!isCanvasResponse) return
 
     // Strip the [canvas-response] / [canvas] prefix


### PR DESCRIPTION
## Summary

Brief diagnostic per kai (msg-1777301062242). Resolved-card late-join proof on bfbeab51 showed pending placeholder reaches \`/room/cards\` but compass's resolved reply never does. This probe logs every \`message_posted\` event reaching \`canvas-query-response-bridge\` with from/channel/content/match-result, so we can see exactly what compass posts and why bridge doesn't catch it.

Will revert in the surgical fix PR once the actual emit path is identified.

## Test plan

- [x] Build green
- [ ] Deploy to canonical staging \`rn-34faba44-wlgkeq\`
- [ ] Run \`_room-card-backfill-resolved-late-join-proof.spec.ts\`
- [ ] \`fly logs -a rn-34faba44-wlgkeq | grep canvas-bridge-probe\` → identify compass's reply path

🤖 Generated with [Claude Code](https://claude.com/claude-code)