### PR TITLE
fix(workflow): quote build metadata command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compute build metadata
         id: build_meta
         run: |
-          echo "app_version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+          echo "app_version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
           echo "git_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           echo "git_short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "git_branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Follow-up to #1335. The Docker publish run on the merge commit failed in the new `Compute build metadata` step because the `node -p` package-version command was shell-quoted incorrectly. This keeps scope to the one-line workflow fix only so Docker publish can complete and the managed-host real-SHA proof can resume.