### PR TITLE
feat(chat-context): inject ROOM STATUS line when a human is in the room

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,7 @@ import { isTestHarnessTask } from './test-task-filter.js'
 import { handleMCPRequest, handleSSERequest, handleMessagesRequest, getActiveSamplingProviders } from './mcp.js'
 import { memoryManager } from './memory.js'
 import { buildContextInjection, getContextBudgets, getContextMemo, upsertContextMemo, type ContextLayer } from './context-budget.js'
+import { listRoomParticipants } from './room-presence-store.js'
 import { deriveScopeId } from './scope-routing.js'
 import { eventBus, VALID_EVENT_TYPES } from './events.js'
 import { presenceManager, IDLE_THRESHOLD_MS, OFFLINE_THRESHOLD_MS } from './presence.js'
@@ -4898,6 +4899,11 @@ export async function createServer(): Promise<FastifyInstance> {
       .sort((a, b) => a.ts - b.ts)
       .slice(-limit)
 
+    // Room-active signal: surfaced both as a top-level field (for any caller)
+    // and as a single line inside compact_text below (for the live OpenClaw plugin
+    // which drops compact_text into the agent's per-turn prompt).
+    const roomActiveCount = listRoomParticipants().length
+
     // Strict compact: render a small text packet with a hard char budget.
     let compact_text: string | undefined
     if (strictCompact) {
@@ -4931,6 +4937,12 @@ export async function createServer(): Promise<FastifyInstance> {
       const push = (s: string) => { if (s) lines.push(s) }
 
       push(`AGENT: ${agent}`)
+      // Tiny semantic signal — locked by kai/link msg-1777356030100 / msg-1777356036716:
+      // one line, no participant roster blob; just enough to flip in-room agents from
+      // status-bot voice to participant voice during a live exchange. Empty room → omit.
+      if (roomActiveCount > 0) {
+        push('ROOM STATUS: in an active room with a human — speak as a meeting participant, not a status bot')
+      }
       push('')
       push('ACTIVE TASK:')
       push(doing ? `- ${doing.id} [${doing.priority}] ${doing.title}` : '- none')
@@ -4964,6 +4976,7 @@ export async function createServer(): Promise<FastifyInstance> {
       since: sinceMs,
       count: messagesOut.length,
       messages: messagesOut,
+      room_status: { in_session: roomActiveCount > 0 },
       ...(strictCompact ? { compact: true, max_chars: maxChars, compact_text } : {}),
       suppressed: {
         system_deduped: systemAlerts.length - dedupedAlerts.length,

--- a/tests/chat-context-room-active.test.ts
+++ b/tests/chat-context-room-active.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Reflectt AI
+
+/**
+ * /chat/context/:agent — room-active signal injection.
+ *
+ * The reflectt-channel OpenClaw plugin pulls compact_text from this endpoint
+ * and drops it into the agent's per-turn prompt (see public/docs.md:356,
+ * "Compact deduplicated chat for agent context injection. Always slim.").
+ *
+ * Behavior under test: when listRoomParticipants() reports any human on this
+ * host, the endpoint surfaces a single-line ROOM STATUS marker inside
+ * compact_text AND a structured `room_status.in_session: true` field.
+ * Empty room → both omit / report false. Locked shape (kai/link
+ * msg-1777356030100, msg-1777356036716): tiny semantic signal, no
+ * participant roster blob.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+
+const listRoomParticipantsMock = vi.fn<[], Array<{ id: string }>>()
+
+vi.mock('../src/room-presence-store.js', () => ({
+  listRoomParticipants: () => listRoomParticipantsMock(),
+  getRoomPresenceStatus: () => ({
+    initialized: false,
+    hostId: null,
+    count: listRoomParticipantsMock().length,
+  }),
+  initRoomPresenceStore: () => false,
+  shutdownRoomPresenceStore: async () => {},
+}))
+
+const { createServer } = await import('../src/server.js')
+
+describe('/chat/context/:agent — room-active signal', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    process.env.REFLECTT_DATA_DIR = `/tmp/reflectt-test-room-active-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    listRoomParticipantsMock.mockReset()
+    listRoomParticipantsMock.mockReturnValue([])
+    app = await createServer()
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    listRoomParticipantsMock.mockReset()
+  })
+
+  it('injects ROOM STATUS into compact_text and sets room_status.in_session=true when a human is present', async () => {
+    listRoomParticipantsMock.mockReturnValue([{ id: 'human-session-abc' }])
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/chat/context/compass?compact=1&max_chars=2000',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+
+    // Structured field for any future caller (cloud sync, debug UI, etc.).
+    expect(body.room_status).toEqual({ in_session: true })
+
+    // The line that lands in compass's per-turn prompt.
+    expect(body.compact_text).toContain('ROOM STATUS:')
+    expect(body.compact_text).toContain('active room with a human')
+    expect(body.compact_text).toContain('speak as a meeting participant')
+
+    // Tiny on purpose — the signal must be one line, not a roster dump.
+    const roomStatusLines = body.compact_text
+      .split('\n')
+      .filter((l: string) => l.startsWith('ROOM STATUS:'))
+    expect(roomStatusLines).toHaveLength(1)
+  })
+
+  it('omits ROOM STATUS from compact_text and reports in_session=false when the room is empty', async () => {
+    listRoomParticipantsMock.mockReturnValue([])
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/chat/context/compass?compact=1&max_chars=2000',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+
+    expect(body.room_status).toEqual({ in_session: false })
+    expect(body.compact_text).not.toContain('ROOM STATUS:')
+    expect(body.compact_text).not.toContain('active room with a human')
+  })
+
+  it('still emits room_status (without compact_text) for non-strict callers', async () => {
+    listRoomParticipantsMock.mockReturnValue([{ id: 'human-x' }])
+
+    const res = await app.inject({ method: 'GET', url: '/chat/context/compass' })
+    const body = JSON.parse(res.body)
+
+    expect(body.room_status).toEqual({ in_session: true })
+    expect(body.compact_text).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Tiny semantic signal added to `/chat/context/:agent` — both as a structured `room_status.in_session` field and as a single line inside `compact_text` (the per-turn prompt packet the reflectt-channel OpenClaw plugin drops into the agent's prompt).

Pairs with #1315: that PR closed the **system idle-nudge** contamination hole; this PR lands the **agent-side voice** counterpart so compass stops answering with \"Still nominal 🧭\" / \"Snapshot noted 🧭\" during a live exchange and behaves like an in-session participant.

## Locked shape (kai msg-1777356030100, link msg-1777356036716)

- one line, not a participant roster blob
- text: \`ROOM STATUS: in an active room with a human — speak as a meeting participant, not a status bot\`
- empty room → omit (zero behavior change)

## Why this seam

The reflectt-channel plugin pulls `compact_text` per turn (`public/docs.md:356` — \"Compact deduplicated chat for agent context injection. Always slim.\"). That's the smallest available seam closer to the room path than memo budgets, per kai's steer. Reuses existing `listRoomParticipants()` truth from room-presence-store — no new state, no AGENTS.md churn, no canonical re-provision needed.

## Diff

- `src/server.ts`: 1 import + 1 line in compact_text builder + 1 field in response. ~12 LOC.
- `tests/chat-context-room-active.test.ts`: 3 vitests — populated room sets the line + field, empty room omits both, non-strict callers still get `room_status`.

## Test plan

- [x] vitest: 3/3 green for new file (`tests/chat-context-room-active.test.ts`)
- [x] vitest: 5/5 green for existing `tests/chat-context.test.ts` (no regression)
- [x] vitest: 2/2 green for #1315 `tests/idle-nudge-in-active-room.test.ts` (no regression)
- [x] `tsc --noEmit` clean
- [ ] **canonical proof** (post-merge, then roll image to canonical):
  - re-walk `_room-walk-observation.spec.ts` on canonical
  - confirm `/chat/context/compass?compact=1` returns `compact_text` with ROOM STATUS line
  - observe compass responds engagingly instead of \"Still nominal 🧭\"