### PR TITLE
feat(canvas): include displayName/identityColor/avatar per agent in cloud push

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -54,7 +54,7 @@ import { getFocus, setFocus, clearFocus, getFocusSummary } from './focus.js'
 import { generatePulse, generateCompactPulse } from './pulse.js'
 import { scanScopeOverlap, scanAndNotify } from './scopeOverlap.js'
 import { getDb } from './db.js'
-import { getIdentityColor, getClaimedAgentIds } from './agent-config.js'
+import { getIdentityColor, getClaimedAgentIds, getAgentConfig } from './agent-config.js'
 import type { AgentMessage, Task } from './types.js'
 import { isTestHarnessTask } from './test-task-filter.js'
 import { handleMCPRequest, handleSSERequest, handleMessagesRequest, getActiveSamplingProviders } from './mcp.js'
@@ -13111,11 +13111,38 @@ export async function createServer(): Promise<FastifyInstance> {
     // are skipped so they don't render. No new states introduced.
     const activeSlots = canvasSlots.getActive()
     const presences = presenceManager.getAllPresence()
-    const agents: Record<string, { state: string; task?: string | null }> = {}
+    const roles = getAgentRoles()
+    const roleByName = new Map(roles.map(r => [r.name.toLowerCase(), r]))
+    const agents: Record<string, {
+      state: string
+      task?: string | null
+      displayName?: string
+      identityColor?: string
+      avatar?: string
+    }> = {}
     for (const p of presences) {
       if (p.status === 'offline') continue
       const canvasState = (p.status === 'working' || p.status === 'reviewing') ? 'working' : 'ambient'
-      agents[p.agent] = { state: canvasState, task: p.task ?? null }
+      // Identity enrichment: pull each agent's claimed identity from its
+      // existing sources (role map + agent_config) so cloud renders with
+      // truth instead of hash/title-case fallbacks. Only set fields the
+      // agent has actually claimed — empty/undefined preserves the cloud's
+      // own AGENT_COLORS / agentDisplayName fallback path.
+      const role = roleByName.get(p.agent.toLowerCase())
+      const claimedColor = getIdentityColor(p.agent, '')
+      const settingsAvatar = ((): string | undefined => {
+        const cfg = getAgentConfig(p.agent)
+        const v = cfg?.settings?.avatar
+        return typeof v === 'string' && v.length > 0 ? v : undefined
+      })()
+      const avatar = role?.avatar ?? settingsAvatar
+      agents[p.agent] = {
+        state: canvasState,
+        task: p.task ?? null,
+        ...(role?.displayName ? { displayName: role.displayName } : {}),
+        ...(claimedColor ? { identityColor: claimedColor } : {}),
+        ...(avatar ? { avatar } : {}),
+      }
     }
     const state = { slots: activeSlots, agents, pushedAt: Date.now() }
     const stateJson = JSON.stringify(state)


### PR DESCRIPTION
## Summary

Identity coverage seam (audit-driven, kai+link greenlit). The node was projecting per-agent presence into `/api/hosts/:hostId/canvas` POST as `{state, task}` only — dropping `displayName` (TEAM-ROLES.yaml), `identityColor` (`agent_config.settings.identityColor`), and `avatar` (TEAM-ROLES or `agent_config.settings.avatar`) at the wire even though node already has them.

Cloud frontend already trusts payload-supplied identity over hardcoded fallbacks (`apps/web/src/components/agents-panel/AgentsPanel.tsx:60,77`, `agent-detail/AgentDetailPanel.tsx:797,1087`, `app/presence/agent-field.tsx:219`, `app/presence/agent-detail-panel.tsx:50`, `presence/canvas/visuals/ghost-trails.tsx:97`, `…/thought-arcs.tsx:75`); cloud GET passes payload through unchanged via `...payload` spread (`host-canvas-state-routes.ts:150`). So this single-function widen lights up identity end-to-end without any cloud or schema change.

Constraints honored per kai's lane lock:
- node only, one function (`pushCanvasStateToCloud` in `src/server.ts:13103`)
- 3 fields only — `displayName`, `identityColor`, `avatar`
- no watchdog special-casing
- no TEAM-ROLES / agent-config write-path changes
- no cloud or frontend edits
- no schema migrations

Unclaimed agents emit only `{state, task}` exactly as before — cloud's `AGENT_COLORS` and `agentDisplayName()` fallbacks remain authoritative for them.

## Test plan
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] Full vitest suite: 2625 passed / 7 skipped / 0 fail (243 files)
- [ ] After merge: roll canonical (`rn-34faba44-wlgkeq`) to new image
- [ ] Prove one non-watchdog agent renders truthful identity end-to-end on canvas; report which fields lit up and for which agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)