### PR TITLE
build: bake git metadata into production image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "app_version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+          echo "git_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "git_short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "git_branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "git_author=$(git log -1 --pretty=%an)" >> "$GITHUB_OUTPUT"
+          echo "git_timestamp=$(git log -1 --pretty=%cI)" >> "$GITHUB_OUTPUT"
+          echo "build_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          {
+            echo 'git_message<<EOF'
+            git log -1 --pretty=%s
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -46,6 +62,15 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_APP_VERSION=${{ steps.build_meta.outputs.app_version }}
+            BUILD_GIT_SHA=${{ steps.build_meta.outputs.git_sha }}
+            BUILD_GIT_SHORT_SHA=${{ steps.build_meta.outputs.git_short_sha }}
+            BUILD_GIT_BRANCH=${{ steps.build_meta.outputs.git_branch }}
+            BUILD_GIT_MESSAGE=${{ steps.build_meta.outputs.git_message }}
+            BUILD_GIT_AUTHOR=${{ steps.build_meta.outputs.git_author }}
+            BUILD_GIT_TIMESTAMP=${{ steps.build_meta.outputs.git_timestamp }}
+            BUILD_TIMESTAMP=${{ steps.build_meta.outputs.build_timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,15 @@ RUN npm run build
 # ── Runtime stage ──
 FROM node:22-slim
 
+ARG BUILD_APP_VERSION=unknown
+ARG BUILD_GIT_SHA=unknown
+ARG BUILD_GIT_SHORT_SHA=unknown
+ARG BUILD_GIT_BRANCH=unknown
+ARG BUILD_GIT_MESSAGE=unknown
+ARG BUILD_GIT_AUTHOR=unknown
+ARG BUILD_GIT_TIMESTAMP=unknown
+ARG BUILD_TIMESTAMP=unknown
+
 WORKDIR /app
 
 # Runtime dependencies
@@ -80,8 +89,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npx playwright install chromium --with-deps
 
 COPY --from=build /app/dist/ dist/
-# Copy pre-baked commit.txt for version reporting (run npm run build locally first)
-COPY commit.txt* ./
+COPY --from=build /app/commit.txt ./commit.txt
 
 # Runtime assets (dashboard UI, role defaults, CLI templates)
 COPY public/ public/
@@ -93,6 +101,14 @@ ENV REFLECTT_HOME=/data
 ENV NODE_ENV=production
 ENV PORT=4445
 ENV HOST=0.0.0.0
+ENV BUILD_APP_VERSION=${BUILD_APP_VERSION}
+ENV BUILD_GIT_SHA=${BUILD_GIT_SHA}
+ENV BUILD_GIT_SHORT_SHA=${BUILD_GIT_SHORT_SHA}
+ENV BUILD_GIT_BRANCH=${BUILD_GIT_BRANCH}
+ENV BUILD_GIT_MESSAGE=${BUILD_GIT_MESSAGE}
+ENV BUILD_GIT_AUTHOR=${BUILD_GIT_AUTHOR}
+ENV BUILD_GIT_TIMESTAMP=${BUILD_GIT_TIMESTAMP}
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
 
 EXPOSE 4445
 

--- a/src/buildInfo.ts
+++ b/src/buildInfo.ts
@@ -7,7 +7,7 @@
  */
 
 import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 
 export interface BuildInfo {
@@ -30,7 +30,6 @@ export interface BuildInfo {
 // When running from a global install or launchd plist, cwd may point
 // to an unrelated directory (or a different git repo entirely).
 import { fileURLToPath } from 'node:url'
-import { existsSync } from 'node:fs'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // Check if we're inside a reflectt-node repo (not an ancestor .git like Homebrew's).
@@ -67,6 +66,29 @@ function git(cmd: string): string {
   }
 }
 
+function readEnvValue(...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = process.env[key]?.trim()
+    if (value) return value
+  }
+  return null
+}
+
+function readBakedCommit(): string | null {
+  const candidates = [
+    resolve(__dirname, '..', 'commit.txt'),
+    resolve(process.cwd(), 'commit.txt'),
+  ]
+  for (const path of candidates) {
+    try {
+      if (!existsSync(path)) continue
+      const value = readFileSync(path, 'utf8').trim()
+      if (value) return value
+    } catch { /* try next */ }
+  }
+  return null
+}
+
 function readPackageVersion(): string {
   // Try repo root first, then __dirname, then cwd as last resort
   const candidates = [repoRoot, __dirname, process.cwd()].filter(Boolean) as string[]
@@ -83,14 +105,19 @@ function readPackageVersion(): string {
 
 // Capture at module load (startup) time
 const startedAtMs = Date.now()
-const appVersion = readPackageVersion()
-const gitSha = git('rev-parse HEAD')
-const gitShortSha = git('rev-parse --short HEAD')
-const gitBranch = git('rev-parse --abbrev-ref HEAD')
-const gitMessage = git('log -1 --pretty=%s')
-const gitAuthor = git('log -1 --pretty=%an')
-const gitTimestamp = git('log -1 --pretty=%ci')
-const buildTimestamp = gitTimestamp !== 'unknown' ? gitTimestamp : new Date(startedAtMs).toISOString()
+const appVersion = readEnvValue('BUILD_APP_VERSION', 'APP_VERSION') ?? readPackageVersion()
+const bakedCommit = readBakedCommit()
+const gitSha = readEnvValue('BUILD_GIT_SHA', 'GIT_SHA') ?? git('rev-parse HEAD')
+const gitShortSha = readEnvValue('BUILD_GIT_SHORT_SHA', 'GIT_SHORT_SHA')
+  ?? (gitSha !== 'unknown' ? gitSha.slice(0, 7) : null)
+  ?? bakedCommit
+  ?? git('rev-parse --short HEAD')
+const gitBranch = readEnvValue('BUILD_GIT_BRANCH', 'GIT_BRANCH') ?? git('rev-parse --abbrev-ref HEAD')
+const gitMessage = readEnvValue('BUILD_GIT_MESSAGE', 'GIT_MESSAGE') ?? git('log -1 --pretty=%s')
+const gitAuthor = readEnvValue('BUILD_GIT_AUTHOR', 'GIT_AUTHOR') ?? git('log -1 --pretty=%an')
+const gitTimestamp = readEnvValue('BUILD_GIT_TIMESTAMP', 'GIT_TIMESTAMP') ?? git('log -1 --pretty=%ci')
+const buildTimestamp = readEnvValue('BUILD_TIMESTAMP')
+  ?? (gitTimestamp !== 'unknown' ? gitTimestamp : new Date(startedAtMs).toISOString())
 
 export function getBuildInfo(): BuildInfo {
   return {


### PR DESCRIPTION
## Summary
- prefer baked build metadata in `src/buildInfo.ts` before falling back to live `.git` inspection
- pass git/build metadata into the production image from `docker-publish.yml`
- preserve that metadata in the runtime image so `/health/build` and heartbeat attestation can emit a real SHA on managed hosts

## Why
After `reflectt-node#1334` rolled, the four managed portfolio hosts correctly reported `app_version = 0.1.34` and fresh `build_timestamp`, but `git_sha` still emitted `"unknown"`.

The root cause was structural:
- production images do not contain a live `.git` checkout
- `src/buildInfo.ts` was reading git metadata from `.git` at runtime
- the Docker publish path was not baking commit metadata into the image

This keeps the fix narrow to the build-attestation seam only.

## Proof
- local env-precedence check passed:
  - `BUILD_GIT_SHA=abcdef1234567890`
  - `BUILD_GIT_SHORT_SHA=abcdef1`
  - `BUILD_TIMESTAMP=2026-05-06T14:21:00Z`
  - `getBuildInfo()` returned those baked values instead of `unknown`
- managed-host fleet proof before this fix already showed rollout + calendar truth were green; `git_sha` was the last remaining attestation gap

## Validation caveat
- full `npm run build` is still noisy in this environment from pre-existing unrelated repo/runtime drift, including:
  - missing `@sentry/node` types
  - missing `team-context-writer.js`
  - missing `seedCapabilityMap` export
- this PR should therefore ride normal CI + docker publish + rolled-host proof as the authoritative validation bar
