### PR TITLE
feat(room): add camera-snapshot artifact kind (Cut C-image-A)

### DIFF
--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -169,18 +169,32 @@ export function updateArtifactMetadata(id: string, partial: Record<string, unkno
 }
 
 /**
- * Snapshot retention sweep — Room Share Snapshot v0 lock: keep last `max`
- * snapshots per `agentId` (= per host = per room in v0), evict oldest.
+ * Image-artifact retention sweep — Camera Snapshot v0 lock (kai
+ * msg-1777619980384 R1-3 + R2-4): keep last `max` artifacts across the
+ * union of `kinds` per `agentId` (= per host = per room in v0), evict
+ * oldest. Camera + screen snapshots share ONE pool of 20, not separate
+ * quotas — so a camera snapshot can evict an older screen snapshot.
  * Deletes both the original PNG and the matching `*-thumb.png` thumbnail
  * file alongside the DB row. Synchronous + cheap; no scheduler.
  *
- * Per-kind cap so future kinds (recordings, agent outputs) carry their
- * own retention rules set by their own specs without conflict.
+ * Renamed from `pruneSnapshotsForRetention` in slice C-image-A: the old
+ * name lied once the helper spans both image kinds. Future non-image
+ * kinds (recordings, agent outputs) get their own retention helpers.
  */
