### PR TITLE
fix(room): join presence channel as node listener

### DIFF
--- a/src/room-presence-store.ts
+++ b/src/room-presence-store.ts
@@ -96,12 +96,12 @@ export function initRoomPresenceStore(): boolean {
     auth: { persistSession: false, autoRefreshToken: false },
   })
 
+  const nodePresenceKey = `node:${hostId}`
   const channel = state.client.channel(`room:${hostId}`, {
-    // Listening as a service-role client — node never publishes its own
-    // presence track. The presence key is required by Supabase even for
-    // listen-only subscribers; we use a stable node sentinel that won't
-    // collide with browser session ids (which are random uuids).
-    config: { presence: { key: `node:${hostId}` } },
+    // Node must JOIN the presence channel to receive sync state. We still
+    // publish only a non-human sentinel payload so browsers/agents never
+    // mistake the listener for a participant.
+    config: { presence: { key: nodePresenceKey } },
   })
 
   const recompute = () => {
@@ -144,6 +144,14 @@ export function initRoomPresenceStore(): boolean {
     .subscribe((status) => {
       if (status === 'SUBSCRIBED') {
         console.log(`[room-presence] subscribed to room:${hostId}`)
+        void channel.track({
+          kind: 'listener',
+          id: nodePresenceKey,
+          hostId,
+          joinedAt: Date.now(),
+        }).catch((err) => {
+          console.warn(`[room-presence] sentinel track failed for room:${hostId}:`, err)
+        })
       } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
         console.warn(`[room-presence] channel ${status} for room:${hostId}`)
       }

--- a/tests/room-presence-subscribe.test.ts
+++ b/tests/room-presence-subscribe.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('room-presence-store subscribe behavior', () => {
+  const originalEnv = { ...process.env }
+
+  afterEach(async () => {
+    process.env = { ...originalEnv }
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('tracks a non-human node sentinel after subscribe so presence sync can populate', async () => {
+    const track = vi.fn().mockResolvedValue('ok')
+    const unsubscribe = vi.fn().mockResolvedValue('ok')
+    const removeChannel = vi.fn().mockResolvedValue('ok')
+    let subscribeHandler: ((status: string) => void) | null = null
+
+    const channel: any = {
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn((handler: (status: string) => void) => {
+        subscribeHandler = handler
+        return channel
+      }),
+      track,
+      presenceState: vi.fn(() => ({})),
+      unsubscribe,
+    }
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => ({
+        channel: vi.fn(() => channel),
+        removeChannel,
+      })),
+    }))
+
+    process.env.SUPABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role'
+    process.env.REFLECTT_HOST_ID = 'host-123'
+
+    const mod = await import('../src/room-presence-store.js')
+    expect(mod.initRoomPresenceStore()).toBe(true)
+    expect(track).not.toHaveBeenCalled()
+
+    expect(subscribeHandler).toBeTypeOf('function')
+    subscribeHandler?.('SUBSCRIBED')
+    await Promise.resolve()
+
+    expect(track).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'listener',
+      id: 'node:host-123',
+      hostId: 'host-123',
+    }))
+
+    await mod.shutdownRoomPresenceStore()
+    expect(unsubscribe).toHaveBeenCalled()
+    expect(removeChannel).toHaveBeenCalledWith(channel)
+  })
+})


### PR DESCRIPTION
## Summary
- track a non-human node sentinel after the room presence channel reaches `SUBSCRIBED`
- keep filtering non-human presence payloads so the node listener never appears as a participant
- add a regression test covering the subscribe->track handshake

## Why
The canonical narrowing now shows the cloud/browser path is live and returns `200`, but the payload stays empty (`participants: []`). The node room subscriber was subscribing to `room:${hostId}` with a presence key but never calling `track()`. Supabase presence semantics require joining the presence set after `SUBSCRIBED`; otherwise the node cache can remain empty even while browsers are in the room.

## Validation
- `npm run build`
- `npx vitest run tests/room-presence-store.test.ts tests/room-presence-subscribe.test.ts tests/chat-context-room-active.test.ts`
