### PR TITLE
feat(mcp): heartbeat next_event reads from cloud (canvas-truth alignment)

### DIFF
--- a/src/calendar-events.ts
+++ b/src/calendar-events.ts
@@ -10,6 +10,7 @@
 
 import { getDb } from './db.js'
 import { eventBus } from './events.js'
+import { cloudGet } from './cloud.js'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -831,21 +832,32 @@ export interface HeartbeatNextEvent {
   starts_at_iso: string
 }
 
-// MCP get_heartbeat surface: single confirmed event whose next occurrence falls
-// in [now, now + 24h]. Reuses getAgentNextEvent (which already filters
-// status='confirmed' and walks both attendee + organizer) and clamps its 7-day
-// window to 24h here. Same source the team-calendar-store-backed canvas panel
-// reads from, so heartbeat and panel cannot diverge.
-export function getNextEventForHeartbeat(agent: string, atMs?: number): HeartbeatNextEvent | null {
-  const now = atMs ?? Date.now()
-  const upcoming = getAgentNextEvent(agent, now)
-  if (!upcoming) return null
-  if (upcoming.starts_at - now > 24 * 60 * 60 * 1000) return null
+// MCP get_heartbeat surface: returns the next event from the canonical cloud
+// Supabase calendar store (same source the canvas CalendarPanel reads), so
+// heartbeat and panel cannot diverge. Reads via host-credential auth on
+// GET /api/hosts/:hostId/calendar/upcoming?days=1.
+//
+// Returns null on any failure (auth, network, empty list, etc.) — the panel's
+// "honest empty" rule applies here too. See docs/HEARTBEAT_CALENDAR_TRUTH_V0.md
+// in reflectt-cloud (approved by kai msg-1777840126026).
+export async function getNextEventForHeartbeat(hostId: string): Promise<HeartbeatNextEvent | null> {
+  if (!hostId || hostId === 'unknown') return null
+
+  const resp = await cloudGet<{ events?: Array<{ id: string; title: string; start: string }> }>(
+    `/api/hosts/${encodeURIComponent(hostId)}/calendar/upcoming?days=1`,
+  )
+  if (!resp.success || !resp.data?.events?.length) return null
+
+  const first = resp.data.events[0]
+  if (!first?.id || !first.title || !first.start) return null
+  const startsMs = Date.parse(first.start)
+  if (!Number.isFinite(startsMs)) return null
+
   return {
-    id: upcoming.event.id,
-    title: upcoming.event.summary,
-    starts_at: upcoming.starts_at,
-    starts_at_iso: new Date(upcoming.starts_at).toISOString(),
+    id: first.id,
+    title: first.title,
+    starts_at: startsMs,
+    starts_at_iso: new Date(startsMs).toISOString(),
   }
 }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -365,7 +365,8 @@ tool(
     const inbox = inboxManager.getInbox(agent, allMessages, { limit: 10 })
     const activeTasks = taskManager.listTasks({ status: "doing", assignee: agent })
     const nextTask = taskManager.getNextTask(agent)
-    const next_event = calendarEvents.getNextEventForHeartbeat(agent)
+    const hostId = process.env.REFLECTT_HOST_ID || process.env.HOSTNAME || ''
+    const next_event = await calendarEvents.getNextEventForHeartbeat(hostId)
     const queue = {
       todo: taskManager.listTasks({ status: "todo", assignee: agent }).length,
       doing: activeTasks.length,
@@ -1003,7 +1004,8 @@ function initToolHandlers() {
       const inbox = inboxManager.getInbox(args.agent, allMessages, { limit: 10 })
       const activeTasks = taskManager.listTasks({ status: "doing", assignee: args.agent })
       const nextTask = taskManager.getNextTask(args.agent)
-      const next_event = calendarEvents.getNextEventForHeartbeat(args.agent)
+      const hostId = process.env.REFLECTT_HOST_ID || process.env.HOSTNAME || ''
+      const next_event = await calendarEvents.getNextEventForHeartbeat(hostId)
       const queue = {
         todo: taskManager.listTasks({ status: "todo", assignee: args.agent }).length,
         doing: activeTasks.length,

--- a/tests/calendar-events.test.ts
+++ b/tests/calendar-events.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { calendarEvents } from '../src/calendar-events.js'
+import * as cloud from '../src/cloud.js'
 
 function clearAllEvents() {
   const events = calendarEvents.listEvents({ limit: 500 })
@@ -367,77 +368,77 @@ describe('Calendar Events', () => {
     })
   })
 
-  describe('getNextEventForHeartbeat', () => {
-    it('returns confirmed next event within 24h with shaped payload', () => {
-      const now = Date.now()
-      const startsAt = now + 2 * 60 * 60 * 1000 // +2h
-      calendarEvents.createEvent({
-        summary: 'Standup',
-        dtstart: startsAt,
-        dtend: startsAt + 30 * 60_000,
-        organizer: 'ryan',
-        attendees: [{ name: 'link', status: 'accepted' }],
+  describe('getNextEventForHeartbeat (cloud-sourced)', () => {
+    // The heartbeat next_event field reads from the canonical cloud Supabase
+    // calendar store via GET /api/hosts/:hostId/calendar/upcoming?days=1, so it
+    // matches the canvas CalendarPanel exactly. These tests mock cloudGet to
+    // exercise the response-shape mapping and the null-on-failure contract.
+
+    it('shapes events[0] from a cloud success into HeartbeatNextEvent', async () => {
+      const startsIso = new Date(Date.now() + 2 * 60 * 60_000).toISOString()
+      const spy = vi.spyOn(cloud, 'cloudGet').mockResolvedValue({
+        success: true,
+        data: { events: [
+          { id: 'evt-cloud-1', title: 'Standup', start: startsIso },
+          { id: 'evt-cloud-2', title: 'Later', start: new Date(Date.now() + 5 * 60 * 60_000).toISOString() },
+        ] },
       })
 
-      const result = calendarEvents.getNextEventForHeartbeat('link', now)
+      const result = await calendarEvents.getNextEventForHeartbeat('host-abc')
+      expect(spy).toHaveBeenCalledWith('/api/hosts/host-abc/calendar/upcoming?days=1')
       expect(result).not.toBeNull()
+      expect(result!.id).toBe('evt-cloud-1')
       expect(result!.title).toBe('Standup')
-      expect(result!.starts_at).toBe(startsAt)
-      expect(result!.starts_at_iso).toBe(new Date(startsAt).toISOString())
-      expect(result!.id).toMatch(/^evt-/)
+      expect(result!.starts_at).toBe(Date.parse(startsIso))
+      expect(result!.starts_at_iso).toBe(new Date(Date.parse(startsIso)).toISOString())
+      spy.mockRestore()
     })
 
-    it('returns null when next event is beyond the 24h window', () => {
-      const now = Date.now()
-      calendarEvents.createEvent({
-        summary: 'Three days out',
-        dtstart: now + 3 * 24 * 60 * 60 * 1000,
-        dtend: now + 3 * 24 * 60 * 60 * 1000 + 30 * 60_000,
-        organizer: 'ryan',
-        attendees: [{ name: 'link', status: 'accepted' }],
+    it('returns null when cloud returns an empty events list', async () => {
+      const spy = vi.spyOn(cloud, 'cloudGet').mockResolvedValue({
+        success: true,
+        data: { events: [] },
       })
-
-      expect(calendarEvents.getNextEventForHeartbeat('link', now)).toBeNull()
+      expect(await calendarEvents.getNextEventForHeartbeat('host-abc')).toBeNull()
+      spy.mockRestore()
     })
 
-    it('skips cancelled events even when in window', () => {
-      const now = Date.now()
-      calendarEvents.createEvent({
-        summary: 'Cancelled',
-        dtstart: now + 60 * 60_000,
-        dtend: now + 90 * 60_000,
-        organizer: 'ryan',
-        attendees: [{ name: 'link', status: 'accepted' }],
-        status: 'cancelled',
+    it('returns null when cloud call fails (auth, network, etc.)', async () => {
+      const spy = vi.spyOn(cloud, 'cloudGet').mockResolvedValue({
+        success: false,
+        error: 'HTTP 401',
       })
-
-      expect(calendarEvents.getNextEventForHeartbeat('link', now)).toBeNull()
+      expect(await calendarEvents.getNextEventForHeartbeat('host-abc')).toBeNull()
+      spy.mockRestore()
     })
 
-    it('returns null when agent has no events at all', () => {
-      expect(calendarEvents.getNextEventForHeartbeat('ghost', Date.now())).toBeNull()
+    it('returns null when hostId is empty or unresolved', async () => {
+      const spy = vi.spyOn(cloud, 'cloudGet')
+      expect(await calendarEvents.getNextEventForHeartbeat('')).toBeNull()
+      expect(await calendarEvents.getNextEventForHeartbeat('unknown')).toBeNull()
+      expect(spy).not.toHaveBeenCalled()
+      spy.mockRestore()
     })
 
-    it('picks the earlier of multiple in-window events', () => {
-      const now = Date.now()
-      calendarEvents.createEvent({
-        summary: 'Later same day',
-        dtstart: now + 8 * 60 * 60_000,
-        dtend: now + 9 * 60 * 60_000,
-        organizer: 'ryan',
-        attendees: [{ name: 'link', status: 'accepted' }],
+    it('returns null on malformed payloads (missing fields, bad date)', async () => {
+      const spy = vi.spyOn(cloud, 'cloudGet').mockResolvedValue({
+        success: true,
+        data: { events: [{ id: 'evt-1', title: 'Bad', start: 'not-a-date' }] },
       })
-      calendarEvents.createEvent({
-        summary: 'Earlier same day',
-        dtstart: now + 90 * 60_000,
-        dtend: now + 120 * 60_000,
-        organizer: 'ryan',
-        attendees: [{ name: 'link', status: 'accepted' }],
-      })
+      expect(await calendarEvents.getNextEventForHeartbeat('host-abc')).toBeNull()
+      spy.mockRestore()
+    })
 
-      const result = calendarEvents.getNextEventForHeartbeat('link', now)
-      expect(result).not.toBeNull()
-      expect(result!.title).toBe('Earlier same day')
+    it('url-encodes hostId to defend against unusual characters', async () => {
+      const spy = vi.spyOn(cloud, 'cloudGet').mockResolvedValue({
+        success: true,
+        data: { events: [] },
+      })
+      await calendarEvents.getNextEventForHeartbeat('host with spaces/and?chars')
+      expect(spy).toHaveBeenCalledWith(
+        '/api/hosts/host%20with%20spaces%2Fand%3Fchars/calendar/upcoming?days=1',
+      )
+      spy.mockRestore()
     })
   })
 


### PR DESCRIPTION
## Summary
- `get_heartbeat.next_event` now reads from the canonical cloud Supabase calendar store via host-credential auth (`GET /api/hosts/:hostId/calendar/upcoming?days=1`) — same source the canvas CalendarPanel uses, so the two surfaces cannot diverge.
- `getNextEventForHeartbeat` is async + takes `hostId` (not agent name); shapes `events[0]` into the existing `HeartbeatNextEvent` type. Returns `null` on any failure (auth, network, empty list, bad payload, unresolved hostId) — kai's locked answer for the empty case (msg-1777840126026).
- Both heartbeat call sites (SDK macro + SSE handler) await the new helper and resolve hostId from `REFLECTT_HOST_ID`/`HOSTNAME`.
- `next_event` field shape unchanged: `{id, title, starts_at, starts_at_iso} | null`.

## Companion PR
[reflectt-cloud#3200](https://github.com/reflectt/reflectt-cloud/pull/3200) — adds `/api/hosts/:hostId/calendar/upcoming` to the host-machine `ROUTE_TABLE` so credential auth fires for this read. Must merge + deploy first; until then, the heartbeat call returns `null` (no regression vs the previous SQLite path's empty case).

## Scope lock (kai msg-1777840126026)
- Same cloud truth as canvas
- Same `next_event` field name
- Event object or `null`
- Nothing else moves (no writes, no sync, no reminders, no RRULE, no Google/Outlook)

## Test plan
- [x] `npm test` — 2647/2647 pass (1 skipped, 1 pre-existing flake in `bridge-dedup-fix.test.ts` unrelated)
- [x] `npm run build` (tsc) — clean
- [ ] After both PRs merge: roll canonical staging host `e4e35463-…` and call `mcp__reflectt__get_heartbeat` to confirm `next_event` matches what the canvas CalendarPanel shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)