### PR TITLE
feat(mcp): add next_event to get_heartbeat — confirmed event in next 24h or null

### DIFF
--- a/src/calendar-events.ts
+++ b/src/calendar-events.ts
@@ -824,6 +824,31 @@ export function getAgentNextEvent(agent: string, atMs?: number): { event: Calend
   return earliest
 }
 
+export interface HeartbeatNextEvent {
+  id: string
+  title: string
+  starts_at: number
+  starts_at_iso: string
+}
+
+// MCP get_heartbeat surface: single confirmed event whose next occurrence falls
+// in [now, now + 24h]. Reuses getAgentNextEvent (which already filters
+// status='confirmed' and walks both attendee + organizer) and clamps its 7-day
+// window to 24h here. Same source the team-calendar-store-backed canvas panel
+// reads from, so heartbeat and panel cannot diverge.
+export function getNextEventForHeartbeat(agent: string, atMs?: number): HeartbeatNextEvent | null {
+  const now = atMs ?? Date.now()
+  const upcoming = getAgentNextEvent(agent, now)
+  if (!upcoming) return null
+  if (upcoming.starts_at - now > 24 * 60 * 60 * 1000) return null
+  return {
+    id: upcoming.event.id,
+    title: upcoming.event.summary,
+    starts_at: upcoming.starts_at,
+    starts_at_iso: new Date(upcoming.starts_at).toISOString(),
+  }
+}
+
 // ── Export singleton ───────────────────────────────────────────────────────
 
 export const calendarEvents = {
@@ -838,6 +863,7 @@ export const calendarEvents = {
   markReminderFired,
   getAgentCurrentEvent,
   getAgentNextEvent,
+  getNextEventForHeartbeat,
   getOccurrences,
   parseRRule,
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -356,7 +356,7 @@ tool(
 
 tool(
   "get_heartbeat",
-  "Get your agent heartbeat — active task, inbox count, queue state, and recommended action. The single most efficient call for staying oriented.",
+  "Get your agent heartbeat — active task, inbox count, queue state, next confirmed calendar event in the next 24h, and recommended action. The single most efficient call for staying oriented.",
   {
     agent: z.string().describe("Your agent name (e.g. 'claude')"),
   },
@@ -365,6 +365,7 @@ tool(
     const inbox = inboxManager.getInbox(agent, allMessages, { limit: 10 })
     const activeTasks = taskManager.listTasks({ status: "doing", assignee: agent })
     const nextTask = taskManager.getNextTask(agent)
+    const next_event = calendarEvents.getNextEventForHeartbeat(agent)
     const queue = {
       todo: taskManager.listTasks({ status: "todo", assignee: agent }).length,
       doing: activeTasks.length,
@@ -380,7 +381,7 @@ tool(
     return {
       content: [{
         type: "text",
-        text: JSON.stringify({ agent, ts: Date.now(), inbox, inboxCount: inbox.length, active: activeTasks[0] ?? null, next: nextTask ?? null, queue, action })
+        text: JSON.stringify({ agent, ts: Date.now(), inbox, inboxCount: inbox.length, active: activeTasks[0] ?? null, next: nextTask ?? null, next_event, queue, action })
       }]
     }
   }
@@ -1002,6 +1003,7 @@ function initToolHandlers() {
       const inbox = inboxManager.getInbox(args.agent, allMessages, { limit: 10 })
       const activeTasks = taskManager.listTasks({ status: "doing", assignee: args.agent })
       const nextTask = taskManager.getNextTask(args.agent)
+      const next_event = calendarEvents.getNextEventForHeartbeat(args.agent)
       const queue = {
         todo: taskManager.listTasks({ status: "todo", assignee: args.agent }).length,
         doing: activeTasks.length,
@@ -1012,7 +1014,7 @@ function initToolHandlers() {
         : activeTasks.length > 0
           ? `Continue task: ${activeTasks[0]?.title}`
           : nextTask ? `Pick up next task: ${nextTask.title}` : "IDLE"
-      return { content: [{ type: "text", text: JSON.stringify({ agent: args.agent, ts: Date.now(), inbox, inboxCount: inbox.length, active: activeTasks[0] ?? null, next: nextTask ?? null, queue, action }) }] }
+      return { content: [{ type: "text", text: JSON.stringify({ agent: args.agent, ts: Date.now(), inbox, inboxCount: inbox.length, active: activeTasks[0] ?? null, next: nextTask ?? null, next_event, queue, action }) }] }
     },
   })
 

--- a/tests/calendar-events.test.ts
+++ b/tests/calendar-events.test.ts
@@ -367,6 +367,80 @@ describe('Calendar Events', () => {
     })
   })
 
+  describe('getNextEventForHeartbeat', () => {
+    it('returns confirmed next event within 24h with shaped payload', () => {
+      const now = Date.now()
+      const startsAt = now + 2 * 60 * 60 * 1000 // +2h
+      calendarEvents.createEvent({
+        summary: 'Standup',
+        dtstart: startsAt,
+        dtend: startsAt + 30 * 60_000,
+        organizer: 'ryan',
+        attendees: [{ name: 'link', status: 'accepted' }],
+      })
+
+      const result = calendarEvents.getNextEventForHeartbeat('link', now)
+      expect(result).not.toBeNull()
+      expect(result!.title).toBe('Standup')
+      expect(result!.starts_at).toBe(startsAt)
+      expect(result!.starts_at_iso).toBe(new Date(startsAt).toISOString())
+      expect(result!.id).toMatch(/^evt-/)
+    })
+
+    it('returns null when next event is beyond the 24h window', () => {
+      const now = Date.now()
+      calendarEvents.createEvent({
+        summary: 'Three days out',
+        dtstart: now + 3 * 24 * 60 * 60 * 1000,
+        dtend: now + 3 * 24 * 60 * 60 * 1000 + 30 * 60_000,
+        organizer: 'ryan',
+        attendees: [{ name: 'link', status: 'accepted' }],
+      })
+
+      expect(calendarEvents.getNextEventForHeartbeat('link', now)).toBeNull()
+    })
+
+    it('skips cancelled events even when in window', () => {
+      const now = Date.now()
+      calendarEvents.createEvent({
+        summary: 'Cancelled',
+        dtstart: now + 60 * 60_000,
+        dtend: now + 90 * 60_000,
+        organizer: 'ryan',
+        attendees: [{ name: 'link', status: 'accepted' }],
+        status: 'cancelled',
+      })
+
+      expect(calendarEvents.getNextEventForHeartbeat('link', now)).toBeNull()
+    })
+
+    it('returns null when agent has no events at all', () => {
+      expect(calendarEvents.getNextEventForHeartbeat('ghost', Date.now())).toBeNull()
+    })
+
+    it('picks the earlier of multiple in-window events', () => {
+      const now = Date.now()
+      calendarEvents.createEvent({
+        summary: 'Later same day',
+        dtstart: now + 8 * 60 * 60_000,
+        dtend: now + 9 * 60 * 60_000,
+        organizer: 'ryan',
+        attendees: [{ name: 'link', status: 'accepted' }],
+      })
+      calendarEvents.createEvent({
+        summary: 'Earlier same day',
+        dtstart: now + 90 * 60_000,
+        dtend: now + 120 * 60_000,
+        organizer: 'ryan',
+        attendees: [{ name: 'link', status: 'accepted' }],
+      })
+
+      const result = calendarEvents.getNextEventForHeartbeat('link', now)
+      expect(result).not.toBeNull()
+      expect(result!.title).toBe('Earlier same day')
+    })
+  })
+
   describe('Reminders', () => {
     it('returns pending reminder when window opens', () => {
       const now = Date.now()


### PR DESCRIPTION
## Summary

Follow-up to PR #3198 (cloud canvas Calendar panel). Per kai (msg-1777837350565): \"add \`next_event\` to MCP \`get_heartbeat\` so agents get the same now/next truth in their orient path.\"

**Bar:**
- node-only ✅
- read-only ✅
- single confirmed event in next 24h, or \`null\` ✅
- no calendar command surface ✅
- no reminder-engine changes ✅

## What changed

- \`src/calendar-events.ts\`: new \`getNextEventForHeartbeat(agent, atMs?)\` helper that reuses \`getAgentNextEvent\` (already filters \`status='confirmed'\` across attendee + organizer paths) and clamps the 7-day default down to 24h.
- \`src/mcp.ts\`: both \`get_heartbeat\` registration sites (SDK \`tool()\` macro + SSE \`toolHandlers.set\`) now include \`next_event\` in the payload alongside \`next\`.
- \`tests/calendar-events.test.ts\`: 5 new unit tests covering in-window/out-of-window/cancelled/no-events/earliest-of-many.

## Payload shape

\`\`\`json
{
  \"agent\": \"claude\",
  \"ts\": 1777837500000,
  \"inbox\": [...],
  \"inboxCount\": 0,
  \"active\": null,
  \"next\": { \"id\": \"task-...\", \"title\": \"...\" },
  \"next_event\": {
    \"id\": \"evt-...\",
    \"title\": \"Standup\",
    \"starts_at\": 1777841100000,
    \"starts_at_iso\": \"2026-05-03T20:45:00.000Z\"
  },
  \"queue\": { \"todo\": 0, \"doing\": 0, \"validating\": 0 },
  \"action\": \"IDLE\"
}
\`\`\`

\`next_event\` is \`null\` when the agent has no confirmed event in the next 24h.

## Test plan

- [x] \`npx vitest run tests/calendar-events.test.ts\` — 37 pass (5 new + 32 existing)
- [x] \`npx tsc --noEmit\` — clean
- [ ] CI green