### PR TITLE
fix: cut stale agent context at latest canvas seed

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4790,6 +4790,94 @@ export async function createServer(): Promise<FastifyInstance> {
     return payload
   })
 
+  type AgentSeedCutoff = {
+    timestamp: number
+    messageId: string
+    source: string
+  }
+
+  function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+
+  function findLatestAgentSeedCutoff(messages: AgentMessage[], agent: string): AgentSeedCutoff | null {
+    const agentPattern = new RegExp(`@${escapeRegExp(agent)}\\b`, 'i')
+
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index]
+      if (!message) continue
+
+      const metadata = (message.metadata || {}) as Record<string, unknown>
+      const source = typeof metadata.source === 'string' ? metadata.source : ''
+      const replyVia = typeof metadata.reply_via === 'string' ? metadata.reply_via : ''
+      const isCanvasSeed = source === 'canvas_query' || replyVia === 'canvas_push'
+      if (!isCanvasSeed) continue
+
+      const directToAgent = typeof message.to === 'string' && message.to.trim().toLowerCase() === agent
+      const mentionsAgent = agentPattern.test(message.content || '')
+      if (!directToAgent && !mentionsAgent) continue
+
+      const timestamp = Number(message.timestamp) || 0
+      if (timestamp <= 0) continue
+
+      return {
+        timestamp,
+        messageId: message.id,
+        source: source || replyVia,
+      }
+    }
+
+    return null
+  }
+
+  function selectAgentContextMessages(opts: {
+    agent: string
+    limit: number
+    channelFilter?: string
+    sinceMs: number
+  }): {
+    allMessages: AgentMessage[]
+    filteredMessages: AgentMessage[]
+    mentions: AgentMessage[]
+    systemAlerts: AgentMessage[]
+    teamMessages: AgentMessage[]
+    seedCutoff: AgentSeedCutoff | null
+    seedFilteredCount: number
+  } {
+    const allMessages = chatManager.getMessages({
+      channel: opts.channelFilter,
+      limit: Math.min(opts.limit * 6, 800),
+      since: opts.sinceMs,
+    })
+
+    const seedCutoff = findLatestAgentSeedCutoff(allMessages, opts.agent)
+    const filteredMessages = seedCutoff
+      ? allMessages.filter(message => (message.timestamp || 0) >= seedCutoff.timestamp)
+      : allMessages
+
+    const mentions: AgentMessage[] = []
+    const systemAlerts: AgentMessage[] = []
+    const teamMessages: AgentMessage[] = []
+    const agentPattern = new RegExp(`@${escapeRegExp(opts.agent)}\\b`, 'i')
+
+    for (const message of filteredMessages) {
+      const content = message.content || ''
+      if (message.from === 'system') systemAlerts.push(message)
+      else if (agentPattern.test(content)) mentions.push(message)
+      else teamMessages.push(message)
+    }
+
+    return {
+      allMessages,
+      filteredMessages,
+      mentions,
+      systemAlerts,
+      teamMessages,
+      seedCutoff,
+      seedFilteredCount: Math.max(0, allMessages.length - filteredMessages.length),
+    }
+  }
+
   // ── Agent context endpoint ──────────────────────────────────────────
   // Returns a compact, deduplicated view of recent chat optimized for
   // agent context injection. Includes: mentions of the agent, recent
