### PR TITLE
feat(idle-nudge): suppress per-agent nudges while a human is in the room

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -20,6 +20,7 @@ import { taskManager } from './tasks.js'
 import { routeMessage } from './messageRouter.js'
 import type { Task } from './types.js'
 import { resolveIdleNudgeLane, type IdleNudgeLaneState } from './watchdog/idleNudgeLane.js'
+import { listRoomParticipants } from './room-presence-store.js'
 import { getAgentLane } from './lane-config.js'
 import { getDb } from './db.js'
 import { policyManager } from './policy.js'
@@ -285,6 +286,7 @@ export type IdleNudgeDecision = {
     | 'queue-clear-restart-window'
     | 'eligible'
     | 'eligible-restart-window'
+    | 'in-active-room'
   lane: IdleNudgeLaneState
   renderedMessage: string | null
   at: number
@@ -1912,6 +1914,14 @@ class TeamHealthMonitor {
     const taskById = new Map(tasks.map((t: any) => [t.id, t]))
     const messages = chatManager.getMessages({ limit: 300 })
 
+    // Suppress all idle-nudge noise on this host while a human is in the
+    // room — system "@agent idle nudge" messages bleed into #general (which
+    // the canvas chat reads), so during a live exchange agents look like
+    // status bots instead of meeting participants. Truth source: the same
+    // Supabase Realtime room channel cloud already publishes to
+    // (room-presence-store).
+    const roomParticipantCount = listRoomParticipants().length
+
     for (const presence of presences) {
       const agent = (presence.agent || '').toLowerCase()
       if (!agent) continue
@@ -1932,6 +1942,11 @@ class TeamHealthMonitor {
         recentSuppressMin: this.idleNudgeSuppressRecentMin,
         lane,
         at: now,
+      }
+
+      if (roomParticipantCount > 0) {
+        decisions.push({ ...baseDecision, decision: 'none', reason: 'in-active-room', renderedMessage: null })
+        continue
       }
 
       if (!this.idleNudgeEnabled) {

--- a/tests/idle-nudge-in-active-room.test.ts
+++ b/tests/idle-nudge-in-active-room.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * Idle-nudge gate: in-active-room suppression.
+ *
+ * Reflectt agents on a managed host post into a single #general chat that
+ * the canvas surface reads. Before this gate, the system idle-nudge
+ * subsystem fired during live human exchanges, dropping "@agent idle nudge"
+ * lines into the room and making agents read like status bots.
+ *
+ * Behavior under test: when the room-presence-store reports any human
+ * participant on this host, every per-agent decision in runIdleNudgeTick
+ * short-circuits to `decision: 'none', reason: 'in-active-room'` — before
+ * any other gate runs. Empty room → original flow.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const listRoomParticipantsMock = vi.fn<[], Array<{ id: string }>>()
+
+vi.mock('../src/room-presence-store.js', () => ({
+  listRoomParticipants: () => listRoomParticipantsMock(),
+}))
+
+// Import after mock so the health module picks up the stub.
+const { healthMonitor } = await import('../src/health.js')
+const { presenceManager } = await import('../src/presence.js')
+
+describe('idle-nudge in-active-room gate', () => {
+  beforeEach(() => {
+    listRoomParticipantsMock.mockReset()
+  })
+
+  afterEach(() => {
+    listRoomParticipantsMock.mockReset()
+  })
+
+  it('marks every per-agent decision as in-active-room when humans are present', async () => {
+    presenceManager.updatePresence('test-agent-room-gate', 'working')
+    listRoomParticipantsMock.mockReturnValue([
+      { id: 'human-session-abc' },
+    ])
+
+    const result = await healthMonitor.runIdleNudgeTick(Date.now(), { dryRun: true })
+
+    // Every decision (one per known presence agent) must be the new gate —
+    // no nudges should be fired and no other reason should appear, since
+    // this gate runs before every other suppression check.
+    expect(result.nudged).toEqual([])
+    const seeded = result.decisions.find(d => d.agent === 'test-agent-room-gate')
+    expect(seeded?.decision).toBe('none')
+    expect(seeded?.reason).toBe('in-active-room')
+    expect(seeded?.renderedMessage).toBeNull()
+    // No agent escapes the gate — every decision in this tick is in-active-room.
+    for (const d of result.decisions) {
+      expect(d.reason).toBe('in-active-room')
+    }
+  })
+
+  it('falls through to existing gates when the room is empty', async () => {
+    presenceManager.updatePresence('test-agent-room-gate', 'working')
+    listRoomParticipantsMock.mockReturnValue([])
+
+    const result = await healthMonitor.runIdleNudgeTick(Date.now(), { dryRun: true })
+
+    // With no humans in the room, no decision should carry the new reason —
+    // the existing 15 suppression gates own the outcome.
+    for (const d of result.decisions) {
+      expect(d.reason).not.toBe('in-active-room')
+    }
+  })
+})


### PR DESCRIPTION
## Why

System idle-nudge messages (`@agent idle nudge: no update in #general for 15m+`) post into `#general` — which the canvas chat reads — and bleed into live human exchanges as status-bot noise.

Observed on canonical staging during a real room walk just now:
```
[      user general] @compass hi — checking the room
[   compass general] Room nominal 🧭
[  watchdog general] @watchdog idle nudge: no update in #general for 15m+. Post shipped / blocker / next+ETA now.
```

Per @kai's direction (msg-1777354734403): _"when a real meeting is active, suppress idle-nudge / idle-mode contamination"_ → no `idle nudge` lines during a live exchange.

## What

Truth source for "in a meeting" already exists: `room-presence-store.ts` mirrors the Supabase Realtime room channel cloud publishes to. Adds a single gate at the top of `runIdleNudgeTick`'s per-agent loop. When `listRoomParticipants().length > 0`, every decision short-circuits to `{ decision: 'none', reason: 'in-active-room' }` before any other suppression runs.

Empty room → original 15-gate flow unchanged.

Scope:
- `src/health.ts`: import `listRoomParticipants`, add `'in-active-room'` to the `IdleNudgeDecision` reason union, query participant count once per tick, gate at top of per-agent loop (~10 LOC of behavior)
- `tests/idle-nudge-in-active-room.test.ts`: 2 vitests — populated room (every decision tagged `in-active-room`, `nudged === []`) and empty room (no decision carries the new reason)

## Test plan
- [x] Local: `npx vitest run tests/idle-nudge-in-active-room.test.ts` → 2/2 pass
- [x] Local: `npx vitest run tests/idle-nudge-lane-aware.test.ts tests/idle-nudge-lane-scoped.test.ts tests/validating-stall-nudge.test.ts tests/health-scope.test.ts` → 15/15 pass, no regressions
- [x] `npx tsc --noEmit` → clean
- [ ] After merge + canonical roll: re-walk room, expect chat history during the walk to contain zero `idle nudge` lines (verified via `GET /chat/messages` on `rn-34faba44-wlgkeq.fly.dev`)

## Followup (separate PR)

This drops system noise during a meeting. Compass's _own_ "Room nominal 🧭" / "All nominal from my side 🧭" status-bot voice during human exchanges is a separate cut — needs `roomParticipants` injected into compass's heartbeat/context + an AGENTS.md rule. Will land that after this one ships and we walk again.