### PR TITLE
feat(canvas-sync): derive voiceCapable + voiceId from agent_config.settings.voice

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -1520,7 +1520,7 @@ async function syncCanvas(): Promise<void> {
   try {
     const db = getDb()
     const settingsRows = db.prepare(
-      "SELECT agent_id, settings FROM agent_config WHERE settings LIKE '%avatar%' OR settings LIKE '%identityColor%'"
+      "SELECT agent_id, settings FROM agent_config WHERE settings LIKE '%avatar%' OR settings LIKE '%identityColor%' OR settings LIKE '%voice%'"
     ).all() as Array<{ agent_id: string; settings: string }>
     const displayNameByAgent = new Map<string, string>()
     for (const role of getAgentRoles()) {
@@ -1531,10 +1531,16 @@ async function syncCanvas(): Promise<void> {
     for (const row of settingsRows) {
       if (!agents[row.agent_id]) continue
       try {
-        const s = JSON.parse(row.settings) as { avatar?: { content?: string }; identityColor?: string }
+        const s = JSON.parse(row.settings) as { avatar?: { content?: string }; identityColor?: string; voice?: string }
         const target = agents[row.agent_id] as Record<string, unknown>
         if (s.avatar?.content) target.avatar = s.avatar.content
         if (typeof s.identityColor === 'string' && s.identityColor) target.identityColor = s.identityColor
+        // voiceCapable: agent has claimed a kokoro voice (settings.voice non-empty string).
+        // Read by web AgentPresence.voiceCapable to gate Speak row + 🎤 badge.
+        if (typeof s.voice === 'string' && s.voice.trim()) {
+          target.voiceCapable = true
+          target.voiceId = s.voice.trim()
+        }
       } catch { /* skip malformed settings */ }
     }
     // Inject displayName for every agent in payload that has a TEAM-ROLES entry,


### PR DESCRIPTION
## Summary
- `voiceCapable` was a phantom — defined on `AgentPresence` (cloud), read by the 🎤 header badge + agents-panel badge + my new Speak row in `AgentDetailPanel.tsx`, but never produced anywhere. Every consumer fell to `?? false` and the badge was dead code.
- Truth source already exists: `agent_config.settings.voice` (kokoro voice ID — see `canvas-interactive.ts` hashTts and `assignment.ts`). Same shape as `identityColor`/`avatar` injection.
- This patch extends the SQL filter in `syncCanvas` to also include rows with `voice` in settings, then injects `voiceCapable: true` + `voiceId` on the agent shape pushed to cloud.
- Cloud passes payload through unchanged (`host-canvas-state-routes.ts` spreads `row.payload`), so this single node-side change makes the boolean real end-to-end.

## Why this is a 1-file change
Cloud is already pass-through. `apps/web/src/app/presence/use-host-state.ts:340,464` already maps `voiceCapable: a.voiceCapable ?? false` and `voiceId: a.voiceId`. The whole chain was waiting on the producer.

## Verified canonical baseline
Curled `/api/hosts/e4e35463…/agent-configs` — compass has `settings.voice = "af_sarah"`. Once this rolls, compass will be the lit-row test case for the speak V0 lane.

## Test plan
- [x] tsc clean (`npx tsc --noEmit`)
- [ ] After merge: roll canonical to new node image
- [ ] Curl `/api/hosts/.../canvas` post-roll — confirm `agents.compass.voiceCapable === true` + `voiceId === "af_sarah"`
- [ ] Then re-prove cloud-side speak V0 row (#3230) on canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)