-export function pruneSnapshotsForRetention(agentId: string, max: number = 20): { removed: number } {
-  const snapshots = listArtifacts({ agentId, kind: 'snapshot', limit: 1000 })
-  if (snapshots.length <= max) return { removed: 0 }
-  const toRemove = snapshots.slice(max)
+export function pruneImageArtifactsForRetention(
+  agentId: string,
+  kinds: string[] = ['snapshot', 'camera-snapshot'],
+  max: number = 20,
+): { removed: number } {
+  // Gather rows per kind (each list already sorted by createdAt DESC),
+  // merge into one union, re-sort, slice off everything past `max`.
+  const union: Artifact[] = []
+  for (const kind of kinds) {
+    union.push(...listArtifacts({ agentId, kind, limit: 1000 }))
+  }
+  if (union.length <= max) return { removed: 0 }
+  union.sort((a, b) => b.createdAt - a.createdAt)
+  const toRemove = union.slice(max)
   let removed = 0
   for (const art of toRemove) {
     const thumb = (art.metadata?.thumbnailPath as string | undefined) ?? null

--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -94,23 +94,22 @@ function formatJoin(p: RoomJoinPayload['participant'], defaultAgent: string): st
   return `@${defaultAgent} 🚪 **${p.displayName}** joined the room (${p.device})`
 }
 
-// Per-kind dispatch — v0 only handles `kind='snapshot'`. Future kinds
-// (recordings, agent outputs) add their own one-liner here without
-// changing the event name. Body stays utilitarian (kai lock
-// msg-1777191217389: "thin factual notification, not narration") but
-// includes the artifact URL inline. The original design pushed url etc
-// into msg.metadata for "agent pulls on demand" — but receiving agents
-// only see the chat body in their prompt, so a metadata-only pointer
-// has no caller. Inline URL keeps the body factual while giving the
-// agent something to fetch (mj2z6nzjz follow-up: "noted 🧭" replies on
-// canonical staging because compass had no pointer to the bytes).
+// Per-kind dispatch — v0 handles `kind='snapshot'` (5A) and
+// `kind='camera-snapshot'` (Cut C-image, kai msg-1777619980384). Future
+// kinds add their own one-liner here without changing the event name.
+// Body stays utilitarian (kai lock msg-1777191217389: "thin factual
+// notification, not narration") but includes the artifact URL inline.
+// Distinct emoji per kind (R2-2 lock): 📸 screen, 📷 camera — lets
+// agents and humans read which kind was shared without opening the
+// artifact.
 function formatArtifactShared(p: RoomArtifactSharedPayload, defaultAgent: string): string | null {
   const who = p.artifact.sharedByDisplayName ?? 'Someone'
+  const dim = p.artifact.dimensions ? ` (${p.artifact.dimensions.width}×${p.artifact.dimensions.height})` : ''
   switch (p.artifact.kind) {
-    case 'snapshot': {
-      const dim = p.artifact.dimensions ? ` (${p.artifact.dimensions.width}×${p.artifact.dimensions.height})` : ''
+    case 'snapshot':
       return `@${defaultAgent} 📸 **${who}** shared a snapshot${dim} → ${p.artifact.url}`
-    }
+    case 'camera-snapshot':
+      return `@${defaultAgent} 📷 **${who}** shared a camera snapshot${dim} → ${p.artifact.url}`
     default: return null
   }
 }

--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -11,7 +11,7 @@
  *   - GET /room/artifacts               (5A — list, generic, filterable by kind)
  *   - GET /room/artifacts/:id/content   (5A — full-res bytes)
  *   - GET /room/artifacts/:id/thumbnail (5A — server-generated 480px PNG)
- *   - POST /room/artifacts              (5A — multipart write; v0 only accepts kind='snapshot')
+ *   - POST /room/artifacts              (5A — multipart write; v0 accepts kind='snapshot' or 'camera-snapshot')
  *
  * Auth uses the same heartbeat-token model as `/hosts/heartbeat`: if
  * REFLECTT_HOST_HEARTBEAT_TOKEN is set, requests must present it via
@@ -31,15 +31,16 @@ import {
   deleteArtifact,
   listArtifacts,
   updateArtifactMetadata,
-  pruneSnapshotsForRetention,
+  pruneImageArtifactsForRetention,
   ROOM_ARTIFACT_AGENT_ID,
   type Artifact,
 } from './artifact-store.js'
 import { generateSnapshotThumbnail, thumbnailPathFor } from './snapshot-thumbnail.js'
 import { broadcastArtifactShared } from './room-artifact-broadcast.js'
 
-const SNAPSHOT_RETENTION_MAX = 20
-const ALLOWED_KINDS_V0 = new Set(['snapshot'])
+const IMAGE_ARTIFACT_RETENTION_MAX = 20
+const IMAGE_ARTIFACT_KINDS = ['snapshot', 'camera-snapshot'] as const
+const ALLOWED_KINDS_V0 = new Set<string>(IMAGE_ARTIFACT_KINDS)
 
 function verifyAuth(request: FastifyRequest): { ok: boolean; error?: string } {
   const expectedToken = process.env.REFLECTT_HOST_HEARTBEAT_TOKEN
@@ -67,8 +68,9 @@ function resolveHostId(): string {
 /**
  * Project an artifact for the wire — strips on-disk paths, adds the
  * relative URL the cloud will resolve. `thumbnailUrl` is present even
- * for kinds without a thumbnail (returns 404 in that case); v0 only
- * accepts `kind='snapshot'` so all v0 artifacts have one.
+ * for kinds without a thumbnail (returns 404 in that case); v0 accepts
+ * `kind='snapshot'` (5B) or `kind='camera-snapshot'` (C-image), both
+ * image/png — so all v0 artifacts have a thumbnail.
  */
 function projectArtifact(art: Artifact): Record<string, unknown> {
   const meta = art.metadata ?? {}
@@ -261,7 +263,7 @@ export async function roomRoutes(app: FastifyInstance) {
   /**
    * POST /room/artifacts (multipart)
    * Field 'file' = PNG bytes (required; v0 enforces image/png).
-   * Field 'kind' = discriminator (required; v0 only accepts 'snapshot').
+   * Field 'kind' = discriminator (required; v0 accepts 'snapshot' or 'camera-snapshot').
    * Field 'sharedBy' = participant id (required).
    * Field 'sharedByDisplayName' = denormalized display name (required).
    *
@@ -300,10 +302,11 @@ export async function roomRoutes(app: FastifyInstance) {
       reply.status(400)
       return { error: 'sharedBy + sharedByDisplayName required' }
     }
-    // v0 only handles image/png snapshots. Future kinds may relax this.
+    // v0 image artifacts (snapshot + camera-snapshot) require image/png.
+    // Future non-image kinds may relax this.
     if (data.mimetype !== 'image/png') {
       reply.status(400)
-      return { error: 'snapshot requires image/png' }
+      return { error: `${kind} requires image/png` }
     }
 
     const buf = await data.toBuffer()
@@ -314,7 +317,7 @@ export async function roomRoutes(app: FastifyInstance) {
 
     const hostId = resolveHostId()
     const isoNow = new Date().toISOString()
-    const fileName = `snapshot-${isoNow.replace(/[:.]/g, '-')}.png`
+    const fileName = `${kind}-${isoNow.replace(/[:.]/g, '-')}.png`
 
     const art = storeArtifact({
       agentId: ROOM_ARTIFACT_AGENT_ID,
@@ -379,11 +382,16 @@ export async function roomRoutes(app: FastifyInstance) {
       thumbnailUrl: projected.thumbnailUrl as string,
     })
 
-    // Per-kind retention sweep — last 20 snapshots, evict oldest. Sync,
-    // cheap, no scheduler. Future kinds set their own caps from their
-    // own specs.
-    if (kind === 'snapshot') {
-      pruneSnapshotsForRetention(ROOM_ARTIFACT_AGENT_ID, SNAPSHOT_RETENTION_MAX)
+    // Image-artifact retention sweep — shared pool of 20 across both
+    // image kinds (snapshot + camera-snapshot), evict oldest of any
+    // image kind. Sync, cheap, no scheduler. Camera Snapshot v0 lock
+    // (kai msg-1777619980384 R1-3): ONE pool, not separate quotas.
+    if ((IMAGE_ARTIFACT_KINDS as readonly string[]).includes(kind)) {
+      pruneImageArtifactsForRetention(
+        ROOM_ARTIFACT_AGENT_ID,
+        [...IMAGE_ARTIFACT_KINDS],
+        IMAGE_ARTIFACT_RETENTION_MAX,
+      )
     }
 
     reply.status(201)

--- a/tests/artifact-store-room.test.ts
+++ b/tests/artifact-store-room.test.ts
@@ -1,7 +1,9 @@
-// Room Share Snapshot v0 slice 5A: tests for the artifact-store extensions
-// (kind filter, sinceMs filter, updateArtifactMetadata, pruneSnapshotsForRetention).
-// The room flow piles all room-scoped artifacts under agentId=ROOM_ARTIFACT_AGENT_ID
+// Room Share Snapshot v0 slice 5A + Camera Snapshot v0 slice C-image-A:
+// tests for the artifact-store extensions (kind filter, sinceMs filter,
+// updateArtifactMetadata, pruneImageArtifactsForRetention). The room
+// flow piles all room-scoped artifacts under agentId=ROOM_ARTIFACT_AGENT_ID
 // with metadata.kind as the discriminator — these tests pin that contract.
+// Shared-pool retention (kai msg-1777619980384 R1-3) verified separately.
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import { promises as fs } from 'fs'
@@ -98,7 +100,7 @@ describe('artifact-store room extensions', () => {
     expect(mod.updateArtifactMetadata('art-nonexistent', { x: 1 })).toBeNull()
   })
 
-  it('pruneSnapshotsForRetention(agentId, max=2) keeps the newest 2 snapshots and deletes thumbs', async () => {
+  it('pruneImageArtifactsForRetention(agentId, [snapshot], max=2) keeps the newest 2 snapshots and deletes thumbs', async () => {
     const mod = await import('../src/artifact-store.js')
     const items = [] as Awaited<ReturnType<typeof storeSnapshot>>[]
     for (let i = 0; i < 5; i++) {
@@ -112,7 +114,7 @@ describe('artifact-store room extensions', () => {
       await new Promise((r) => setTimeout(r, 5)) // force createdAt ordering
     }
 
-    const result = mod.pruneSnapshotsForRetention(mod.ROOM_ARTIFACT_AGENT_ID, 2)
+    const result = mod.pruneImageArtifactsForRetention(mod.ROOM_ARTIFACT_AGENT_ID, ['snapshot'], 2)
     expect(result.removed).toBe(3)
 
     const remaining = mod.listArtifacts({
@@ -131,9 +133,92 @@ describe('artifact-store room extensions', () => {
     }
   })
 
-  it('pruneSnapshotsForRetention is a no-op when count <= max', async () => {
+  it('pruneImageArtifactsForRetention is a no-op when union count <= max', async () => {
     const mod = await import('../src/artifact-store.js')
     await storeSnapshot('only.png')
-    expect(mod.pruneSnapshotsForRetention(mod.ROOM_ARTIFACT_AGENT_ID, 20)).toEqual({ removed: 0 })
+    expect(mod.pruneImageArtifactsForRetention(mod.ROOM_ARTIFACT_AGENT_ID, ['snapshot', 'camera-snapshot'], 20))
+      .toEqual({ removed: 0 })
+  })
+
+  // ── Camera Snapshot v0 (Cut C-image) ─────────────────────────────────
+  // Shared-pool retention: snapshot + camera-snapshot count against ONE
+  // pool of `max`. A new image of either kind can evict an older image
+  // of either kind. Pinning kai's R1-3 lock (msg-1777619980384).
+
+  it('pruneImageArtifactsForRetention shared-pool: a camera-snapshot can evict an older snapshot', async () => {
+    const mod = await import('../src/artifact-store.js')
+
+    // 2 screen snapshots first (older), then 1 camera snapshot (newest).
+    // With max=2 across the union, the OLDEST screen snapshot must evict.
+    const oldScreen = await storeSnapshot('old-screen.png', 'snapshot')
+    await new Promise((r) => setTimeout(r, 5))
+    const newerScreen = await storeSnapshot('newer-screen.png', 'snapshot')
+    await new Promise((r) => setTimeout(r, 5))
+    const camera = await storeSnapshot('cam.png', 'camera-snapshot')
+
+    const result = mod.pruneImageArtifactsForRetention(
+      mod.ROOM_ARTIFACT_AGENT_ID,
+      ['snapshot', 'camera-snapshot'],
+      2,
+    )
+    expect(result.removed).toBe(1)
+
+    // The oldest screen snapshot is gone; the newer screen + camera survive.
+    const allKinds = mod.listArtifacts({ agentId: mod.ROOM_ARTIFACT_AGENT_ID, limit: 100 })
+    const surviving = new Set(allKinds.map((a) => a.id))
+    expect(surviving.has(oldScreen.id)).toBe(false)
+    expect(surviving.has(newerScreen.id)).toBe(true)
+    expect(surviving.has(camera.id)).toBe(true)
+  })
+
+  it('pruneImageArtifactsForRetention shared-pool: a snapshot can evict an older camera-snapshot', async () => {
+    const mod = await import('../src/artifact-store.js')
+
+    // Inverse of above — proves eviction is kind-agnostic, not snapshot-priority.
+    const oldCamera = await storeSnapshot('old-cam.png', 'camera-snapshot')
+    await new Promise((r) => setTimeout(r, 5))
+    const newerCamera = await storeSnapshot('newer-cam.png', 'camera-snapshot')
+    await new Promise((r) => setTimeout(r, 5))
+    const screen = await storeSnapshot('s.png', 'snapshot')
+
+    mod.pruneImageArtifactsForRetention(
+      mod.ROOM_ARTIFACT_AGENT_ID,
+      ['snapshot', 'camera-snapshot'],
+      2,
+    )
+
+    const allKinds = mod.listArtifacts({ agentId: mod.ROOM_ARTIFACT_AGENT_ID, limit: 100 })
+    const surviving = new Set(allKinds.map((a) => a.id))
+    expect(surviving.has(oldCamera.id)).toBe(false)
+    expect(surviving.has(newerCamera.id)).toBe(true)
+    expect(surviving.has(screen.id)).toBe(true)
+  })
+
+  it('pruneImageArtifactsForRetention only counts kinds in the kinds list', async () => {
+    const mod = await import('../src/artifact-store.js')
+
+    // 5 recordings (a hypothetical future kind not in the image kinds list)
+    // + 2 snapshots — with max=2 and kinds=['snapshot'], no eviction should happen.
+    for (let i = 0; i < 5; i++) {
+      await storeSnapshot(`r${i}.png`, 'recording')
+      await new Promise((r) => setTimeout(r, 2))
+    }
+    await storeSnapshot('s1.png', 'snapshot')
+    await storeSnapshot('s2.png', 'snapshot')
+
+    const result = mod.pruneImageArtifactsForRetention(
+      mod.ROOM_ARTIFACT_AGENT_ID,
+      ['snapshot'],
+      2,
+    )
+    expect(result.removed).toBe(0)
+
+    // Recordings are untouched (different kind, not in the prune list).
+    const recordings = mod.listArtifacts({
+      agentId: mod.ROOM_ARTIFACT_AGENT_ID,
+      kind: 'recording',
+      limit: 100,
+    })
+    expect(recordings).toHaveLength(5)
   })
 })

--- a/tests/room-event-bridge.test.ts
+++ b/tests/room-event-bridge.test.ts
@@ -200,6 +200,54 @@ describe('room-event-bridge', () => {
     expect(getRoomEventBridgeStatus().artifactCount).toBe(1)
   })
 
+  // Cut C-image (Camera Snapshot v0): second image kind on the same
+  // substrate. Distinct emoji per kai R2-2 lock (msg-1777619980384):
+  // 📷 camera vs 📸 screen — lets readers distinguish at a glance.
+  it('forwards a camera-snapshot artifact_shared with the 📷 prefix', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-evt-cam-1',
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: {
+        artifact: {
+          id: 'art-cam-456',
+          kind: 'camera-snapshot',
+          name: 'cam.png',
+          mimeType: 'image/png',
+          sizeBytes: 22345,
+          createdAt: Date.now(),
+          sharedBy: 'session-cam-456',
+          sharedByDisplayName: 'Ryan',
+          dimensions: { width: 640, height: 480 },
+          url: 'https://cdn.example/art-cam-456.png',
+          thumbnailUrl: 'https://cdn.example/art-cam-456.thumb.png',
+        },
+        by: 'session-cam-456',
+        hostId: 'host-1',
+      },
+    })
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.from).toBe('room')
+    expect(call.to).toBe('genesis')
+    expect(call.channel).toBe('general')
+    expect(call.content).toContain('@genesis')
+    expect(call.content).toContain('Ryan')
+    expect(call.content).toContain('camera snapshot')
+    // Distinct camera emoji — pins R2-2 lock so a future revert collapses
+    // both kinds back into one push line.
+    expect(call.content).toContain('📷')
+    expect(call.content).not.toContain('📸')
+    expect(call.content).toContain('https://cdn.example/art-cam-456.png')
+    expect(call.content).toContain('640×480')
+    expect(call.metadata.kind).toBe('camera-snapshot')
+    expect(call.metadata.url).toBe('https://cdn.example/art-cam-456.png')
+    expect(call.metadata.dedup_key).toBe('room-artifact-art-cam-456')
+    expect(getRoomEventBridgeStatus().artifactCount).toBe(1)
+  })
+
   it('drops unknown artifact kinds silently (no generic "an artifact was shared" line)', () => {
     initRoomEventBridge()
     eventBus.emit({


### PR DESCRIPTION
## Summary

Slice **C-image-A** of [CAMERA_SNAPSHOT_V0](https://github.com/reflectt/reflectt-cloud/blob/develop/docs/CAMERA_SNAPSHOT_V0.md) (spec v0.2 APPROVED by kai msg-1777619980384). Adds `camera-snapshot` as the second image-artifact kind on the existing room artifact substrate.

**Net infra delta = 0.** No new endpoints, no new tables, no new MCP tools, no new event types, no new realtime channels. One value added to a kinds enum, one new dispatch case, one helper renamed and generalized.

### Changes

- **`room-routes.ts`** — add `'camera-snapshot'` to `ALLOWED_KINDS_V0`; rename `SNAPSHOT_RETENTION_MAX` → `IMAGE_ARTIFACT_RETENTION_MAX`; route triggers shared-pool retention sweep for both image kinds (kai **R1-3** — ONE pool of 20, not separate quotas)
- **`artifact-store.ts`** — rename `pruneSnapshotsForRetention` → `pruneImageArtifactsForRetention(agentId, kinds, max)`; generalize to union over a kind list (kai **R2-4** — old name lied once it spans both kinds); eviction is kind-agnostic across the union
- **`room-event-bridge.ts`** — new `case 'camera-snapshot'` in artifact dispatch; push reads `📷 **{name}** shared a camera snapshot` with distinct emoji from screen `📸` (kai **R2-2**)

### Tests added

- `artifact-store-room.test.ts` — 3 shared-pool retention tests:
  - camera-snapshot can evict an older screen snapshot
  - screen snapshot can evict an older camera-snapshot (proves eviction is not snapshot-priority)
  - kind-list isolation: recordings are untouched when not in the kinds list
- `room-event-bridge.test.ts` — camera-snapshot dispatch test pinning the `📷` emoji, URL inline, dedup_key shape

### Implementation locks honored

| Lock | Source | How |
|---|---|---|
| Shared strip distinguished by kind | R1-1 | Substrate lets cloud render both in one strip; kind discriminator is just a metadata field |
| Preview + confirm required | R1-2 | Cloud-side responsibility (Slice C-image-B) |
| Shared last-20 retention pool | R1-3 | `pruneImageArtifactsForRetention` unions over kinds, single max |
| Desktop-first + truthful | R1-4 | No node-side coupling here; cloud will gate button on lane state |
| Distinct push emoji | R2-2 | `📷` for camera-snapshot, `📸` stays for screen-snapshot |
| Existing live `cameraStream` only | R2-3 | Cloud-side responsibility (Slice C-image-B) |
| Helper rename | R2-4 | Done — `pruneImageArtifactsForRetention(agentId, kinds, max)` |
| Cross-participant shared | R2-5 | Substrate is room-scoped, not author-scoped — already true |

### Test plan

- [x] `npx vitest run tests/artifact-store-room.test.ts tests/room-event-bridge.test.ts` — 19/19 pass
- [x] `npx vitest run` — 2612 / 2613 (1 pre-existing skipped) pass
- [x] `npx tsc --noEmit` — clean
- [ ] Real-device proof on canonical staging host (rn-34faba44-wlgkeq) — will run after merge + image roll, before C-image-B opens

### Slice budget

| Phase | LOC | Status |
|---|---|---|
| C-image-A node | ~80 | This PR |
| C-image-B cloud | ~95 | Next, after merge + canonical roll |

Source LOC delta: +80 / -43 (within ~80 spec budget). Test LOC: +138 / -9.

### Notes for reviewers

- The dedup_key for the camera-snapshot dispatch is `room-artifact-{artifactId}` (existing convention) rather than spec's literal suggestion `camera-snapshot-{artifactId}`. The existing key is already per-artifact-unique because artifact ids are unique, so prefixing by kind would be churn for no semantic gain. Flagging in case kai/link want it changed before merge.
- `IMAGE_ARTIFACT_KINDS` is a `readonly` tuple shared between the allowed-kinds set and the retention call — single source of truth for what counts as an image artifact in v0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)