### PR TITLE
fix(heartbeat): restore readiness and deploy attestation payloads

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -31,6 +31,9 @@ import { listApprovalQueue, listAgentEvents, listAgentRuns, type AgentRun } from
 import { syncTeamContextToAgents } from './team-context-writer.js'
 import { getUnpushedTrustEvents, markTrustEventsPushed } from './trust-events.js'
 import { pollAndProcessCommands, COMMAND_POLL_ACTIVE_MS, COMMAND_POLL_IDLE_MS } from './commands/drain.js'
+import { getBuildInfo } from './buildInfo.js'
+import { getCapabilityReadiness } from './capability-readiness.js'
+import { getProvisioningManager } from './provisioning.js'
 
 /**
  * Docker identity guard: detect when a container has inherited cloud
@@ -159,6 +162,16 @@ export function _registerImmediateSync(fn: () => void): void {
 // The cloud then broadcasts each as a `canvas_push` SSE event to all subscribers.
 const MAX_PENDING_PUSH_EVENTS = 20
 const pendingPushEvents: Array<Record<string, unknown>> = []
+
+function getHeartbeatCapabilityReadiness() {
+  const provisioning = getProvisioningManager()
+  const provStatus = provisioning.getStatus()
+  return getCapabilityReadiness({
+    cloudConnected: provStatus.phase === 'ready',
+    cloudUrl: provStatus.cloudUrl,
+    webhooks: provStatus.webhooks as Array<{ provider: string; active: boolean }>,
+  })
+}
 
 /** Queue a canvas_push event for relay to cloud in the next sync cycle. */
 export function queueCanvasPushEvent(event: Record<string, unknown>): void {
@@ -838,11 +851,15 @@ async function sendHeartbeat(): Promise<void> {
   // "degraded" only if there are actual health issues (e.g., DB errors, high error rate).
   // Idle agents are normal — not a degraded state.
   const hostStatus = 'online' as const
+  const buildInfo = getBuildInfo()
+  const capabilityReadiness = getHeartbeatCapabilityReadiness()
 
   const result = await cloudPost(`/api/hosts/${state.hostId}/heartbeat`, {
     contractVersion: 'host-heartbeat.v1',
     status: hostStatus,
     timestamp: Date.now(),
+    buildTimestamp: buildInfo.buildTimestamp,
+    capabilityReadiness,
     agents: agents.map(a => {
       const agentAliases = [a.name]
       const todoCount = tasks.filter(t => t.status === 'todo' && agentAliases.includes(t.assignee || '')).length
@@ -906,6 +923,8 @@ async function sendHeartbeat(): Promise<void> {
       hostName: config.hostName,
       hostType: config.hostType,
       uptimeMs: Date.now() - state.startedAt,
+      version: buildInfo.appVersion,
+      sha: buildInfo.gitSha,
     },
     // V2 capability-visibility ack — only emitted when we have fresh acks
     // from the most recent /capabilities/context fetch. Cloud uses these


### PR DESCRIPTION
## Summary
- restore `capabilityReadiness` in the managed-host heartbeat payload on current `main`
- send deploy attestation fields in the same heartbeat (`source.version`, `source.sha`, `buildTimestamp`)
- keep the fix narrow to `src/cloud.ts`

## Why
Managed hosts are currently showing null deploy attestation in cloud and stale capability truth, including the Home calendar lane where `nodeReadiness?.calendar` stays null and the cloud falls back to `needs-config`.

## Validation
- focused local regression: `tests/capability-readiness.test.ts` passed in the working checkout used to cut the fix
- full clean-worktree validation is still blocked on environment/dependency setup in the temp worktree, so real-host redeploy proof is still required

## Expected host proof after deploy
- `app_version` populated in cloud host rows
- `git_sha` populated in cloud host rows
- `build_timestamp` populated in cloud host rows
- `nodeReadiness?.calendar` present so managed Home stops presenting standalone calendar as missing config due to null heartbeat truth