@@ -4807,25 +4895,19 @@ export async function createServer(): Promise<FastifyInstance> {
     const strictCompact = query.compact === '1' || query.compact === 'true'
     const maxChars = Math.max(400, Math.min(Number(query.max_chars) || 1200, 8000))
 
-    const allMessages = chatManager.getMessages({
-      channel: channelFilter,
-      limit: Math.min(limit * 6, 800), // fetch more, then filter
-      since: sinceMs,
+    const {
+      allMessages,
+      mentions,
+      systemAlerts,
+      teamMessages,
+      seedCutoff,
+      seedFilteredCount,
+    } = selectAgentContextMessages({
+      agent,
+      limit,
+      channelFilter,
+      sinceMs,
     })
-
-    // Partition: mentions, system alerts, team messages
-    const mentions: typeof allMessages = []
-    const systemAlerts: typeof allMessages = []
-    const teamMessages: typeof allMessages = []
-
-    const agentPattern = new RegExp(`@${agent}\\b`, 'i')
-
-    for (const m of allMessages) {
-      const content = m.content || ''
-      if (m.from === 'system') systemAlerts.push(m)
-      else if (agentPattern.test(content)) mentions.push(m)
-      else teamMessages.push(m)
-    }
 
     const normalizeForDedup = (content: string): string => {
       return (content || '')
@@ -4981,8 +5063,18 @@ export async function createServer(): Promise<FastifyInstance> {
       suppressed: {
         system_deduped: systemAlerts.length - dedupedAlerts.length,
         total_scanned: allMessages.length,
+        seed_cutoff_filtered: seedFilteredCount,
         ...(strictCompact ? { truncated: result.length - messagesOut.length } : {}),
       },
+      ...(seedCutoff
+        ? {
+            seed_cutoff: {
+              timestamp: seedCutoff.timestamp,
+              message_id: seedCutoff.messageId,
+              source: seedCutoff.source,
+            },
+          }
+        : {}),
     }
   })
 
@@ -5006,25 +5098,19 @@ export async function createServer(): Promise<FastifyInstance> {
     const peer = (query.peer || '').trim()
     const taskIdOverride = (query.task_id || '').trim()
 
-    const allMessages = chatManager.getMessages({
-      channel: channelFilter,
-      limit: Math.min(limit * 6, 800),
-      since: sinceMs,
+    const {
+      allMessages,
+      mentions,
+      systemAlerts,
+      teamMessages,
+      seedCutoff,
+      seedFilteredCount,
+    } = selectAgentContextMessages({
+      agent,
+      limit,
+      channelFilter,
+      sinceMs,
     })
-
-    // Partition: mentions, system alerts, team messages
-    const mentions: typeof allMessages = []
-    const systemAlerts: typeof allMessages = []
-    const teamMessages: typeof allMessages = []
-
-    const agentPattern = new RegExp(`@${agent}\\b`, 'i')
-
-    for (const m of allMessages) {
-      const content = m.content || ''
-      if (m.from === 'system') systemAlerts.push(m)
-      else if (agentPattern.test(content)) mentions.push(m)
-      else teamMessages.push(m)
-    }
 
     // Deduplicate system alerts by normalized content
     const seenHashes = new Set<string>()
@@ -5088,7 +5174,17 @@ export async function createServer(): Promise<FastifyInstance> {
         selected: selected.length,
         suppressed: {
           system_deduped: systemAlerts.length - dedupedAlerts.length,
+          seed_cutoff_filtered: seedFilteredCount,
         },
+        ...(seedCutoff
+          ? {
+              seed_cutoff: {
+                timestamp: seedCutoff.timestamp,
+                message_id: seedCutoff.messageId,
+                source: seedCutoff.source,
+              },
+            }
+          : {}),
       },
     }
   })

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -5308,6 +5308,47 @@ describe('Context budget', () => {
       await fs.rm(tmp, { recursive: true, force: true }).catch(() => {})
     }
   })
+
+  it('GET /context/inject drops pre-seed stale chat before the latest canvas query for that agent', async () => {
+    const agent = `seed-cutoff-${Date.now()}`
+
+    await req('POST', '/chat/messages', {
+      from: 'sage',
+      content: `@${agent} stale failure memory says use /capture_frame surface=camera`,
+      channel: 'general',
+    })
+
+    const seed = await req('POST', '/chat/messages', {
+      from: 'kai',
+      to: agent,
+      content: `[canvas] @${agent} use the uploaded room artifact instead of capturing a fresh frame`,
+      channel: 'general',
+      metadata: {
+        source: 'canvas_query',
+        reply_via: 'canvas_push',
+        attachments: [{ name: 'proof.png', type: 'image/png', sizeBytes: 1234 }],
+      },
+    })
+    expect(seed.status).toBe(200)
+
+    await req('POST', '/chat/messages', {
+      from: 'echo',
+      content: 'Fresh room artifact is already shared in the canvas.',
+      channel: 'general',
+    })
+
+    const injected = await req('GET', `/context/inject/${agent}?limit=12&channel=general`)
+    expect(injected.status).toBe(200)
+
+    const sessionItems = injected.body.layers.session_local.items as Array<{ content: string }>
+    const contents = sessionItems.map(item => item.content)
+
+    expect(contents.some(content => content.includes('stale failure memory says use /capture_frame surface=camera'))).toBe(false)
+    expect(contents.some(content => content.includes('use the uploaded room artifact instead of capturing a fresh frame'))).toBe(true)
+    expect(contents.some(content => content.includes('Fresh room artifact is already shared in the canvas.'))).toBe(true)
+    expect(injected.body.session_source.suppressed.seed_cutoff_filtered).toBeGreaterThanOrEqual(1)
+    expect(injected.body.session_source.seed_cutoff.source).toBe('canvas_query')
+  })
 })
 
 describe('Duplicate-closure validating evidence gate', () => {


### PR DESCRIPTION
## Summary
- add a per-agent seed cutoff at the latest canvas query boundary
- filter stale pre-seed session-local chat from `/chat/context/:agent` and `/context/inject/:agent`
- add a regression proving stale `/capture_frame` guidance is excluded once fresh artifact context arrives

## Scope
- reflectt-node only
- no cloud changes
- no prompt rewrite

## Validation
- focused tests passed in a clean branch cut from `origin/main`
- `tests/api.test.ts`
- `tests/chat-context.test.ts`

## Notes
- local full build still hits unrelated existing `@sentry/node` type-resolution drift in `src/sentry.ts`
