### PR TITLE
fix(canvas-sync): mirror voiceCapable+voiceId in pushCanvasStateToCloud

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13119,6 +13119,8 @@ export async function createServer(): Promise<FastifyInstance> {
       displayName?: string
       identityColor?: string
       avatar?: string
+      voiceCapable?: boolean
+      voiceId?: string
     }> = {}
     for (const p of presences) {
       if (p.status === 'offline') continue
@@ -13128,12 +13130,21 @@ export async function createServer(): Promise<FastifyInstance> {
       // truth instead of hash/title-case fallbacks. Only set fields the
       // agent has actually claimed — empty/undefined preserves the cloud's
       // own AGENT_COLORS / agentDisplayName fallback path.
+      // Mirror the same enrichment as cloud.ts:1531 syncCanvas — both
+      // writers POST to the same host_canvas_state row, so they must
+      // agree on payload shape or the later writer strips fields the
+      // earlier one set (e.g. voiceCapable from a 30s-cadence syncCanvas
+      // gets clobbered by this 5s-cadence push).
       const role = roleByName.get(p.agent.toLowerCase())
       const claimedColor = getIdentityColor(p.agent, '')
+      const cfg = getAgentConfig(p.agent)
       const settingsAvatar = ((): string | undefined => {
-        const cfg = getAgentConfig(p.agent)
         const v = cfg?.settings?.avatar
         return typeof v === 'string' && v.length > 0 ? v : undefined
+      })()
+      const settingsVoice = ((): string | undefined => {
+        const v = cfg?.settings?.voice
+        return typeof v === 'string' && v.trim() ? v.trim() : undefined
       })()
       const avatar = role?.avatar ?? settingsAvatar
       agents[p.agent] = {
@@ -13142,6 +13153,7 @@ export async function createServer(): Promise<FastifyInstance> {
         ...(role?.displayName ? { displayName: role.displayName } : {}),
         ...(claimedColor ? { identityColor: claimedColor } : {}),
         ...(avatar ? { avatar } : {}),
+        ...(settingsVoice ? { voiceCapable: true, voiceId: settingsVoice } : {}),
       }
     }
     const state = { slots: activeSlots, agents, pushedAt: Date.now() }


### PR DESCRIPTION
## Summary

Two node writers POST to `/api/hosts/:id/canvas`:
- `src/cloud.ts:1558` syncCanvas (~30s cadence) — sets `voiceCapable` via the PR #1330 truth seam from `agent_config.settings.voice`
- `src/server.ts:13151` pushCanvasStateToCloud (5s cadence) — sent only `{state, task, displayName, identityColor, avatar}`

The cloud POST handler at `apps/api/src/host-canvas-state-routes.ts:89-99` writes `payload: agentState as object` — full replace, not merge. So the 5s writer was clobbering `voiceCapable`/`voiceId` set by the 30s syncCanvas. Compass on canonical was observed flipping `voiceCapable` true → false → true on each cycle.

## Patch

Extend the 5s writer to mirror writer #1's voice derivation from the same `agent_config.settings.voice` source. Both writers now agree on payload shape, so the later writer preserves what the earlier one set.

13 lines, one file. Build clean.

## Why this and not a cloud-side merge

Cloud-side merge in the POST handler would also fix it, but `(c) every writer sends canonical shape` is the right invariant for now — it stays explicit about the source of truth for each field. Flagged the structural fragility (two writers + full-replace POST) to @kai separately for a follow-up lane.

## Unblocks

reflectt-cloud PR #3230 — speak visibility V0. Once this merges and canonical rolls, the speak proof spec can prove compass lit / others honestly blocked.

## Test plan

- [ ] Build clean (verified locally — `npm run build` passes)
- [ ] After merge + canonical roll, GET `/api/hosts/{canonical}/canvas` returns `compass.voiceCapable=true, voiceId='af_sarah'` and stays stable across multiple polls (not just first sync)
- [ ] Re-run `apps/web/e2e/_speak-row-proof.spec.ts` against PR #3230 Vercel preview — passes 4-bar test