### PR TITLE
feat(room): /capture_frame replies echo originating channel

### DIFF
--- a/src/room-event-bridge.ts
+++ b/src/room-event-bridge.ts
@@ -73,6 +73,11 @@ interface RoomArtifactSharedPayload {
   }
   by: string
   hostId: string
+  // Channel the issuing /capture_frame command was posted in (#general,
+  // dm:*, or thread:*). Set by room-routes when the upload carries an
+  // `originatingChannel` field. Manual user uploads omit it — bridge
+  // falls back to `general` so behavior is unchanged for that path.
+  originatingChannel?: string
 }
 
 // Resolve the founding/default agent for this host. Same pattern used
@@ -177,11 +182,17 @@ export function initRoomEventBridge(): boolean {
       if (!line) return
 
       state.artifactCount++
+      // Command-reply locality: when the artifact came from a /capture_frame
+      // issued in a specific channel (dm:*, thread:*, or #general), echo the
+      // reply back to that same channel so command results land alongside the
+      // command. Manual user uploads carry no originatingChannel — fall back
+      // to `general` so that path is unchanged. `room_participant_joined`
+      // above stays on `general` unconditionally — joins are not replies.
       void chatManager.sendMessage({
         from: 'room',
         to: defaultAgent,
         content: line,
-        channel: 'general',
+        channel: payload.originatingChannel ?? 'general',
         metadata: {
           source: 'room-event',
           category: 'room-artifact',
@@ -191,6 +202,7 @@ export function initRoomEventBridge(): boolean {
           sharedBy: payload.by,
           sharedByDisplayName: payload.artifact.sharedByDisplayName,
           hostId: payload.hostId,
+          originatingChannel: payload.originatingChannel ?? null,
           url: payload.artifact.url,
           thumbnailUrl: payload.artifact.thumbnailUrl,
           dimensions: payload.artifact.dimensions,

--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -293,6 +293,14 @@ export async function roomRoutes(app: FastifyInstance) {
     const kind = typeof fields.kind?.value === 'string' ? (fields.kind.value as string) : undefined
     const sharedBy = typeof fields.sharedBy?.value === 'string' ? (fields.sharedBy.value as string) : undefined
     const sharedByDisplayName = typeof fields.sharedByDisplayName?.value === 'string' ? (fields.sharedByDisplayName.value as string) : undefined
+    // Originating channel = the chat channel the issuing /capture_frame
+    // command was posted in (`#general`, `dm:*`, or `thread:*`). Threaded
+    // through so the artifact-shared bridge can echo the reply back to the
+    // same channel instead of always landing in `#general`. Manual user
+    // uploads don't send this field; bridge falls back to `general`.
+    const originatingChannel = typeof fields.originatingChannel?.value === 'string'
+      ? (fields.originatingChannel.value as string).trim() || undefined
+      : undefined
 
     if (!kind || !ALLOWED_KINDS_V0.has(kind)) {
       reply.status(400)
@@ -366,7 +374,7 @@ export async function roomRoutes(app: FastifyInstance) {
       id: `room-artifact-${updated.id}`,
       type: 'room_artifact_shared',
       timestamp: Date.now(),
-      data: { artifact: projected, by: sharedBy, hostId },
+      data: { artifact: projected, by: sharedBy, hostId, originatingChannel },
     })
 
     // Realtime fan-out: cloud subscribers (other participants) refresh

--- a/tests/room-event-bridge.test.ts
+++ b/tests/room-event-bridge.test.ts
@@ -271,6 +271,104 @@ describe('room-event-bridge', () => {
     expect(getRoomEventBridgeStatus().artifactCount).toBe(0)
   })
 
+  // Command-reply locality: when an artifact event carries an
+  // `originatingChannel` (set by room-routes when the upload form has the
+  // field — only `/capture_frame` does today), the bridge echoes the reply
+  // back to that same channel. Manual user uploads omit the field and
+  // continue to land in `#general` (covered by the snapshot test above).
+  it('echoes originatingChannel when present (dm:* in → dm:* out)', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-evt-dm',
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: {
+        artifact: {
+          id: 'art-dm-789',
+          kind: 'camera-snapshot',
+          name: 'cam.png',
+          mimeType: 'image/png',
+          sizeBytes: 11111,
+          createdAt: Date.now(),
+          sharedBy: 'self',
+          sharedByDisplayName: 'Frame for compass',
+          dimensions: { width: 640, height: 480 },
+          url: 'https://cdn.example/art-dm-789.png',
+          thumbnailUrl: 'https://cdn.example/art-dm-789.thumb.png',
+        },
+        by: 'self',
+        hostId: 'host-1',
+        originatingChannel: 'dm:compass_user',
+      },
+    })
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.channel).toBe('dm:compass_user')
+    expect(call.metadata.originatingChannel).toBe('dm:compass_user')
+  })
+
+  it('echoes originatingChannel when present (thread:* in → thread:* out)', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-evt-thread',
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: {
+        artifact: {
+          id: 'art-thread-321',
+          kind: 'camera-snapshot',
+          name: 'cam.png',
+          mimeType: 'image/png',
+          sizeBytes: 22222,
+          createdAt: Date.now(),
+          sharedBy: 'self',
+          sharedByDisplayName: 'Frame for compass',
+          dimensions: { width: 640, height: 480 },
+          url: 'https://cdn.example/art-thread-321.png',
+          thumbnailUrl: 'https://cdn.example/art-thread-321.thumb.png',
+        },
+        by: 'self',
+        hostId: 'host-1',
+        originatingChannel: 'thread:msg-1777829-abc',
+      },
+    })
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.channel).toBe('thread:msg-1777829-abc')
+    expect(call.metadata.originatingChannel).toBe('thread:msg-1777829-abc')
+  })
+
+  it('falls back to #general when originatingChannel is missing (manual user upload)', () => {
+    initRoomEventBridge()
+    eventBus.emit({
+      id: 'art-evt-manual',
+      type: 'room_artifact_shared',
+      timestamp: Date.now(),
+      data: {
+        artifact: {
+          id: 'art-manual-555',
+          kind: 'snapshot',
+          name: 'screen.png',
+          mimeType: 'image/png',
+          sizeBytes: 33333,
+          createdAt: Date.now(),
+          sharedBy: 'session-abc-123',
+          sharedByDisplayName: 'Ryan',
+          dimensions: { width: 1920, height: 1080 },
+          url: 'https://cdn.example/art-manual-555.png',
+          thumbnailUrl: 'https://cdn.example/art-manual-555.thumb.png',
+        },
+        by: 'session-abc-123',
+        hostId: 'host-1',
+        // originatingChannel intentionally omitted
+      },
+    })
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    const call = sendMessageMock.mock.calls[0][0]
+    expect(call.channel).toBe('general')
+    expect(call.metadata.originatingChannel).toBeNull()
+  })
+
   it('ignores artifact events with no kind or no id', () => {
     initRoomEventBridge()
     eventBus.emit({


### PR DESCRIPTION
## Summary

- Threads `originatingChannel` from the `/room/artifacts` multipart upload through `room_artifact_shared` events
- `room-event-bridge` posts the artifact-shared chat reply to that channel (`dm:*`, `thread:*`, or `#general`) instead of always `#general`
- Manual user uploads omit the field — fallback is `'general'`, so that path is unchanged

Pairs with reflectt-cloud `feat/command-reply-locality-cloud` which sets the field on the upload.

## Test plan

- [x] 13/13 `vitest` (3 new bridge tests: dm: → dm:, thread: → thread:, missing → general)
- [x] Clean `tsc --noEmit`
- [ ] Roll canonical staging host with new image
- [ ] Live 3-check on canonical (`e4e35463-…`): `/capture_frame` in `dm:`, `thread:`, `#general` lands in matching channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)