### PR TITLE
feat(room): surface commandId/requestedBy on artifact API

### DIFF
--- a/src/room-routes.ts
+++ b/src/room-routes.ts
@@ -84,6 +84,13 @@ function projectArtifact(art: Artifact): Record<string, unknown> {
     sharedBy: (meta.sharedBy as string | undefined) ?? null,
     sharedByDisplayName: (meta.sharedByDisplayName as string | undefined) ?? null,
     dimensions: (meta.dimensions as { width: number; height: number } | undefined) ?? null,
+    // Agent-issued /capture_frame stamps these on POST so the cloud chat
+    // panel's inline command card can pair the artifact with its raw
+    // `/capture_frame` request line via commandId (= chat msg id).
+    // Optional — user-shared artifacts (modal upload) carry no command
+    // provenance and these stay undefined.
+    commandId: (meta.commandId as string | undefined) ?? undefined,
+    requestedBy: (meta.requestedBy as string | undefined) ?? undefined,
     url: `/room/artifacts/${art.id}/content`,
     thumbnailUrl: `/room/artifacts/${art.id}/thumbnail`,
   }
@@ -301,6 +308,16 @@ export async function roomRoutes(app: FastifyInstance) {
     const originatingChannel = typeof fields.originatingChannel?.value === 'string'
       ? (fields.originatingChannel.value as string).trim() || undefined
       : undefined
+    // Agent /capture_frame uploader stamps these so the cloud chat panel
+    // can pair the resulting artifact with its raw `/capture_frame`
+    // request line via commandId (= chat msg id from intake.ts). Optional
+    // — modal user uploads omit them.
+    const commandId = typeof fields.commandId?.value === 'string'
+      ? (fields.commandId.value as string).trim() || undefined
+      : undefined
+    const requestedBy = typeof fields.requestedBy?.value === 'string'
+      ? (fields.requestedBy.value as string).trim() || undefined
+      : undefined
 
     if (!kind || !ALLOWED_KINDS_V0.has(kind)) {
       reply.status(400)
@@ -337,6 +354,8 @@ export async function roomRoutes(app: FastifyInstance) {
         roomId: hostId,
         sharedBy,
         sharedByDisplayName,
+        ...(commandId ? { commandId } : {}),
+        ...(requestedBy ? { requestedBy } : {}),
       },
     })
 


### PR DESCRIPTION
## Summary

Additive node-side change to expose two existing-but-stripped metadata fields on the room-artifact API.

- `POST /room/artifacts` now extracts optional multipart fields `commandId` and `requestedBy` (both strings) and stamps them into stored metadata
- `GET /room/artifacts` projects both fields on the wire so cloud consumers can read them

## Why

Cloud chat panel slice (reflectt-cloud PR #3201) renders an inline command card beneath agent-issued `/capture_frame` chat lines, pairing the raw request line with its produced artifact via `commandId === chat message id` (per `apps/api/src/domains/command/intake.ts`). Staging probe confirmed two structural gaps on the node side:

1. POST handler wasn't extracting `commandId`/`requestedBy` from multipart at all → never persisted
2. `projectArtifact()` didn't surface them on the wire even when present

This patch closes both. Modal user uploads omit both fields and remain unaffected.

## Scope guard

- Wire shape only; no schema migration, no broadcast change
- Both fields strictly optional; missing → `undefined` on read
- Lane: `/capture_frame` only (kai lock msg-1777841976155)

## Test plan

- [x] `npm test` — 2647 pass / 1 unrelated env-teardown skip
- [ ] Roll canonical staging machine `568354e7ad5348` once merged
- [ ] Real-device proof drives reflectt-cloud PR #3201 (pending → fulfilled → lightbox)